### PR TITLE
Fixes a bug in GaussPyramid

### DIFF
--- a/src/main/scala/scalismo/faces/image/pyramid/GaussPyramid.scala
+++ b/src/main/scala/scalismo/faces/image/pyramid/GaussPyramid.scala
@@ -34,13 +34,13 @@ import scala.reflect._
 class GaussPyramid[A: ClassTag](val image: PixelImage[A], val reduce: ImageFilter[A, A], val reductions: Int)(implicit ops: ColorSpaceOperations[A])
   extends ImagePyramid[A] {
 
-  override val levels: Int = {
+  private val maxReductions: Int = {
     val maxNumberOfReductions = min(
       GaussPyramid.findNumberOfTwoInPrimFactorDecomposition(image.width),
       GaussPyramid.findNumberOfTwoInPrimFactorDecomposition(image.height))
 
     if (reductions >= 0 && reductions < maxNumberOfReductions) {
-      reductions + 1
+      reductions
     } else {
       maxNumberOfReductions.toInt
     }
@@ -52,8 +52,10 @@ class GaussPyramid[A: ClassTag](val image: PixelImage[A], val reduce: ImageFilte
       else image +: makeReducedImages(reduce(image), levels - 1)
     }
 
-    makeReducedImages(image, levels)
+    makeReducedImages(image, maxReductions)
   }
+
+  override val levels = level.size
 }
 
 object GaussPyramid {

--- a/src/test/scala/scalismo/faces/image/ImagePyramidTests.scala
+++ b/src/test/scala/scalismo/faces/image/ImagePyramidTests.scala
@@ -107,6 +107,14 @@ class ImagePyramidTests extends FacesTestSuite {
       }
     }
 
+    it("calculates the correct number of levels") {
+      val image: PixelImage[Double] = chessBoard(1024, 128, 1.0, 0.0)
+      for( reductions <- 0 to 10 by 2) {
+        val pyramid = GaussPyramid(image,reductions)
+        pyramid.levels shouldBe (reductions+1)
+      }
+    }
+
   }
 
   describe("A Laplacian Pyramid") {


### PR DESCRIPTION
The number of levels was wrong before. Now the number of levels of the constructed pyramid is the number of requested reductions +1 if possible. A test is added to check this property.