### PR TITLE
Added read and write image to stream to PixelImageIO

### DIFF
--- a/src/main/scala/scalismo/faces/image/PixelImageIO.scala
+++ b/src/main/scala/scalismo/faces/image/PixelImageIO.scala
@@ -18,7 +18,6 @@ package scalismo.faces.image
 
 import java.awt.Color
 import java.awt.image.BufferedImage
-import java.io.File
 
 import scalismo.faces.color.{RGB, RGBA}
 import scalismo.faces.image.PixelImageConversion.BufferedImageConverter
@@ -162,6 +161,17 @@ object PixelImageConversion {
 }
 
 object PixelImageIO {
+  import java.io.{File, InputStream, OutputStream}
+
+  def read[Pixel](inputStream: InputStream)(implicit converter: BufferedImageConverter[Pixel]): Try[PixelImage[Pixel]] = {
+    val img: Try[java.awt.image.BufferedImage] = Try(javax.imageio.ImageIO.read(inputStream))
+    img.map(converter.fromBufferedImage)
+  }
+
+  def write[Pixel](image: PixelImage[Pixel], outputStream: OutputStream, format: String = "png")(implicit converter: BufferedImageConverter[Pixel]): Try[Unit] = {
+    val bufImage = converter.toBufferedImage(image)
+    Try(javax.imageio.ImageIO.write(bufImage, format, outputStream))
+  }
 
   def read[Pixel](file: File)(implicit converter: BufferedImageConverter[Pixel]): Try[PixelImage[Pixel]] = {
     val img: Try[java.awt.image.BufferedImage] = Try(javax.imageio.ImageIO.read(file))


### PR DESCRIPTION
Two new methods were added to PixelImageIO object. One method for read and one for writting an image to and from a stream. This is nescessary to use images from within a .jar-file.

Tests were added to check that read write cycles do not alter the image (i.e. that they are identity transformations). The tests can serve also as example how to use the new methods.