### PR TITLE
Fix git versioning issues with sbt "+" versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,4 +20,4 @@ bintrayOrganization := Some("unibas-gravis")
 // Git versioning
 enablePlugins(GitVersioning, GitBranchPrompt)
 com.typesafe.sbt.SbtGit.useJGit 
-git.useGitDescribe := true
+git.baseVersion := "develop"


### PR DESCRIPTION
Change git versions from git describe to plain `develop-SHA1`:

sbt resolves `0.2.+` with all versions created through git describe in the format `0.2.0-4-SHA1`, even though they are not 0.2 releases but ongoing development on master