### PR TITLE
Alpha blend two images

### DIFF
--- a/src/main/scala/scalismo/faces/image/PixelImageOperations.scala
+++ b/src/main/scala/scalismo/faces/image/PixelImageOperations.scala
@@ -24,10 +24,27 @@ import scala.reflect.ClassTag
 
 object PixelImageOperations {
 
+  /**
+    * Blends the foreground over the background according to the mask.
+    * The foreground is visible where the mask is 1.0. The Background is visible where the mask is 0.0. For other mask
+    * values the two images are blended accordingly.
+    * @param background visible when mask = 0.0
+    * @param foreground visible when mask = 1.0
+    * @param mask used for blending the colors
+    * @return
+    */
   def alphaBlending(background: PixelImage[RGB], foreground: PixelImage[RGB], mask: PixelImage[Double]): PixelImage[RGB] = {
     alphaBlending(background,setAlpha(foreground,mask))
   }
 
+  /**
+    * Blends the foreground over the background according to the alpha channel of the foreground.
+    * The foreground is visible where its alpha channel is 1.0. The Background is visible when the foreground alpha
+    * channel is 0.0. For other values the two images are blended accordingly.
+    * @param background visible when alpha channel of foreground = 0.0
+    * @param foreground visible when alpha channel = 1.0
+    * @return
+    */
   def alphaBlending(background: PixelImage[RGB], foreground: PixelImage[RGBA]): PixelImage[RGB] = {
     background.zip(foreground).map{
       case (bg,fg) => bg.blend(fg)

--- a/src/main/scala/scalismo/faces/image/PixelImageOperations.scala
+++ b/src/main/scala/scalismo/faces/image/PixelImageOperations.scala
@@ -24,6 +24,16 @@ import scala.reflect.ClassTag
 
 object PixelImageOperations {
 
+  def alphaBlending(background: PixelImage[RGB], foreground: PixelImage[RGB], mask: PixelImage[Double]): PixelImage[RGB] = {
+    alphaBlending(background,setAlpha(foreground,mask))
+  }
+
+  def alphaBlending(background: PixelImage[RGB], foreground: PixelImage[RGBA]): PixelImage[RGB] = {
+    background.zip(foreground).map{
+      case (bg,fg) => bg.blend(fg)
+    }
+  }
+
   def applyToRGB(image: PixelImage[RGBA], f: PixelImage[RGB] => PixelImage[RGB]): PixelImage[RGBA] = {
     setAlpha(f(removeAlpha(image)), extractAlpha(image))
   }

--- a/src/test/scala/scalismo/faces/image/ImageOperationsTest.scala
+++ b/src/test/scala/scalismo/faces/image/ImageOperationsTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.faces.image
+
+import scalismo.faces.FacesTestSuite
+import scalismo.faces.color.RGB
+
+class ImageOperationsTest  extends FacesTestSuite {
+
+  describe("ImageOperations support") {
+
+    it("alpha blending of two images") {
+      val bg = PixelImage(PixelImageDomain(2, 2), (x, y) => RGB(1, 0, 0))
+      val fg = PixelImage(PixelImageDomain(2, 2), (x, y) => RGB(0, 1, 0))
+      val mask = PixelImage(PixelImageDomain(2, 2), (x, y) => (x + y) / 2.0)
+
+      val expected = PixelImage(PixelImageDomain(2, 2), Array(RGB(1, 0, 0), RGB(0.5, 0.5, 0.0), RGB(0.5, 0.5, 0.0), RGB(0.0, 1.0, 0.0)))
+
+      val produced = PixelImageOperations.alphaBlending(bg, fg, mask)
+
+      val diff = PixelImage(produced.width, produced.height, (x, y) => produced(x, y) - expected(x, y))
+      math.sqrt(diff.values.map(_.norm).max) should be <= 1.0e-5
+    }
+
+  }
+
+}

--- a/src/test/scala/scalismo/faces/image/ImageOperatorsTest.scala
+++ b/src/test/scala/scalismo/faces/image/ImageOperatorsTest.scala
@@ -18,6 +18,7 @@ package scalismo.faces.image
 
 import scalismo.faces.FacesTestSuite
 import scalismo.faces.color.ColorSpaceOperations.implicits._
+import scalismo.faces.color.RGB
 import scalismo.faces.image.PixelImage.implicits._
 
 class ImageOperatorsTest extends FacesTestSuite {

--- a/src/test/scala/scalismo/faces/image/ImageOperatorsTest.scala
+++ b/src/test/scala/scalismo/faces/image/ImageOperatorsTest.scala
@@ -18,7 +18,6 @@ package scalismo.faces.image
 
 import scalismo.faces.FacesTestSuite
 import scalismo.faces.color.ColorSpaceOperations.implicits._
-import scalismo.faces.color.RGB
 import scalismo.faces.image.PixelImage.implicits._
 
 class ImageOperatorsTest extends FacesTestSuite {


### PR DESCRIPTION
Two new PixelImageOperations were introduced that blends two images together according to a mask.
The mask describes the blending of the foreground onto the background. Either two PixelImage[RGB] are passed with a separate mask as PixelImage[Double] or the foreground contains an alpha channel that is used as mask.