### PR TITLE
Add mapWithIndex to PixelImage

### DIFF
--- a/src/main/scala/scalismo/faces/image/PixelImage.scala
+++ b/src/main/scala/scalismo/faces/image/PixelImage.scala
@@ -117,10 +117,18 @@ class PixelImage[@specialized A](val domain: PixelImageDomain, val accessMode: A
   /** apply a function to each pixel */
   def mapLazy[B](f: A => B): PixelImage[B] = PixelImage.view(domain, (x, y) => f(this.f(x, y)))
 
+  /** apply a function to each pixel, has access to location of pixel */
+  def mapWithIndex[B](f: (Int, Int, A) => B)(implicit tag: ClassTag[B]): PixelImage[B] = PixelImage(domain, (x, y) => f(x, y, this(x, y)))
+
   /** zip two images together into a single tupled image */
   def zip[B](other: PixelImage[B]): PixelImage[(A, B)] = {
     require(domain == other.domain)
     PixelImage.view(domain, (x, y) => (this(x, y), other(x, y)))
+  }
+
+  /** zip pixel values with their location, yields (Color, (x, y)) */
+  def zipWithIndex: PixelImage[(A, (Int, Int))] = {
+    PixelImage.view(domain, (x, y) => (this(x, y), (x, y)))
   }
 
   /** iterator of all values in image */

--- a/src/main/scala/scalismo/faces/image/PixelImage.scala
+++ b/src/main/scala/scalismo/faces/image/PixelImage.scala
@@ -118,7 +118,7 @@ class PixelImage[@specialized A](val domain: PixelImageDomain, val accessMode: A
   def mapLazy[B](f: A => B): PixelImage[B] = PixelImage.view(domain, (x, y) => f(this.f(x, y)))
 
   /** apply a function to each pixel, has access to location of pixel */
-  def mapWithIndex[B](f: (Int, Int, A) => B)(implicit tag: ClassTag[B]): PixelImage[B] = PixelImage(domain, (x, y) => f(x, y, this(x, y)))
+  def mapWithIndex[B](f: (A, Int, Int) => B)(implicit tag: ClassTag[B]): PixelImage[B] = PixelImage(domain, (x, y) => f(this(x, y), x, y))
 
   /** zip two images together into a single tupled image */
   def zip[B](other: PixelImage[B]): PixelImage[(A, B)] = {

--- a/src/test/scala/scalismo/faces/image/PixelImageTests.scala
+++ b/src/test/scala/scalismo/faces/image/PixelImageTests.scala
@@ -223,6 +223,27 @@ class PixelImageTests extends FacesTestSuite {
     }
   }
 
+  describe("A PixelImage") {
+    describe("has mapWithIndex with") {
+      val image = PixelImage(10, 10, (x, y) => x - y).withAccessMode(AccessMode.Padded(0))
+
+      val summed = image.mapWithIndex((x, y, c) => {
+        image(x - 1, y) + image(x + 1, y) + c
+      })
+
+      it("proper effect inside image") {
+        summed(5, 0) shouldBe 15
+        summed(5, 5) shouldBe 15 - 15
+      }
+
+      it("proper behavior outside image borders") {
+        summed(0, 0) shouldBe 1
+        summed(0, 5) shouldBe 1 - 10
+        summed(0, -1) shouldBe 0
+      }
+    }
+  }
+
   describe("PixelImage to/from ImageBuffer") {
     // ensure buffered image
     val blackImage = PixelImage(w, h, (x, y) => RGB.Black).buffer

--- a/src/test/scala/scalismo/faces/image/PixelImageTests.scala
+++ b/src/test/scala/scalismo/faces/image/PixelImageTests.scala
@@ -227,7 +227,7 @@ class PixelImageTests extends FacesTestSuite {
     describe("has mapWithIndex with") {
       val image = PixelImage(10, 10, (x, y) => x - y).withAccessMode(AccessMode.Padded(0))
 
-      val summed = image.mapWithIndex((x, y, c) => {
+      val summed = image.mapWithIndex((c, x, y) => {
         image(x - 1, y) + image(x + 1, y) + c
       })
 


### PR DESCRIPTION
PixelImage can now be transformed using `PixelImage[A].mapWithIndex[B](f: (A, Int, Int) => B)`

This is almost equivalent to `map` but with the current image location additionally available.

You can also use `zipWithIndex` to tag each pixel value with its location, results in `PixelImage[(A, (Int, Int))]`