### PR TITLE
Renderer

### DIFF
--- a/src/main/scala/scalismo/faces/io/RenderParameterIO.scala
+++ b/src/main/scala/scalismo/faces/io/RenderParameterIO.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.io
+
+import java.io._
+import java.util.Scanner
+
+import scalismo.faces.io.renderparameters.RenderParameterJSONFormat
+import scalismo.faces.parameters.RenderParameter
+import scalismo.faces.utils.ResourceManagement
+import spray.json._
+
+import RenderParameterJSONFormat.defaultFormat._
+
+import scala.util.Try
+
+object RenderParameterIO {
+
+  /** write a RenderParameter to a file */
+  def write(parameter: RenderParameter, file: File): Try[Unit] = writeWithFormat[RenderParameter](parameter, file)
+
+  /** read RenderParameter from a json file */
+  def read(file: File): Try[RenderParameter] = readWithFormat[RenderParameter](file)
+
+  /** read a Parameter type from a json file, needs the json format, e.g. RenderParameterJSONFormatLegacy._ */
+  def readWithFormat[A](file: File)(implicit format: RootJsonFormat[A]): Try[A] = Try(readASTFromStream(new FileInputStream(file)).convertTo[A])
+
+  /** write a parameter type to a file, needs a json format for the type, e.g. RenderParameterJSONFormatLegacy._ */
+  def writeWithFormat[A](parameter: A, file: File)(implicit format: RootJsonFormat[A]): Try[Unit] = Try(writeASTToStream(parameter.toJson, new FileOutputStream(file)))
+
+  /**
+    * read a parameter type from a path in a nested json file, path format: field1/field2/field3
+    *
+    * @param file File to read from
+    * @param path path in the json tree, format: field1/field2/field3
+    */
+  def readWithPath[A](file: File, path: String)(implicit format: JsonFormat[A]): Try[A] = {
+    readFromStreamWithPath[A](new FileInputStream(file),path)
+  }
+
+  /**
+    * write a parameter to a file at a given path
+    *
+    * @param parameter Parameter to write
+    * @param file File to write
+    * @param path path inside json, format: field1/field2/field3
+    */
+  def writeWithPath[A](parameter: A, file: File, path: String)(implicit format: JsonFormat[A]): Try[Unit] = {
+    writeToStreamWithPath[A](parameter,new FileOutputStream(file), path)
+  }
+
+  /** write a RenderParameter to a file */
+  def writeToStream(parameter: RenderParameter, stream: OutputStream): Try[Unit] = writeToStreamWithFormat[RenderParameter](parameter, stream)
+
+  /** read RenderParameter from a json file */
+  def readFromStream(stream: InputStream): Try[RenderParameter] = readFromStreamWithFormat[RenderParameter](stream)
+
+  /** read a Parameter type from a json file, needs the json format, e.g. RenderParameterJSONFormatLegacy._ */
+  def readFromStreamWithFormat[A](stream: InputStream)(implicit format: RootJsonFormat[A]): Try[A] = Try(readASTFromStream(stream).convertTo[A])
+
+  /** write a parameter type to a file, needs a json format for the type, e.g. RenderParameterJSONFormatLegacy._ */
+  def writeToStreamWithFormat[A](parameter: A, stream: OutputStream)(implicit format: RootJsonFormat[A]): Try[Unit] = Try(writeASTToStream(parameter.toJson, stream))
+
+  /**
+    * read a parameter type from a path in a nested json file, path format: field1/field2/field3
+    *
+    * @param stream File to read from
+    * @param path path in the json tree, format: field1/field2/field3
+    */
+  def readFromStreamWithPath[A](stream: InputStream, path: String)(implicit format: JsonFormat[A]): Try[A] = {
+    val json = readASTFromStream(stream)
+    readFromASTWithPath[A](json,path)
+  }
+
+  /**
+    * write a parameter to a file at a given path
+    *
+    * @param parameter Parameter to write
+    * @param stream Stream to write
+    * @param path path inside json, format: field1/field2/field3
+    */
+  def writeToStreamWithPath[A](parameter: A, stream: OutputStream, path: String)(implicit format: JsonFormat[A]): Try[Unit] = Try {
+    val fullAST = writeToASTWithPath(parameter,path)
+    writeASTToStream(fullAST, stream)
+  }
+
+
+  /**
+    * read a parameter type from a path in a nested json file, path format: field1/field2/field3
+    *
+    * @param json JsValue containing full ASTree
+    * @param path path in the json tree, format: field1/field2/field3
+    */
+  def readFromASTWithPath[A](json: JsValue, path: String)(implicit format: JsonFormat[A]): Try[A] = Try {
+    val version = RenderParameterJSONFormat.versionString(json)
+    val fieldNames: IndexedSeq[String] = path.split("/").filter(_.nonEmpty)
+    // traverse the json AST along the given path
+    val jsonField = fieldNames.foldLeft(json) { (jsValue, fieldName) => jsValue.asJsObject.fields(fieldName) }
+    jsonField.convertTo[A]
+  }
+
+  /**
+    * write a parameter to a file at a given path
+    *
+    * @param parameter Parameter to write
+    * @param path path inside json, format: field1/field2/field3
+    */
+  def writeToASTWithPath[A](parameter: A, path: String)(implicit format: JsonFormat[A]): JsValue = {
+    val parameterAST = parameter.toJson
+    val fieldNames: IndexedSeq[String] = path.split("/").filter(_.nonEmpty)
+    // create composite, nested tree along path
+    val fullAST = fieldNames.reverse.foldLeft(parameterAST) { (compositeTree, fieldName) => JsObject((fieldName, compositeTree)) }
+    fullAST
+  }
+
+
+  /** parse json from stream as abstract syntax tree (spray's JsValue) */
+  def readASTFromStream(stream: InputStream): JsValue = {
+    val scanner = new Scanner(stream).useDelimiter("\\A")
+    val string = if(scanner.hasNext()) scanner.next() else ""
+    string.parseJson
+  }
+
+  /** write an abstract syntax tree (spray's JsValue) to a file (pretty printed) */
+  def writeASTToStream(jasonAST: JsValue, stream: OutputStream): Unit = {
+    ResourceManagement.using(new PrintWriter(stream)) { f =>
+      f.print(jasonAST.prettyPrint)
+    }
+  }
+}

--- a/src/main/scala/scalismo/faces/io/ply/PLYMesh.scala
+++ b/src/main/scala/scalismo/faces/io/ply/PLYMesh.scala
@@ -62,7 +62,7 @@ object PLYMesh {
   def writePLY(mesh: VertexColorMesh3D,
                fileURL: String,
                plyFormat: PlyFormat,
-               headerFormat: PlyHeader) = {
+               headerFormat: PlyHeader): Unit = {
     val points = mesh.shape.pointSet.points.toIndexedSeq
     val triangles = mesh.shape.triangulation.triangles.map(_.toIntVector3D)
     val colors = mesh.color
@@ -80,7 +80,7 @@ object PLYMesh {
   def writePLY(mesh: ColorNormalMesh3D,
                fileURL: String,
                plyFormat: PlyFormat,
-               headerFormat: PlyHeader) = {
+               headerFormat: PlyHeader): Unit = {
     val points = mesh.shape.pointSet.points.toIndexedSeq
     val triangles = mesh.shape.triangulation.triangles.map(_.toIntVector3D)
     val colors = mesh.color

--- a/src/main/scala/scalismo/faces/io/ply/PlyMeshPropertyWriters.scala
+++ b/src/main/scala/scalismo/faces/io/ply/PlyMeshPropertyWriters.scala
@@ -60,7 +60,7 @@ object PlyMeshPropertyWriters {
   abstract class VertexPoint[D <: Dim](override val property: SurfacePointProperty[Point[D]] )
     extends SurfacePointPropertyWriter[Point[D]]
   {
-    val numberFormat = PlyTypes.float
+    val numberFormat: PlyHelpers.PlyTypes.Value = PlyTypes.float
     private val writer = new SequenceWriter[Float]()
 
     override def write(vec: Point[D], osw: OutputStreamWriter): Unit = {
@@ -73,7 +73,7 @@ object PlyMeshPropertyWriters {
   }
 
   abstract class VertexVector[D <: Dim](override val property: SurfacePointProperty[Vector[D]] ) extends SurfacePointPropertyWriter[Vector[D]] {
-    val numberFormat = PlyTypes.float
+    val numberFormat: PlyHelpers.PlyTypes.Value = PlyTypes.float
     private val writer = new SequenceWriter[Float]()
 
     override def write(vec: Vector[D], osw: OutputStreamWriter): Unit = {
@@ -116,7 +116,7 @@ object PlyMeshPropertyWriters {
   }
 
   abstract class FaceVertexVectors[D<:Dim]( override val property: VertexPropertyPerTriangle[Vector[D]]) extends VertexPerTrianglePropertyWriter[Vector[D]] {
-    val numberFormat = PlyTypes.float
+    val numberFormat: PlyHelpers.PlyTypes.Value = PlyTypes.float
     private val writer = new ListWriter[Float]
 
     override def write(seq: Seq[Vector[D]], osw: OutputStreamWriter): Unit = {
@@ -132,7 +132,7 @@ object PlyMeshPropertyWriters {
   }
 
   class Vertex(val vertices: IndexedSeq[Point[_3D]]) extends IndexedProperty {
-    val numberFormat = PlyTypes.float
+    val numberFormat: PlyHelpers.PlyTypes.Value = PlyTypes.float
     private val writer = new SequenceWriter[Float]
 
     override def write(idx: Int, osw: OutputStreamWriter): Unit = {
@@ -151,7 +151,7 @@ object PlyMeshPropertyWriters {
   }
 
   class VertexColor(override val property: SurfacePointProperty[RGBA] ) extends SurfacePointPropertyWriter[RGBA] {
-    val numberFormat = PlyTypes.uchar
+    val numberFormat: PlyHelpers.PlyTypes.Value = PlyTypes.uchar
     private val writer = new SequenceWriter[Byte]
 
     override def write(color: RGBA, osw: OutputStreamWriter): Unit = {
@@ -185,7 +185,7 @@ object PlyMeshPropertyWriters {
   class VertexTextureCoordinates(property: SurfacePointProperty[Point[_2D]], format : PlyHeader = PlyHeader.meshlab)
     extends VertexPoint[_2D](property)
   {
-    val headerFormat = format
+    val headerFormat: PlyHeader = format
     override def writeHeader(osw: OutputStreamWriter): Unit = {
       headerFormat match {
         case PlyHeader.meshlab =>
@@ -201,7 +201,7 @@ object PlyMeshPropertyWriters {
   class Faces(val faces: IndexedSeq[IntVector[_3D]])
     extends IndexedProperty
   {
-    val numberFormat = PlyTypes.int
+    val numberFormat: PlyHelpers.PlyTypes.Value = PlyTypes.int
     private val writer = new ListWriter[Int]
 
     override def writeHeader(osw: OutputStreamWriter): Unit = {
@@ -218,7 +218,7 @@ object PlyMeshPropertyWriters {
   }
 
   class FaceColor( override val property: TriangleProperty[RGBA]) extends TrianglePropertyWriter[RGBA] {
-    val numberFormat = PlyTypes.uchar
+    val numberFormat: PlyHelpers.PlyTypes.Value = PlyTypes.uchar
     private val writer = new SequenceWriter[Byte]()
 
     override def write(color: RGBA, osw: OutputStreamWriter): Unit = {
@@ -240,7 +240,7 @@ object PlyMeshPropertyWriters {
   }
 
   class FaceNormal( override val property: TriangleProperty[Vector[_3D]]) extends TrianglePropertyWriter[Vector[_3D]] {
-    val numberFormat = PlyTypes.float
+    val numberFormat: PlyHelpers.PlyTypes.Value = PlyTypes.float
     private val writer = new SequenceWriter[Float]()
 
     override def write(vec: Vector[_3D], osw: OutputStreamWriter): Unit = {
@@ -259,7 +259,7 @@ object PlyMeshPropertyWriters {
   }
 
   class FaceVertexTextureCoordinates( override val property: VertexPropertyPerTriangle[Point[_2D]]) extends VertexPerTrianglePropertyWriter[Point[_2D]] {
-    val numberFormat = PlyTypes.float
+    val numberFormat: PlyHelpers.PlyTypes.Value = PlyTypes.float
     private val writer = new ListWriter[Float]
 
     override def write(seq: Seq[Point[_2D]], osw: OutputStreamWriter): Unit = {
@@ -279,7 +279,7 @@ object PlyMeshPropertyWriters {
   }
 
   class FaceVertexColors( override val property: VertexPropertyPerTriangle[RGBA]) extends VertexPerTrianglePropertyWriter[RGBA] {
-    val numberFormat = PlyTypes.uchar
+    val numberFormat: PlyHelpers.PlyTypes.Value = PlyTypes.uchar
     private val writer = new ListWriter[Byte]
 
     override def write(seq: Seq[RGBA], osw: OutputStreamWriter): Unit = {

--- a/src/main/scala/scalismo/faces/io/ply/PlyMeshWriter.scala
+++ b/src/main/scala/scalismo/faces/io/ply/PlyMeshWriter.scala
@@ -52,8 +52,8 @@ private[io] case class PlyMeshWriter(url: String,
                                      plyFormat: PlyFormat = PlyFormat.ASCII,
                                      headerFormat: PlyHeader = PlyHeader.meshlab) {
 
-  val nVertices = vertices.map(_.length).getOrElse(-1)
-  val nFaces = faces.map(_.length).getOrElse(-1)
+  val nVertices: Int = vertices.map(_.length).getOrElse(-1)
+  val nFaces: Int = faces.map(_.length).getOrElse(-1)
   val (hasTextures, hasMultipleTextures) = checkTextures
 
   val vertexProperties: IndexedSeq[IndexedProperty] = getVertexProperties

--- a/src/main/scala/scalismo/faces/io/ply/PlyReader.scala
+++ b/src/main/scala/scalismo/faces/io/ply/PlyReader.scala
@@ -167,7 +167,7 @@ object PlyReader {
   private def parseElementsInHeader(header: List[String]): List[(String, PlyElementReader)] = {
     val startingElement = header.dropWhile(l => !l.startsWith(PLY.element))
     val elements = parseElementFromListStart(startingElement)
-    elements.map(headerPartToReader).flatten
+    elements.flatMap(headerPartToReader)
   }
 
 

--- a/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormat.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.io.renderparameters
+
+import scalismo.faces.parameters.RenderParameter
+import spray.json._
+
+/**
+  * default JSON reader and writer for RenderParameter
+  * versioned reader, writer uses default format
+  * */
+object RenderParameterJSONFormat extends RenderParameterJSONFormatV3 {
+
+  val version1 = RenderParameterJSONFormatLegacy
+  val version2 = RenderParameterJSONFormatV2
+  val version3 = RenderParameterJSONFormatV3
+  val version4 = RenderParameterJSONFormatV4
+
+  val defaultFormat = RenderParameterJSONFormatV4
+
+  def versionString(json: JsValue): Option[String] = {
+    val fields = json.asJsObject(s"expected RenderParameter object, got: $json").fields
+
+    fields.get("version") match {
+      case Some(JsString(v)) => Some(v)
+      case _ => None
+    }
+  }
+
+  /** parse a RenderParameter from the JSON tree, selects proper version */
+  def readRenderParameter(json: JsValue): RenderParameter = json.convertTo[RenderParameter]
+
+  /** construct JSON serialization of a RenderParameter, uses default format */
+  def writeRenderParameter(param: RenderParameter): JsValue = param.toJson
+
+  override implicit val renderParameterFormat: RootJsonFormat[RenderParameter] = new RootJsonFormat[RenderParameter]{
+    def readLegacy(json: JsValue): RenderParameter = {
+      RenderParameterJSONFormatLegacy.renderParameterFormat.read(json)
+    }
+
+    override def read(json: JsValue): RenderParameter = {
+      val version = versionString(json)
+      version match {
+        case None => readLegacy(json)
+        case Some("") => readLegacy(json)
+        case Some("legacy") => readLegacy(json)
+        case Some(RenderParameterJSONFormatLegacy.version) => readLegacy(json)
+        case Some(RenderParameterJSONFormatV2.version) => RenderParameterJSONFormatV2.renderParameterFormat.read(json)
+        case Some(RenderParameterJSONFormatV3.version) => RenderParameterJSONFormatV3.renderParameterFormat.read(json)
+        case Some(RenderParameterJSONFormatV4.version) => RenderParameterJSONFormatV4.renderParameterFormat.read(json)
+        case Some(vstr) => throw new DeserializationException("unknown version: " + vstr)
+      }
+    }
+
+    override def write(obj: RenderParameter): JsValue = defaultFormat.renderParameterFormat.write(obj)
+  }
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatLegacy.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatLegacy.scala
@@ -1,0 +1,312 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.io.renderparameters
+
+import java.net.URI
+
+import scalismo.faces.color.{RGB, RGBA}
+import scalismo.faces.parameters._
+import scalismo.faces.mesh._
+import scalismo.geometry._
+
+import spray.json._
+
+/** legacy JSON format for RenderParameter, compatible to C++, uses spray's AST but no typeclass conversions */
+trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
+  val version = "V1.0"
+
+  implicit val vector1DFormat: JsonFormat[Vector[_1D]] = new JsonFormat[Vector[_1D]] {
+    override def write(vec: Vector[_1D]): JsValue = JsArray(JsNumber(vec.x))
+
+    override def read(json: JsValue): Vector[_1D] = json match {
+      case JsArray(List(JsNumber(x))) => Vector(x.toDouble)
+      case _ => deserializationError("Expected Vector[_1D], got:" + json)
+    }
+  }
+
+  implicit val vector2DFormat: JsonFormat[Vector[_2D]] = new JsonFormat[Vector[_2D]] {
+    override def write(vec: Vector[_2D]): JsValue = JsArray(JsNumber(vec.x), JsNumber(vec.y))
+
+    override def read(json: JsValue): Vector[_2D] = json match {
+      case JsArray(List(JsNumber(x), JsNumber(y))) => Vector(x.toDouble, y.toDouble)
+      case _ => deserializationError("Expected Vector[_2D], got:" + json)
+    }
+  }
+
+  implicit val vector3DFormat: JsonFormat[Vector[_3D]] = new JsonFormat[Vector[_3D]] {
+    override def write(vec: Vector[_3D]): JsValue = JsArray(JsNumber(vec.x), JsNumber(vec.y), JsNumber(vec.z))
+
+    override def read(json: JsValue): Vector[_3D] = json match {
+      case JsArray(List(JsNumber(x), JsNumber(y), JsNumber(z))) => Vector(x.toDouble, y.toDouble, z.toDouble)
+      case _ => deserializationError("Expected Vector[_3D], got:" + json)
+    }
+  }
+
+  implicit val rgbFormat: JsonFormat[RGB] = new JsonFormat[RGB] {
+    override def write(col: RGB): JsValue = JsArray(JsNumber(col.r), JsNumber(col.g), JsNumber(col.b))
+
+    override def read(json: JsValue): RGB = json match {
+      case JsArray(List(JsNumber(r), JsNumber(g), JsNumber(b))) => RGB(r.toDouble, g.toDouble, b.toDouble)
+      case _ => deserializationError(s"Expected RGB, got: $json")
+    }
+  }
+
+  implicit val rgbaFormat: JsonFormat[RGBA] = new JsonFormat[RGBA] {
+    override def write(col: RGBA): JsValue = JsArray(JsNumber(col.r), JsNumber(col.g), JsNumber(col.b), JsNumber(col.a))
+
+    override def read(json: JsValue): RGBA = json match {
+      case JsArray(List(JsNumber(r), JsNumber(g), JsNumber(b), JsNumber(a))) => RGBA(r.toDouble, g.toDouble, b.toDouble, a.toDouble)
+      case _ => deserializationError(s"Expected RGBA, got: $json")
+    }
+  }
+
+  implicit val uriFormat: JsonFormat[URI] = new JsonFormat[URI] {
+    override def read(json: JsValue): URI = json match {
+      case JsString(uri) => new URI(uri)
+      case _ => throw new DeserializationException(s"expected URI, got $json")
+    }
+
+    override def write(obj: URI): JsValue = JsString(obj.toString)
+  }
+
+  implicit val colorFormat: RootJsonFormat[ColorTransform] = new RootJsonFormat[ColorTransform] {
+    override def write(color: ColorTransform): JsValue = JsObject(
+      "gain" -> color.gain.toJson,
+      "gamma" -> color.colorContrast.toJson,
+      "offset" -> color.offset.toJson)
+
+    override def read(json: JsValue): ColorTransform = {
+      val fields = json.asJsObject(s"expected Color object, got: $json").fields
+      ColorTransform(
+        gain = fields("gain").convertTo[RGB],
+        colorContrast = fields("gamma").convertTo[Double],
+        offset = fields("offset").convertTo[RGB])
+    }
+  }
+
+  implicit val poseFormat: RootJsonFormat[Pose] = new RootJsonFormat[Pose] {
+    override def write(p: Pose): JsValue = JsObject(
+      ("scaling", p.scaling.toJson),
+      ("translation", p.translation.toJson),
+      ("roll",p.roll.toJson),
+      ("yaw", p.yaw.toJson),
+      ("pitch", p.pitch.toJson))
+
+    override def read(json: JsValue): Pose = {
+      val fields = json.asJsObject(s"expected Pose object, got: $json").fields
+      Pose(
+        scaling = fields("scaling").convertTo[Double],
+        translation = fields("translation").convertTo[Vector[_3D]],
+        roll = fields("roll").convertTo[Double],
+        yaw = fields("yaw").convertTo[Double],
+        pitch = fields("pitch").convertTo[Double])
+    }
+  }
+
+  private case class LegacyCamera(far: Double,
+                                  focalLength: Double,
+                                  near: Double,
+                                  orthographic: Boolean,
+                                  pitch: Double,
+                                  principlePoint: Vector[_2D],
+                                  roll: Double,
+                                  sensorSize: Vector[_2D],
+                                  skewFactor: Double,
+                                  translation: Vector[_3D],
+                                  yaw: Double) {
+    def toCamera(imageSize: ImageSize): Camera = {
+      val pp = Point(2 * principlePoint.x/imageSize.width, 2 * principlePoint.y/imageSize.height)
+      Camera(
+        focalLength,
+        pp,
+        sensorSize / near,
+        near = near,
+        far = far,
+        orthographic = orthographic
+      )
+    }
+
+    def toView: ViewParameter = ViewParameter(
+      translation = translation,
+      pitch = pitch,
+      yaw = yaw,
+      roll = roll
+    )
+  }
+
+  private object LegacyCamera {
+    def apply(cam: Camera, imageSize: ImageSize, view: ViewParameter): LegacyCamera = {
+      val pp = Point(0.5 * imageSize.width * cam.principalPoint.x, 0.5 * imageSize.height * cam.principalPoint.y)
+      new LegacyCamera(
+        far = cam.far,
+        focalLength = cam.focalLength,
+        near = cam.near,
+        orthographic = cam.orthographic,
+        pitch = view.pitch,
+        principlePoint = pp.toVector,
+        roll = view.roll,
+        sensorSize = cam.sensorSize * cam.near,
+        skewFactor = 1.0,
+        translation = view.translation,
+        yaw = view.yaw)
+    }
+  }
+
+  private implicit val legacyCameraFormat = jsonFormat11(LegacyCamera.apply)
+
+  implicit val imageFormat: JsonFormat[ImageSize] = new JsonFormat[ImageSize] {
+    override def write(img: ImageSize): JsValue = JsArray(JsNumber(img.height), JsNumber(img.width))
+
+    override def read(json: JsValue): ImageSize = json match {
+      // warning: order of width and height is not as expected!!
+      case JsArray(List(JsNumber(height), JsNumber(width))) => ImageSize(width.toInt, height.toInt)
+      case _ => deserializationError("Expected Image, got:" + json)
+    }
+  }
+
+  implicit val directionalLightFormat: RootJsonFormat[DirectionalLight] = new RootJsonFormat[DirectionalLight] {
+    override def write(light: DirectionalLight): JsValue = JsObject(
+      ("ambient", light.ambient.toJson),
+      ("diffuse", light.diffuse.toJson),
+      ("direction", light.direction.toJson),
+      ("specular", light.specular.toJson))
+
+    override def read(json: JsValue): DirectionalLight = {
+      val fields = json.asJsObject(s"expected DirectionalLight object, got: $json").fields
+      DirectionalLight(
+        ambient = fields("ambient").convertTo[RGB],
+        diffuse = fields("diffuse").convertTo[RGB],
+        direction = fields("direction").convertTo[Vector[_3D]],
+        specular = fields("specular").convertTo[RGB])
+    }
+  }
+
+  private case class MoMoInstanceLegacy(shapeCoefficients: IndexedSeq[Double],
+                                colorCoefficients: IndexedSeq[Double],
+                                modelURI: URI,
+                                shininess: Double) {
+    def toMoMoInstance = MoMoInstance(shapeCoefficients, colorCoefficients, IndexedSeq.empty, modelURI)
+  }
+
+  private object MoMoInstanceLegacy {
+    def apply(momo: MoMoInstance, shininess: Double): MoMoInstanceLegacy = MoMoInstanceLegacy(momo.shape, momo.color, momo.modelURI, shininess)
+  }
+
+  private implicit val momoLegacyFormat: RootJsonFormat[MoMoInstanceLegacy] = jsonFormat4(MoMoInstanceLegacy.apply)
+
+  implicit val sphericalHarmonicsLightFormat: RootJsonFormat[SphericalHarmonicsLight] = new RootJsonFormat[SphericalHarmonicsLight] {
+
+    override def write(shl: SphericalHarmonicsLight): JsValue = {
+      def convertSHLToJz(shl: IndexedSeq[Vector[_3D]]): IndexedSeq[Vector[_3D]] = {
+        if (shl.isEmpty)
+          shl
+        else if (shl.size > 9)
+          throw new SerializationException("SHL json writer (V1): cannot write more than 9 coefficients in jz format (use modern version)")
+        else {
+          // 1 - 9 coefficients
+          val permutation = IndexedSeq(0, 3, 1, 2, 6, 5, 7, 4, 8).take(shl.size)
+          permutation map (i => shl(i))
+        }
+      }
+
+      convertSHLToJz(shl.coefficients).toJson
+    }
+
+    override def read(value: JsValue): SphericalHarmonicsLight = {
+      // need to convert from V1 order to our own order (jz order -> ss order)
+      def convertJzToSHL(shl: IndexedSeq[Vector[_3D]]): IndexedSeq[Vector[_3D]] = {
+        if (shl.isEmpty)
+          shl
+        else if (shl.size > 9)
+          throw new DeserializationException("SHL json reader (V1): cannot read more than 2 bands (9 coeffs), there is no conversion from jz to our format")
+        else {
+          // 1 - 0 coeffs
+          val permutation = IndexedSeq(0, 2, 3, 1, 7, 5, 4, 6, 8).take(shl.size)
+          permutation map (i => shl(i))
+        }
+      }
+
+      val shl = value.convertTo[IndexedSeq[Vector[_3D]]]
+      SphericalHarmonicsLight(convertJzToSHL(shl))
+    }
+  }
+
+  implicit val renderParameterFormat: RootJsonFormat[RenderParameter] = new RootJsonFormat[RenderParameter] {
+
+    override def write(param: RenderParameter): JsValue = {
+
+      val shLight = param.environmentMap
+      val dirLight = if (shLight.nonEmpty) DirectionalLight.off else param.directionalLight
+
+      val momoInst: MoMoInstanceLegacy = MoMoInstanceLegacy(param.momo, dirLight.shininess)
+
+      val legacyCamera = LegacyCamera(param.camera, param.imageSize, param.view)
+
+      JsObject(
+        ("camera", legacyCamera.toJson),
+        ("color", param.colorTransform.toJson),
+        ("directionalLight", dirLight.toJson),
+        ("image", param.imageSize.toJson),
+        ("morphableModel", momoInst.toJson),
+        ("pose", param.pose.toJson),
+        ("sphericalHarmonicsLight", shLight.toJson)
+      )
+    }
+
+    override def read(json: JsValue): RenderParameter = {
+      val fields = json.asJsObject(s"expected RenderParameter object, got: $json").fields
+
+      // V1.0: missing version field
+      if (fields.contains("version")) {
+        val version = fields("version").convertTo[String]
+        if (version != "1.0")
+          throw new DeserializationException(s"V1 json reader expects V1.0 json file, got: $version")
+      }
+
+      // parse illumination: SHL overrides directed light
+      val momoLegacy = fields("morphableModel").convertTo[MoMoInstanceLegacy]
+      val momo = momoLegacy.toMoMoInstance
+
+      val shLight = fields("sphericalHarmonicsLight").convertTo[SphericalHarmonicsLight]
+      val dirLight = if (shLight.nonEmpty) DirectionalLight.off else fields("directionalLight").convertTo[DirectionalLight].copy(shininess = momoLegacy.shininess)
+
+      val illumination = if (shLight.nonEmpty) shLight else dirLight
+
+      val pose = fields("pose").convertTo[Pose]
+      val imageSize = fields("image").convertTo[ImageSize]
+      val color = fields("color").convertTo[ColorTransform]
+
+      // legacy camera format
+      val legCam = fields("camera").convertTo[LegacyCamera]
+      val cam = legCam.toCamera(imageSize)
+      val view = legCam.toView
+
+      RenderParameter(
+        pose = pose,
+        view = view,
+        camera = cam,
+        environmentMap = shLight,
+        directionalLight = dirLight,
+        momo = momo,
+        imageSize = imageSize,
+        colorTransform = color
+      )
+    }
+  }
+}
+
+object RenderParameterJSONFormatLegacy extends RenderParameterJSONFormatLegacy

--- a/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatV2.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatV2.scala
@@ -1,0 +1,572 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.io.renderparameters
+
+import java.net.URI
+
+import scalismo.common.PointId
+import scalismo.faces.color.{ColorSpaceOperations, RGB, RGBA}
+import scalismo.faces.image._
+import scalismo.faces.mesh._
+import scalismo.faces.parameters._
+import scalismo.geometry._
+import scalismo.mesh._
+import spray.json._
+
+import scala.reflect.ClassTag
+
+/** JSON object format with variable renderables and illumination */
+trait RenderParameterJSONFormatV2 extends RenderParameterJSONFormatLegacy {
+  override val version = "V2.0"
+
+  // momo express writer and reader
+  protected case class MoMoInstanceV2(shape: IndexedSeq[Double],
+                                    color: IndexedSeq[Double],
+                                    modelURI: URI) {
+    def toMoMoInstance = MoMoInstance(shape, color, IndexedSeq.empty, modelURI)
+  }
+
+  // momo writer and reader
+  protected implicit val momoInstanceV2Format: RootJsonFormat[MoMoInstanceV2] = new RootJsonFormat[MoMoInstanceV2] {
+    def write(momo: MoMoInstanceV2): JsValue = JsObject(
+      ("shape", momo.shape.toJson),
+      ("color", momo.color.toJson),
+      ("modelURI", momo.modelURI.toJson),
+      ("@type", "MoMoInstance".toJson))
+
+    def read(json: JsValue): MoMoInstanceV2 = {
+      val fields = json.asJsObject(s"expected MoMoInstance object, got: $json").fields
+      MoMoInstanceV2(
+        shape = fields("shape").convertTo[IndexedSeq[Double]],
+        color = fields("color").convertTo[IndexedSeq[Double]],
+        modelURI = fields("modelURI").convertTo[URI])
+    }
+  }
+
+  // momo instance writer and reader: maps to a MoMoExpressInstance in this format
+  implicit val momoInstanceFormat: RootJsonFormat[MoMoInstance] = new RootJsonFormat[MoMoInstance] {
+    def write(momo: MoMoInstance): JsValue = momoExpressInstanceV2Format.write(MoMoExpressInstanceV2(momo))
+    def read(json: JsValue): MoMoInstance = json.convertTo[MoMoExpressInstanceV2].toMoMoInstance
+  }
+
+  // momo express writer and reader
+  protected case class MoMoExpressInstanceV2(shape: IndexedSeq[Double],
+                                           color: IndexedSeq[Double],
+                                           expression: IndexedSeq[Double],
+                                           modelURI: URI) {
+    def toMoMoInstance = MoMoInstance(shape, color, expression, modelURI)
+  }
+
+  protected object MoMoExpressInstanceV2 {
+    def apply(momo: MoMoInstance): MoMoExpressInstanceV2 = MoMoExpressInstanceV2(momo.shape, momo.color, momo.expression, momo.modelURI)
+  }
+
+  protected implicit val momoExpressInstanceV2Format: RootJsonFormat[MoMoExpressInstanceV2] = new RootJsonFormat[MoMoExpressInstanceV2] {
+    def write(momo: MoMoExpressInstanceV2): JsValue = JsObject(
+      ("shape", momo.shape.toJson),
+      ("color", momo.color.toJson),
+      ("expression", momo.expression.toJson),
+      ("modelURI", momo.modelURI.toJson),
+      ("@type", "MoMoExpressInstance".toJson))
+
+    override def read(json: JsValue): MoMoExpressInstanceV2 = {
+      val fields = json.asJsObject(s"expected MoMoInstance object, got: $json").fields
+      MoMoExpressInstanceV2(
+        shape = fields("shape").convertTo[IndexedSeq[Double]],
+        color = fields("color").convertTo[IndexedSeq[Double]],
+        expression = fields("expression").convertTo[IndexedSeq[Double]],
+        modelURI = fields("modelURI").convertTo[URI])
+    }
+  }
+
+  // mesh file
+  implicit val meshFileFormat: RootJsonFormat[MeshFile] = new RootJsonFormat[MeshFile] {
+    override def write(meshFile: MeshFile): JsValue = JsObject(
+      ("meshURI", meshFile.meshURI.toJson),
+      ("@type", "MeshFile".toJson)
+    )
+
+    override def read(json: JsValue): MeshFile = {
+      val fields = json.asJsObject(s"expected MeshFile object, got: $json").fields
+      MeshFile(
+        meshURI = fields("meshURI").convertTo[URI]
+      )
+    }
+  }
+
+  implicit val triangleCellFormat: JsonFormat[TriangleCell] = new JsonFormat[TriangleCell] {
+    override def read(json: JsValue): TriangleCell = json match {
+      case JsArray(Seq(JsNumber(p1), JsNumber(p2), JsNumber(p3))) => TriangleCell(PointId(p1.toInt), PointId(p2.toInt), PointId(p3.toInt))
+      case _ => throw new DeserializationException(s"expected TriangleCell, got $json")
+    }
+
+    override def write(obj: TriangleCell): JsValue = JsArray(obj.ptId1.id.toJson, obj.ptId2.id.toJson, obj.ptId3.id.toJson)
+  }
+
+  implicit def surfacePointPropertyFormat[A](implicit formatA: JsonFormat[A], interpolator: Interpolator[A]): RootJsonFormat[SurfacePointProperty[A]] = new RootJsonFormat[SurfacePointProperty[A]] {
+    override def read(json: JsValue): SurfacePointProperty[A] = {
+      val fields = json.asJsObject(s"expected SurfacePointProperty, got $json").fields
+
+      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
+      val triangulation = TriangleList(triangles)
+
+      val pointData = fields("pointData").convertTo[IndexedSeq[A]]
+
+      SurfacePointProperty(
+        triangulation = triangulation,
+        pointData = pointData
+      )
+    }
+
+    override def write(obj: SurfacePointProperty[A]): JsValue = {
+      JsObject(
+        "triangles" -> obj.triangulation.triangles.toJson,
+        "pointData" -> obj.pointData.toJson,
+        "@type" -> "SurfacePointProperty".toJson
+      )
+    }
+  }
+
+  implicit def trianglePropertyFormat[A](implicit formatA: JsonFormat[A]): RootJsonFormat[TriangleProperty[A]] = new RootJsonFormat[TriangleProperty[A]] {
+    override def read(json: JsValue): TriangleProperty[A] = {
+      val fields = json.asJsObject(s"expected TriangleProperty, got $json").fields
+
+      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
+      val triangulation = TriangleList(triangles)
+
+      val triangleData = fields("triangleData").convertTo[IndexedSeq[A]]
+
+      TriangleProperty(
+        triangulation = triangulation,
+        triangleData = triangleData
+      )
+    }
+
+    override def write(obj: TriangleProperty[A]): JsValue = {
+      JsObject(
+        "triangles" -> obj.triangulation.triangles.toJson,
+        "triangleData" -> obj.triangleData.toJson,
+        "@type" -> "TriangleProperty".toJson
+      )
+    }
+  }
+
+  implicit def vertexPropertyPerTriangleFormat[A](implicit formatA: JsonFormat[A], interpolator: Interpolator[A]): RootJsonFormat[VertexPropertyPerTriangle[A]] = new RootJsonFormat[VertexPropertyPerTriangle[A]] {
+    override def read(json: JsValue): VertexPropertyPerTriangle[A] = {
+      val fields = json.asJsObject(s"expected VertexPropertyPerTriangle, got $json").fields
+
+      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
+      val triangulation = TriangleList(triangles)
+
+      val pointData = fields("pointData").convertTo[IndexedSeq[A]]
+      val triangleIndex = fields("triangleIndex").convertTo[IndexedSeq[(Int, Int, Int)]].map{case(i, j, k) => IntVector3D(i, j, k)}
+
+      VertexPropertyPerTriangle(triangulation, triangleIndex, pointData)
+    }
+
+    override def write(obj: VertexPropertyPerTriangle[A]): JsValue = JsObject(
+      "triangles" -> obj.triangulation.triangles.toJson,
+      "pointData" -> obj.vertexData.toJson,
+      "triangleIndex" -> obj.triangleVertexIndex.map{v => (v.i, v.j, v.k)}.toJson,
+      "@type" -> "VertexPropertyPerTriangle".toJson
+    )
+  }
+
+  implicit def pixelImageFormat[A: ClassTag](implicit formatA: JsonFormat[A]): RootJsonFormat[PixelImage[A]] = new RootJsonFormat[PixelImage[A]] {
+    override def read(json: JsValue): PixelImage[A] = {
+      val fields = json.asJsObject(s"expected PixelImage, got $json").fields
+
+      val width = fields("width").convertTo[Int]
+      val height = fields("height").convertTo[Int]
+      val data = fields("data").convertTo[IndexedSeq[A]]
+      val domain = fields("domainMode").convertTo[String] match {
+        case "ColumnMajor" => ColumnMajorImageDomain(width, height)
+        case "RowMajor" => RowMajorImageDomain(width, height)
+        case s: String => throw new DeserializationException(s"unknown image domain mode: $s")
+      }
+
+      PixelImage(domain, data).withAccessMode(AccessMode.Repeat())
+    }
+
+    override def write(obj: PixelImage[A]): JsValue = JsObject(
+      "width" -> obj.width.toJson,
+      "height" -> obj.height.toJson,
+      "domainMode" -> (obj.domain match {
+        case d: ColumnMajorImageDomain => "ColumnMajor"
+        case d: RowMajorImageDomain => "RowMajor"
+      }).toJson,
+      "data" -> obj.values.toIndexedSeq.toJson
+    )
+  }
+
+  implicit val point2DFormat: JsonFormat[Point[_2D]] = new JsonFormat[Point[_2D]] {
+    override def write(vec: Point[_2D]): JsValue = JsArray(JsNumber(vec.x), JsNumber(vec.y))
+
+    override def read(json: JsValue): Point[_2D] = json match {
+      case JsArray(List(JsNumber(x), JsNumber(y))) => Point(x.toDouble, y.toDouble)
+      case _ => deserializationError("Expected Point[_2D], got:" + json)
+    }
+  }
+
+  implicit val colSpaceOps2D: ColorSpaceOperations[Point[_2D]] = new ColorSpaceOperations[Point[_2D]] {
+    override def add(pix1: Point[_2D], pix2: Point[_2D]): Point[_2D] = (pix1.toVector + pix2.toVector).toPoint
+    override def multiply(pix1: Point[_2D], pix2: Point[_2D]): Point[_2D] = Point(pix1.x * pix2.x, pix1.y * pix2.y)
+    override def dot(pix1: Point[_2D], pix2: Point[_2D]): Double = pix1.toVector.dot(pix2.toVector)
+    override def dimensionality: Int = 2
+    override def scale(pix: Point[_2D], l: Double): Point[_2D] = (pix.toVector * l).toPoint
+    override def zero: Point[_2D] = Point2D.origin
+  }
+
+  implicit def textureMappedPropertyFormat[A: ClassTag](implicit formatA: JsonFormat[A], interpolator: Interpolator[A], colorSpaceOperations: ColorSpaceOperations[A]): RootJsonFormat[TextureMappedProperty[A]] = new RootJsonFormat[TextureMappedProperty[A]] {
+    override def read(json: JsValue): TextureMappedProperty[A] = {
+      val fields = json.asJsObject(s"expected TextureMappedProperty, got $json").fields
+
+      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
+      val triangulation = TriangleList(triangles)
+
+      val textureMapping = fields("textureMapping").convertTo[MeshSurfaceProperty[Point[_2D]]]
+      val texture = fields("texture").convertTo[PixelImage[A]]
+
+      TextureMappedProperty(triangulation, textureMapping, texture)
+    }
+
+    override def write(obj: TextureMappedProperty[A]): JsValue = JsObject(
+      "triangles" -> obj.triangulation.triangles.toJson,
+      "textureMapping" -> obj.textureMapping.toJson,
+      "texture" -> obj.texture.toJson,
+      "@type" -> "TextureMappedProperty".toJson
+    )
+  }
+
+  implicit def indirectPropertyFormat[A: ClassTag](implicit formatA: JsonFormat[A], interpolator: Interpolator[A], colorSpaceOperations: ColorSpaceOperations[A]): RootJsonFormat[IndirectProperty[A]] = new RootJsonFormat[IndirectProperty[A]] {
+    override def read(json: JsValue): IndirectProperty[A] = {
+      val fields = json.asJsObject(s"expected IndirectProperty, got $json").fields
+
+      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
+      val triangulation = TriangleList(triangles)
+
+      val properties = fields("properties").convertTo[IndexedSeq[MeshSurfaceProperty[A]]]
+      val triangleIndirectionIndex = fields("triangleIndirectionIndex").convertTo[IndexedSeq[Int]]
+
+      IndirectProperty(triangulation, triangleIndirectionIndex, properties)
+    }
+
+    override def write(obj: IndirectProperty[A]): JsValue = JsObject(
+      "triangles" -> obj.triangulation.triangles.toJson,
+      "properties" -> obj.properties.toJson,
+      "triangleIndirectionIndex" -> obj.triangleIndirectionIndex.toJson,
+      "@type" -> "IndirectProperty".toJson
+    )
+  }
+
+
+  implicit def meshSurfaceProperty[A: ClassTag](implicit formatA: JsonFormat[A], interpolator: Interpolator[A], colorSpaceOperations: ColorSpaceOperations[A]): RootJsonFormat[MeshSurfaceProperty[A]] = new RootJsonFormat[MeshSurfaceProperty[A]] {
+    override def read(json: JsValue): MeshSurfaceProperty[A] = {
+      val fields = json.asJsObject(s"expected MeshSurfaceProperty, got: $json").fields
+      fields("@type") match {
+        case JsString("SurfacePointProperty") => json.convertTo[SurfacePointProperty[A]]
+        case JsString("TriangleProperty") => json.convertTo[TriangleProperty[A]]
+        case JsString("IndirectProperty") => json.convertTo[IndirectProperty[A]]
+        case JsString("VertexPropertyPerTriangle") => json.convertTo[VertexPropertyPerTriangle[A]]
+        case JsString("TextureMappedProperty") => json.convertTo[TextureMappedProperty[A]]
+        case _ => throw new DeserializationException(s"Unknown type of MeshSurfaceProperty")
+      }
+    }
+
+    override def write(obj: MeshSurfaceProperty[A]): JsValue = obj match {
+      case prop: SurfacePointProperty[A] => prop.toJson
+      case prop: TriangleProperty[A] => prop.toJson
+      case prop: IndirectProperty[A] => prop.toJson
+      case prop: VertexPropertyPerTriangle[A] => prop.toJson
+      case prop: TextureMappedProperty[A] => prop.toJson
+      case _ => throw new SerializationException("cannot serialize MeshSurfaceProperty, unknown type")
+    }
+  }
+
+  implicit val colorNormalMesh: RootJsonFormat[ColorNormalMesh3D] = new RootJsonFormat[ColorNormalMesh3D] {
+
+    override def write(mesh: ColorNormalMesh3D): JsValue = JsObject(
+      "points" -> mesh.shape.pointSet.points.map(_.toVector).toIndexedSeq.toJson,
+      "color" -> mesh.color.toJson,
+      "normals" -> mesh.normals.toJson,
+      "triangles" -> mesh.shape.triangles.toJson,
+      "@type" -> "ColorNormalMesh".toJson)
+
+    override def read(json: JsValue): ColorNormalMesh3D = {
+      val fields = json.asJsObject(s"expected Mesh object, got: $json").fields
+
+      val points  = fields("points").convertTo[IndexedSeq[Vector[_3D]]].map(_.toPoint)
+      val color   = fields("color").convertTo[MeshSurfaceProperty[RGBA]]
+      val normals = fields("normals").convertTo[MeshSurfaceProperty[Vector[_3D]]]
+      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
+
+      val triangulation = TriangleList(triangles)
+      val shape = TriangleMesh3D(points, triangulation)
+
+      ColorNormalMesh3D(shape, color, normals)
+    }
+  }
+
+  implicit val vertexColorMesh: RootJsonFormat[VertexColorMesh3D] = new RootJsonFormat[VertexColorMesh3D] {
+
+    override def write(mesh: VertexColorMesh3D): JsValue = JsObject(
+      "points" -> mesh.shape.pointSet.points.map(_.toVector).toIndexedSeq.toJson,
+      "color" -> mesh.color.pointData.toJson,
+      "triangles" -> mesh.shape.triangles.toJson,
+      "@type" -> "VertexColorMesh".toJson)
+
+    override def read(json: JsValue): VertexColorMesh3D = {
+      val fields = json.asJsObject(s"expected VertexColorMesh3D object, got: $json").fields
+
+      val points  = fields("points").convertTo[IndexedSeq[Vector[_3D]]].map(_.toPoint)
+      val color   = fields("color").convertTo[IndexedSeq[RGBA]]
+      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
+
+      val triangulation = TriangleList(triangles)
+      val shape = TriangleMesh3D(points, triangulation)
+
+      require(color.length == points.length)
+
+      VertexColorMesh3D(shape, SurfacePointProperty(triangulation, color))
+    }
+  }
+
+  implicit val meshColorNormalsFormat: RootJsonFormat[MeshColorNormals] = new RootJsonFormat[MeshColorNormals] {
+
+    override def write(mesh: MeshColorNormals): JsValue = mesh.colorNormalMesh.toJson
+
+    override def read(json: JsValue): MeshColorNormals = MeshColorNormals(json.convertTo[ColorNormalMesh3D])
+  }
+
+  implicit val meshVertexColorFormat: RootJsonFormat[MeshVertexColor] = new RootJsonFormat[MeshVertexColor] {
+
+    override def write(mesh: MeshVertexColor): JsValue = mesh.vertexColorMesh3D.toJson
+
+    override def read(json: JsValue): MeshVertexColor = MeshVertexColor(json.convertTo[VertexColorMesh3D])
+  }
+
+  // general object reader/writer
+  implicit val renderObjectFormat: RootJsonFormat[RenderObject] = new RootJsonFormat[RenderObject] {
+
+    override def write(renderObject: RenderObject): JsValue = renderObject match {
+      case momo: MoMoInstance => MoMoExpressInstanceV2(momo).toJson
+      case mF: MeshFile => mF.toJson
+      case meshDirect: MeshColorNormals => meshDirect.colorNormalMesh.toJson
+      case _ => throw new SerializationException(s"no JSON writer for RenderObject: $renderObject")
+    }
+
+    override def read(json: JsValue): RenderObject = {
+      val fields = json.asJsObject(s"expected RenderObject, got: $json").fields
+      fields("@type") match {
+        case JsString("MoMoInstance") => json.convertTo[MoMoInstanceV2].toMoMoInstance
+        case JsString("MoMoExpressInstance") => json.convertTo[MoMoExpressInstanceV2].toMoMoInstance
+        case JsString("MeshFile") => json.convertTo[MeshFile]
+        case JsString("ColorNormalMesh") => MeshColorNormals(json.convertTo[ColorNormalMesh3D])
+        case _ => throw new DeserializationException("Unknown type of RenderObject")
+      }
+    }
+  }
+
+  // illumination
+
+  override implicit val directionalLightFormat: RootJsonFormat[DirectionalLight] = new RootJsonFormat[DirectionalLight] {
+    override def write(light: DirectionalLight): JsValue = JsObject(
+      ("ambient", light.ambient.toJson),
+      ("diffuse", light.diffuse.toJson),
+      ("direction", light.direction.toJson),
+      ("specular", light.specular.toJson),
+      ("shininess", light.shininess.toJson),
+      ("@type", JsString("DirectionalLight")))
+
+    override def read(json: JsValue): DirectionalLight = {
+      val fields = json.asJsObject(s"expected DirectionalLight object, got: $json").fields
+      DirectionalLight(
+        ambient = fields("ambient").convertTo[RGB],
+        diffuse = fields("diffuse").convertTo[RGB],
+        direction = fields("direction").convertTo[Vector[_3D]],
+        specular = fields("specular").convertTo[RGB],
+        shininess = fields("shininess").convertTo[Double])
+    }
+  }
+
+  override implicit val sphericalHarmonicsLightFormat: RootJsonFormat[SphericalHarmonicsLight] = new RootJsonFormat[SphericalHarmonicsLight] {
+    override def write(obj: SphericalHarmonicsLight): JsValue = JsObject(
+      "coefficients" -> obj.coefficients.toJson,
+      "@type" -> "SphericalHarmonicsLight".toJson
+    )
+
+    override def read(json: JsValue): SphericalHarmonicsLight = {
+      val fields = json.asJsObject(s"expected Spherical Harmonics object, got: $json").fields
+      SphericalHarmonicsLight(
+        coefficients = fields("coefficients").convertTo[IndexedSeq[Vector[_3D]]]
+      )
+    }
+  }
+
+  implicit val illuminationFormat: RootJsonFormat[Illumination] = new RootJsonFormat[Illumination] {
+    override def write(obj: Illumination): JsValue = obj match {
+      case dl: DirectionalLight => dl.toJson
+      case shl: SphericalHarmonicsLight => shl.toJson
+      case _ => throw new SerializationException("Unknown type of Illumination")
+    }
+
+    override def read(json: JsValue): Illumination = {
+      val fields = json.asJsObject(s"expected Illumination, got: $json").fields
+      fields("@type") match {
+        case JsString("DirectionalLight") => json.convertTo[DirectionalLight]
+        case JsString("SphericalHarmonicsLight") => json.convertTo[SphericalHarmonicsLight]
+        case _ => throw new DeserializationException("Unknown type of Illumination")
+      }
+    }
+  }
+
+  private case class CameraV2(far: Double,
+                              focalLength: Double,
+                              near: Double,
+                              orthographic: Boolean,
+                              pitch: Double,
+                              principalPoint: Vector[_2D],
+                              roll: Double,
+                              sensorSize: Vector[_2D],
+                              skewFactor: Double,
+                              translation: Vector[_3D],
+                              yaw: Double) {
+    def toCamera(imageSize: ImageSize): Camera = {
+      val pp = Point(2 * principalPoint.x/imageSize.width, 2 * principalPoint.y/imageSize.height)
+      Camera(
+        focalLength,
+        pp,
+        sensorSize,
+        near = near,
+        far = far,
+        orthographic = orthographic
+      )
+    }
+
+    def toView: ViewParameter = ViewParameter(
+      translation = translation,
+      pitch = pitch,
+      yaw = yaw,
+      roll = roll
+    )
+  }
+
+  private object CameraV2 {
+    def apply(cam: Camera, imageSize: ImageSize, view: ViewParameter): CameraV2 = {
+      val pp = Point(0.5 * imageSize.width * cam.principalPoint.x, 0.5 * imageSize.height * cam.principalPoint.y)
+      new CameraV2(
+        far = cam.far,
+        focalLength = cam.focalLength,
+        near = cam.near,
+        orthographic = cam.orthographic,
+        pitch = view.pitch,
+        principalPoint = pp.toVector,
+        roll = view.roll,
+        sensorSize = cam.sensorSize,
+        skewFactor = 1.0,
+        translation = view.translation,
+        yaw = view.yaw)
+    }
+  }
+
+  private implicit val camFormatV2 = jsonFormat11(CameraV2.apply)
+
+  override implicit val imageFormat: JsonFormat[ImageSize] = new JsonFormat[ImageSize] {
+    override def write(img: ImageSize): JsValue = JsObject(
+      "height" -> JsNumber(img.height),
+      "width" -> JsNumber(img.width))
+
+    override def read(json: JsValue): ImageSize = json.asJsObject.getFields("width", "height") match {
+      case Seq(JsNumber(width), JsNumber(height)) => ImageSize(width.toInt, height.toInt)
+      case _ => deserializationError("Expected Image, got:" + json)
+    }
+  }
+
+  override implicit val colorFormat: RootJsonFormat[ColorTransform] = new RootJsonFormat[ColorTransform] {
+    override def write(color: ColorTransform): JsValue = JsObject(
+      ("gain", color.gain.toJson),
+      ("colorContrast", color.colorContrast.toJson),
+      ("offset", color.offset.toJson))
+
+    override def read(json: JsValue): ColorTransform = {
+      val fields = json.asJsObject(s"expected Color object, got: $json").fields
+      ColorTransform(
+        gain = fields("gain").convertTo[RGB],
+        colorContrast = fields("colorContrast").convertTo[Double],
+        offset = fields("offset").convertTo[RGB])
+    }
+  }
+  // render parameter reader / writer
+  override implicit val renderParameterFormat: RootJsonFormat[RenderParameter] = new RootJsonFormat[RenderParameter] {
+
+    override def write(param: RenderParameter): JsValue = {
+
+      val camV2 = CameraV2(param.camera, param.imageSize, param.view)
+      val momoV2 = MoMoExpressInstanceV2(param.momo)
+
+      val illumination: Illumination = if (param.environmentMap.nonEmpty) param.environmentMap else param.directionalLight
+
+      JsObject(
+        "pose" -> param.pose.toJson,
+        "camera" -> camV2.toJson,
+        "illumination" -> illumination.toJson,
+        "renderObject" -> momoV2.toJson,
+        "image" -> param.imageSize.toJson,
+        "color" -> param.colorTransform.toJson,
+        "version" -> version.toJson
+      )
+    }
+
+    override def read(json: JsValue): RenderParameter = {
+      val fields = json.asJsObject(s"expected BetterRenderParameter object, got: $json").fields
+      fields("version") match {
+        case JsString(`version`) =>
+          val imageSize = fields("image").convertTo[ImageSize]
+          val camV2 = fields("camera").convertTo[CameraV2]
+          val momoV2 = fields("renderObject").convertTo[RenderObject] match {
+            case momo: MoMoInstance => momo
+            case _ => throw new RuntimeException("does not support reading other objects than MoMoInstance/MoMoExpressInstance")
+          }
+
+          val shLight = fields("illumination").convertTo[Illumination] match {
+            case sh: SphericalHarmonicsLight => sh
+            case dirLight: DirectionalLight => SphericalHarmonicsLight.empty
+          }
+
+          val dirLight = fields("illumination").convertTo[Illumination] match {
+            case sh: SphericalHarmonicsLight => DirectionalLight.off
+            case dirLight: DirectionalLight => dirLight
+          }
+
+          RenderParameter(
+            pose = fields("pose").convertTo[Pose],
+            view = camV2.toView,
+            camera = camV2.toCamera(imageSize),
+            environmentMap = shLight,
+            directionalLight = dirLight,
+            momo = momoV2,
+            imageSize = imageSize,
+            colorTransform = fields("color").convertTo[ColorTransform]
+          )
+        case v => throw new DeserializationException(s"wrong version number, expected $version, got $v")
+      }
+    }
+  }
+
+}
+
+object RenderParameterJSONFormatV2 extends RenderParameterJSONFormatV2

--- a/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatV3.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatV3.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.io.renderparameters
+
+import scalismo.faces.parameters._
+import scalismo.geometry._
+import spray.json._
+
+trait RenderParameterJSONFormatV3 extends RenderParameterJSONFormatV2 {
+  // based on format V2
+
+  override val version = "V3.0"
+
+  implicit val viewParameterFormat: RootJsonFormat[ViewParameter] = new RootJsonFormat[ViewParameter] {
+    override def write(p: ViewParameter): JsValue = JsObject(
+      ("translation", p.translation.toJson),
+      ("roll",p.roll.toJson),
+      ("yaw", p.yaw.toJson),
+      ("pitch", p.pitch.toJson))
+
+    override def read(json: JsValue): ViewParameter = {
+      val fields = json.asJsObject(s"expected Pose object, got: $json").fields
+      ViewParameter(
+        translation = fields("translation").convertTo[Vector[_3D]],
+        roll = fields("roll").convertTo[Double],
+        yaw = fields("yaw").convertTo[Double],
+        pitch = fields("pitch").convertTo[Double])
+    }
+  }
+
+  implicit val cameraFormat: RootJsonFormat[Camera] = new RootJsonFormat[Camera] {
+    override def write(cam: Camera): JsValue = JsObject(
+      ("focalLength", cam.focalLength.toJson),
+      ("principalPoint", cam.principalPoint.toVector.toJson),
+      ("sensorSize", cam.sensorSize.toJson),
+      ("near", cam.near.toJson),
+      ("far", cam.far.toJson),
+      ("orthographic", cam.orthographic.toJson))
+
+    override def read(json: JsValue): Camera = {
+      val fields = json.asJsObject(s"expected Camera object, got: $json").fields
+      Camera(
+        focalLength = fields("focalLength").convertTo[Double],
+        sensorSize = fields("sensorSize").convertTo[Vector[_2D]],
+        principalPoint = fields("principalPoint").convertTo[Vector[_2D]].toPoint,
+        near = fields("near").convertTo[Double],
+        far = fields("far").convertTo[Double],
+        orthographic = fields("orthographic").convertTo[Boolean])
+    }
+  }
+
+  // render parameter reader / writer
+  override implicit val renderParameterFormat: RootJsonFormat[RenderParameter] = new RootJsonFormat[RenderParameter] {
+    override def write(param: RenderParameter): JsValue = {
+      val illumination: Illumination = if (param.environmentMap.nonEmpty) param.environmentMap else param.directionalLight
+
+      JsObject(
+        "pose" -> param.pose.toJson,
+        "view" -> param.view.toJson,
+        "camera" -> param.camera.toJson,
+        "illumination" -> illumination.toJson,
+        "renderObject" -> MoMoExpressInstanceV2(param.momo).toJson,
+        "imageSize" -> param.imageSize.toJson,
+        "colorTransform" -> param.colorTransform.toJson,
+        "version" -> version.toJson
+      )
+    }
+
+    override def read(json: JsValue): RenderParameter = {
+      val fields = json.asJsObject(s"expected BetterRenderParameter object, got: $json").fields
+
+      val momo = fields("renderObject").convertTo[RenderObject] match {
+        case m: MoMoInstance => m
+        case _ => throw new RuntimeException("cannot read other object than MoMoInstance/MoMoExpressInstance")
+      }
+
+      val shLight = fields("illumination").convertTo[Illumination] match {
+        case sh: SphericalHarmonicsLight => sh
+        case dirLight: DirectionalLight => SphericalHarmonicsLight.empty
+      }
+
+      val dirLight = fields("illumination").convertTo[Illumination] match {
+        case sh: SphericalHarmonicsLight => DirectionalLight.off
+        case dirLight: DirectionalLight => dirLight
+      }
+
+      fields("version") match {
+        case JsString(`version`) => RenderParameter(
+          pose = fields("pose").convertTo[Pose],
+          view = fields("view").convertTo[ViewParameter],
+          camera = fields("camera").convertTo[Camera],
+          environmentMap = shLight,
+          directionalLight = dirLight,
+          momo = momo,
+          imageSize = fields("imageSize").convertTo[ImageSize],
+          colorTransform = fields("colorTransform").convertTo[ColorTransform]
+        )
+        case v => throw new DeserializationException(s"wrong version number, expected $version, got $v")
+      }
+    }
+  }
+
+  // ** scene parameter part **
+
+  implicit val sceneTreeFormat: RootJsonFormat[SceneTree] = new RootJsonFormat[SceneTree] {
+    override def read(json: JsValue): SceneTree = {
+      val fields = json.asJsObject(s"expected SceneTree, got $json").fields
+      fields("@type") match {
+        case JsString("SceneObject") => SceneObject(fields("renderObject").convertTo[RenderObject])
+        case JsString("PoseNode") => PoseNode(
+          pose = fields("pose").convertTo[Pose],
+          children = fields("children").convertTo[IndexedSeq[SceneTree]]
+        )
+        case _ => throw new DeserializationException(s"unknown type of SceneTree node")
+      }
+    }
+
+    override def write(obj: SceneTree): JsValue = obj match {
+      case PoseNode(pose, children) => JsObject(
+        "pose" -> pose.toJson,
+        "children" -> children.toJson,
+        "@type" -> "PoseNode".toJson
+      )
+      case SceneObject(renderObject) => JsObject(
+        "renderObject" -> renderObject.toJson,
+        "@type" -> "SceneObject".toJson
+      )
+    }
+  }
+
+  implicit val sceneParameterFormat: RootJsonFormat[SceneParameter] = new RootJsonFormat[SceneParameter] {
+    val version = "SceneParameterV3.0"
+    override def write(param: SceneParameter): JsValue = JsObject(
+      "view" -> param.view.toJson,
+      "camera" -> param.camera.toJson,
+      "illuminations" -> param.illuminations.toJson,
+      "sceneTree" -> param.sceneTree.toJson,
+      "imageSize" -> param.imageSize.toJson,
+      "colorTransform" -> param.colorTransform.toJson,
+      "version" -> version.toJson
+    )
+
+    override def read(json: JsValue): SceneParameter = {
+      val fields = json.asJsObject(s"expected SceneParameter object, got: $json").fields
+      fields("version") match {
+        case JsString(`version`) => SceneParameter(
+          view = fields("view").convertTo[ViewParameter],
+          camera = fields("camera").convertTo[Camera],
+          illuminations = fields("illuminations").convertTo[IndexedSeq[Illumination]],
+          sceneTree = fields("sceneTree").convertTo[SceneTree],
+          imageSize = fields("imageSize").convertTo[ImageSize],
+          colorTransform = fields("colorTransform").convertTo[ColorTransform]
+        )
+        case v => throw new DeserializationException(s"wrong version number, expected $version, got $v")
+      }
+    }
+  }
+
+}
+
+object RenderParameterJSONFormatV3 extends RenderParameterJSONFormatV3

--- a/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatV4.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatV4.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.io.renderparameters
+
+import java.net.URI
+
+import scalismo.faces.parameters._
+import spray.json._
+
+/** V4 file format */
+trait RenderParameterJSONFormatV4 extends RenderParameterJSONFormatV3 {
+  // based on format V3: updated MoMoInstance now always has expressions, MoMoExpressInstance removed
+
+  override val version = "V4.0"
+
+  // momo instance writer and reader: direct format now
+  override implicit val momoInstanceFormat: RootJsonFormat[MoMoInstance] = new RootJsonFormat[MoMoInstance] {
+    def write(momo: MoMoInstance): JsValue = JsObject(
+      ("shape", momo.shape.toJson),
+      ("color", momo.color.toJson),
+      ("expression", momo.expression.toJson),
+      ("modelURI", momo.modelURI.toJson))
+
+    def read(json: JsValue): MoMoInstance = {
+      val fields = json.asJsObject(s"expected MoMoInstance object, got: $json").fields
+      MoMoInstance(
+        shape = fields("shape").convertTo[IndexedSeq[Double]],
+        color = fields("color").convertTo[IndexedSeq[Double]],
+        expression = fields("expression").convertTo[IndexedSeq[Double]],
+        modelURI = fields("modelURI").convertTo[URI])
+    }
+  }
+
+  // render parameter reader / writer
+  override implicit val renderParameterFormat: RootJsonFormat[RenderParameter] = new RootJsonFormat[RenderParameter] {
+    override def write(param: RenderParameter): JsValue = JsObject(
+      "pose" -> param.pose.toJson,
+      "view" -> param.view.toJson,
+      "camera" -> param.camera.toJson,
+      "environmentMap" -> param.environmentMap.toJson,
+      "directionalLight" -> param.directionalLight.toJson,
+      "momo" -> param.momo.toJson,
+      "imageSize" -> param.imageSize.toJson,
+      "colorTransform" -> param.colorTransform.toJson,
+      "version" -> version.toJson
+    )
+
+    override def read(json: JsValue): RenderParameter = {
+      val fields = json.asJsObject(s"expected BetterRenderParameter object, got: $json").fields
+      fields("version") match {
+        case JsString(`version`) => RenderParameter(
+          pose = fields("pose").convertTo[Pose],
+          view = fields("view").convertTo[ViewParameter],
+          camera = fields("camera").convertTo[Camera],
+          environmentMap = fields("environmentMap").convertTo[SphericalHarmonicsLight],
+          directionalLight = fields("directionalLight").convertTo[DirectionalLight],
+          momo = fields("momo").convertTo[MoMoInstance],
+          imageSize = fields("imageSize").convertTo[ImageSize],
+          colorTransform = fields("colorTransform").convertTo[ColorTransform]
+        )
+        case v => throw new DeserializationException(s"wrong version number, expected $version, got $v")
+      }
+    }
+  }
+}
+
+object RenderParameterJSONFormatV4 extends RenderParameterJSONFormatV4

--- a/src/main/scala/scalismo/faces/mesh/Mesh.scala
+++ b/src/main/scala/scalismo/faces/mesh/Mesh.scala
@@ -17,6 +17,7 @@
 package scalismo.faces.mesh
 
 import scalismo.faces.color.RGBA
+import scalismo.faces.render.Transform3D
 import scalismo.geometry.{Vector, _3D}
 import scalismo.mesh._
 
@@ -27,6 +28,11 @@ import scalismo.mesh._
   */
 case class ColorMesh3D(shape: TriangleMesh3D, color: MeshSurfaceProperty[RGBA]) {
   require(shape.triangulation == color.triangulation)
+
+  def transform(trafo: Transform3D): ColorMesh3D = {
+    val s = shape.transform{trafo(_)}
+    copy(shape = s)
+  }
 }
 
 /**
@@ -36,6 +42,11 @@ case class ColorMesh3D(shape: TriangleMesh3D, color: MeshSurfaceProperty[RGBA]) 
   */
 case class VertexColorMesh3D(shape: TriangleMesh3D, color: SurfacePointProperty[RGBA]) {
   require(shape.triangulation == color.triangulation)
+
+  def transform(trafo: Transform3D): VertexColorMesh3D = {
+    val s = shape.transform{trafo(_)}
+    copy(shape = s)
+  }
 }
 
 /**
@@ -48,6 +59,13 @@ case class ColorNormalMesh3D(shape: TriangleMesh3D, color: MeshSurfaceProperty[R
   // @todo wait for scalismo to fix issue #138
   //  require(shape.triangulation == color.triangulation)
   //  require(shape.triangulation == normals.triangulation)
+
+  def transform(trafo: Transform3D): ColorNormalMesh3D = {
+    val n = normals.map{trafo(_).normalize}
+    val s = shape.transform{trafo(_)}
+    copy(shape = s, normals = n)
+  }
+
   def withVertexNormals: ColorNormalMesh3D = copy(normals = shape.vertexNormals)
 
   def withFaceNormals: ColorNormalMesh3D = copy(normals = shape.cellNormals)
@@ -109,6 +127,12 @@ case class OptionalColorNormalMesh3D(shape: TriangleMesh3D,
     for {
       tex <- texture
     } yield TexturedMesh3D(shape, tex)
+  }
+
+  def transform(trafo: Transform3D): OptionalColorNormalMesh3D = {
+    val s = shape.transform{trafo(_)}
+    val n = for(norm <- normals) yield norm.map{trafo(_)}
+    copy(shape = s, normals = n)
   }
 }
 

--- a/src/main/scala/scalismo/faces/mesh/TextureMappedProperty.scala
+++ b/src/main/scala/scalismo/faces/mesh/TextureMappedProperty.scala
@@ -17,21 +17,24 @@
 package scalismo.faces.mesh
 
 import scalismo.faces.color.ColorSpaceOperations
-import scalismo.faces.image.PixelImage
 import scalismo.faces.image.filter.ImageFilter
+import scalismo.faces.image.{InterpolatedPixelImage, PixelImage, PixelImageDomain}
+import scalismo.faces.render.{PixelShaders, PlainRenderBuffer, PointShader, TriangleRenderer}
 import scalismo.geometry.Point._
-import scalismo.geometry.{Point, _2D}
+import scalismo.geometry.{Point, _2D, _3D}
 import scalismo.mesh.{BarycentricCoordinates, MeshSurfaceProperty, TriangleId, TriangleList}
+
+import scala.reflect.ClassTag
 
 /** texture mapping for a property: texture image contains property values, textureMapping maps surface to texture domain */
 case class TextureMappedProperty[A](override val triangulation: TriangleList,
                                     textureMapping: MeshSurfaceProperty[Point[_2D]],
                                     texture: PixelImage[A])(implicit ops: ColorSpaceOperations[A])
   extends MeshSurfaceProperty[A] {
-  val w = texture.width
-  val h = texture.height
+  val w: Int = texture.width
+  val h: Int = texture.height
 
-  val texInterpolated = texture.interpolate
+  val texInterpolated: InterpolatedPixelImage[A] = texture.interpolate
 
   override def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): A = {
     val t = triangulation.triangle(triangleId)
@@ -53,4 +56,46 @@ object TextureMappedProperty {
   def imageCoordinatesFromUV(texCoord: Point[_2D], w: Int, h: Int) = Point(texCoord.x * w - 0.5, (1 - texCoord.y) * h - 0.5)
   @inline
   def imageCoordinatesToUV(imageCoord: Point[_2D], w: Int, h: Int) = Point((imageCoord.x + 0.5) / w, 1 - (imageCoord.y + 0.5) / h)
+
+  /**
+    * sample an arbitrary surface property into a texture-based property
+    *
+    * @param surfaceProperty surface property to sample
+    * @param textureMapping texture coordinates used to sample the property
+    * @param texImageDomain texture size
+    * @param bgValue value of texture where no information is stored
+    */
+  def fromSurfaceProperty[Pixel: ClassTag](surfaceProperty: MeshSurfaceProperty[Pixel],
+                                           textureMapping: MeshSurfaceProperty[Point[_2D]],
+                                           texImageDomain: PixelImageDomain,
+                                           bgValue: Pixel)(implicit ops: ColorSpaceOperations[Pixel]): TextureMappedProperty[Pixel] = {
+    // triangulation
+    val triangulation = surfaceProperty.triangulation
+
+    // texture size
+    val w = texImageDomain.width
+    val h = texImageDomain.height
+
+    // use rasterer: need shaders to render positions and surface property values
+    // point shader is not needed to do anything
+    val pointShader = new PointShader {
+      override def apply(p: Point[_3D]): Point[_3D] = p
+    }
+    // accesses the surface property at each point of the triangle, the property itself
+    val propertyShader = PixelShaders.PropertyShader(surfaceProperty)
+    // texture image, invert buffer y inversion of renderer (we do this explicitly with UV coordinates here)
+    val textureBuffer = PlainRenderBuffer(w, h, bgValue)
+    def p3d(p: Point[_2D]) = Point(p.x, p.y, 0.0)
+    // raster triangles
+    for (tid <- triangulation.triangleIds) {
+      // points in texture image
+      val p1 = p3d(imageCoordinatesFromUV(textureMapping(tid, BarycentricCoordinates.v0), texImageDomain.width, texImageDomain.height))
+      val p2 = p3d(imageCoordinatesFromUV(textureMapping(tid, BarycentricCoordinates.v1), texImageDomain.width, texImageDomain.height))
+      val p3 = p3d(imageCoordinatesFromUV(textureMapping(tid, BarycentricCoordinates.v2), texImageDomain.width, texImageDomain.height))
+      // raster triangle into texture image
+      TriangleRenderer.rasterTriangle(tid, p1, p2, p3, pointShader, propertyShader, textureBuffer)
+    }
+    // create texture mapped property
+    TextureMappedProperty(triangulation, textureMapping, textureBuffer.toImage)
+  }
 }

--- a/src/main/scala/scalismo/faces/numerics/SphericalHarmonics.scala
+++ b/src/main/scala/scalismo/faces/numerics/SphericalHarmonics.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import scalismo.geometry.{Vector, _3D}
+
+import scala.annotation.switch
+import scala.math._
+
+/** two-values index of Spherical Harmonics function (l, m) */
+case class SHIndex(l: Int, m: Int) {
+  require(isValid, s"SHIndex is invalid! ($l, $m)")
+  def isValid: Boolean = abs(m) <= l
+  val toSingleIndex: Int = l * l + m + l
+}
+
+object SHIndex {
+  def apply(i: Int): SHIndex = {
+    val l = sqrt(i).toInt
+    val m = i - l * l - l
+    SHIndex(l, m)
+  }
+}
+
+/** service functions for real spherical harmonics */
+object SphericalHarmonics {
+  type SHBasisFunction = ((Vector[_3D]) => Double)
+
+  val N0: Double = sqrt(1.0 / Pi) / 2.0
+
+  val N1: Double = sqrt(3.0 / Pi) / 2.0
+
+  val N2_2: Double = sqrt(15.0 / Pi) / 4.0
+  val N2_1: Double = sqrt(15.0 / Pi) / 2.0
+  val N2_0: Double = sqrt(5.0 / Pi) / 4.0
+
+  val N3_3: Double = sqrt(35.0 / 2.0 / Pi) / 4.0
+  val N3_2: Double = sqrt(105.0 / Pi) / 2.0
+  val N3_1: Double = sqrt(21.0 / 2.0 / Pi) / 4.0
+  val N3_0: Double = sqrt(7.0 / Pi) / 4.0
+
+  val N4_4: Double = sqrt(35.0 / Pi) * 3.0 / 16.0
+  val N4_3: Double = sqrt(35.0 / 2.0 / Pi) * 3.0 / 4.0
+  val N4_2: Double = sqrt(5.0 / Pi) * 3.0 / 8.0
+  val N4_1: Double = sqrt(5.0 / 2.0 / Pi) * 3.0 / 8.0
+  val N4_0: Double = sqrt(1.0 / Pi) * 3.0 / 16.0
+
+  //https://en.wikipedia.org/wiki/Table_of_spherical_harmonics#Real_spherical_harmonics
+  private val shBasisPredefined = Map[SHIndex, SHBasisFunction](
+    SHIndex(0, 0) -> ((v: Vector[_3D]) => N0),
+
+    SHIndex(1, -1) -> ((v: Vector[_3D]) => N1 * v.y),
+    SHIndex(1, 0) -> ((v: Vector[_3D]) => N1 * v.z),
+    SHIndex(1, 1) -> ((v: Vector[_3D]) => N1 * v.x),
+
+    SHIndex(2, -2) -> ((v: Vector[_3D]) => N2_1 * v.x * v.y),
+    SHIndex(2, -1) -> ((v: Vector[_3D]) => N2_1 * v.y * v.z),
+    SHIndex(2, 0) -> ((v: Vector[_3D]) => N2_0 * (2 * v.z * v.z - v.x * v.x - v.y * v.y)),
+    SHIndex(2, 1) -> ((v: Vector[_3D]) => N2_1 * v.z * v.x),
+    SHIndex(2, 2) -> ((v: Vector[_3D]) => N2_2 * (v.x * v.x - v.y * v.y)),
+
+    SHIndex(3, -3) -> ((v: Vector[_3D]) => N3_3 * (3 * v.x * v.x - v.y * v.y) * v.y),
+    SHIndex(3, -2) -> ((v: Vector[_3D]) => N3_2 * (v.x * v.y * v.z)),
+    SHIndex(3, -1) -> ((v: Vector[_3D]) => N3_1 * (4 * v.z * v.z - v.x * v.x - v.y * v.y) * v.y),
+    SHIndex(3, 0) -> ((v: Vector[_3D]) => N3_0 * (2 * v.z * v.z - 3 * v.x * v.x - 3 * v.y * v.y) * v.z),
+    SHIndex(3, 1) -> ((v: Vector[_3D]) => N3_1 * (4 * v.z * v.z - v.x * v.x - v.y * v.y) * v.x),
+    SHIndex(3, 2) -> ((v: Vector[_3D]) => N3_2 * (v.x * v.x - v.y * v.y) * v.z),
+    SHIndex(3, 3) -> ((v: Vector[_3D]) => N3_3 * (v.x * v.x - 3 * v.y * v.y) * v.x),
+
+    SHIndex(4, -4) -> ((v: Vector[_3D]) => N4_4 * 4 * v.x * v.y * (v.x * v.x - v.y * v.y)),
+    SHIndex(4, -3) -> ((v: Vector[_3D]) => N4_3 * (3 * v.x * v.x - v.y * v.y) * v.y * v.z),
+    SHIndex(4, -2) -> ((v: Vector[_3D]) => N4_2 * 2 * v.x * v.y * (7 * v.z * v.z - 1.0)),
+    SHIndex(4, -1) -> ((v: Vector[_3D]) => N4_1 * v.y * v.z * (7 * v.z * v.z - 3.0)),
+    SHIndex(4, 0) -> ((v: Vector[_3D]) => N4_0 * (35 * v.z * v.z * v.z * v.z - 30 * v.z * v.z + 3.0)),
+    SHIndex(4, 1) -> ((v: Vector[_3D]) => N4_1 * v.x * v.z * (7 * v.z * v.z - 3.0)),
+    SHIndex(4, 2) -> ((v: Vector[_3D]) => N4_2 * (v.x * v.x - v.y * v.y) * (7 * v.z * v.z - 1.0)),
+    SHIndex(4, 3) -> ((v: Vector[_3D]) => N4_3 * v.x * v.z * (v.x * v.x - 3 * v.y * v.y)),
+    SHIndex(4, 4) -> ((v: Vector[_3D]) => N4_4 * (v.x * v.x * (v.x * v.x - 3 * v.y * v.y) - v.y * v.y * (3 * v.x * v.x - v.y * v.y)))
+  )
+
+  /** analytic fall-back to get an arbitrary SH basis function ... slow! */
+  private def shBasisFunctionAnalytic(ind: SHIndex): SHBasisFunction = ???
+
+  /** back predefined SH basis with slower analytic solution for every index */
+  private val shBasisFunctionFull = shBasisPredefined.withDefault(shBasisFunctionAnalytic)
+
+  /** get proper function and wrap with a normalization */
+  private def shBasisFunctionFromMap(index: SHIndex): SHBasisFunction = {
+    def norm(v: Vector[_3D]): Vector[_3D] = v.normalize
+    val sh = shBasisFunctionFull(index)
+    // work with normalized vector - direction
+    (v: Vector[_3D]) => sh(norm(v))
+  }
+
+  /** cache SH basis in fast Vector */
+  private val shBasisPredefinedTabulated: IndexedSeq[SHBasisFunction] = {
+    IndexedSeq.tabulate(shBasisPredefined.size) { i => shBasisFunctionFromMap(SHIndex(i)) }
+  }
+
+  // lookup table for l and m as function of a linear index i
+  private val lLookup: Array[Int] = Array.tabulate(totalCoefficients(4)) { i => sqrt(i).toInt }
+  private def lFromIndex(i: Int): Int = if (i < lLookup.length) lLookup(i) else sqrt(i).toInt
+
+  /** get SH basis function with given indices l, m - fast for l < 5 */
+  def shBasisFunction(l: Int, m: Int): SHBasisFunction = shBasisFunction(SHIndex(l, m))
+
+  /** get SH basis function with given index - fast for l < 5 */
+  def shBasisFunction(shi: SHIndex): SHBasisFunction = {
+    val i = shi.toSingleIndex
+    if (shBasisPredefinedTabulated.isDefinedAt(i))
+      shBasisPredefinedTabulated(i)
+    else
+      shBasisFunctionFromMap(shi)
+  }
+
+  /** get SH basis function with linear index - fast for i < 25 */
+  def shBasisFunction(i: Int): SHBasisFunction = {
+    if (shBasisPredefinedTabulated.isDefinedAt(i))
+      shBasisPredefinedTabulated(i)
+    else
+      shBasisFunctionFromMap(SHIndex(i))
+  }
+
+  /** total number of functions when using expansions with l bands */
+  def totalCoefficients(bands: Int): Int = (bands + 1) * (bands + 1)
+
+  /** number of m values within a band l */
+  def coefficientsInBand(band: Int): Int = 2 * band + 1
+
+  /** number of l values required to have given number of coefficients */
+  def numberOfBandsForCoefficients(coefficients: Int): Int = sqrt(coefficients - 1).toInt
+
+  /** direction calculation of Spherical Harmonics basis function */
+  def shBasisFunctionDirect(i: Int, direction: Vector[_3D]): Double = {
+    val l = lFromIndex(i)
+    val m = i - l * l - l
+    shBasisFunctionDirect(l, m, direction)
+  }
+
+  /** direct calculation of SH basis function, only for l < 5 (c++ nostalgia version) */
+  def shBasisFunctionDirect(l: Int, m: Int, direction: Vector[_3D]): Double = {
+    //https://en.wikipedia.org/wiki/Table_of_spherical_harmonics#Real_spherical_harmonics
+    val v: Vector[_3D] = direction.normalize
+
+    val x = v.x
+    val y = v.y
+    val z = v.z
+
+    val xx = x * x
+    val yy = y * y
+    val zz = z * z
+
+    (l: @switch) match {
+      case 0 => N0
+      case 1 => m match {
+        case -1 => N1 * y
+        case 0 => N1 * z
+        case 1 => N1 * x
+      }
+      case 2 => m match {
+        case -2 => N2_1 * x * y
+        case -1 => N2_1 * y * z
+        case 0 => N2_0 * (2 * zz - xx - yy)
+        case 1 => N2_1 * z * x
+        case 2 => N2_2 * (xx - yy)
+      }
+      case 3 => m match {
+        case -3 => N3_3 * (3 * xx - yy) * y
+        case -2 => N3_2 * (x * y * z)
+        case -1 => N3_1 * (4 * zz - xx - yy) * y
+        case 0 => N3_0 * (2 * zz - 3 * xx - 3 * yy) * z
+        case 1 => N3_1 * (4 * zz - xx - yy) * x
+        case 2 => N3_2 * (xx - yy) * z
+        case 3 => N3_3 * (xx - 3 * yy) * x
+      }
+      case 4 => m match {
+        case -4 => N4_4 * 4 * x * y * (xx - yy)
+        case -3 => N4_3 * (3 * xx - yy) * y * z
+        case -2 => N4_2 * 2 * x * y * (7 * zz - 1.0)
+        case -1 => N4_1 * y * z * (7 * zz - 3.0)
+        case 0 => N4_0 * (35 * zz * zz - 30 * zz + 3.0)
+        case 1 => N4_1 * x * z * (7 * zz - 3.0)
+        case 2 => N4_2 * (xx - yy) * (7 * zz - 1.0)
+        case 3 => N4_3 * x * z * (xx - 3 * yy)
+        case 4 => N4_4 * (xx * (xx - 3 * yy) - yy * (3 * xx - yy))
+      }
+    }
+  }
+}

--- a/src/main/scala/scalismo/faces/parameters/Camera.scala
+++ b/src/main/scala/scalismo/faces/parameters/Camera.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import scalismo.faces.render._
+import scalismo.geometry._
+
+/** camera parameterization */
+case class Camera(focalLength: Double,
+                  principalPoint: Point[_2D],
+                  sensorSize: Vector[_2D],
+                  near: Double,
+                  far: Double,
+                  orthographic: Boolean) {
+
+  require(focalLength > 0.0, "focal length must be positive")
+  require(sensorSize.x > 0.0 && sensorSize.y > 0.0, "sensor size must be positive")
+  require(near < far, "near plane must be closer than far plane")
+
+  /** projection of this camera, ignores principalPoint, no offset (wrong units, PP is in pixels!) */
+  def projection: FrustumProjection with Transform4x4 = {
+    if (orthographic)
+      FrustumOrthographicProjection(Frustum.fromFocalWithSensor(focalLength, sensorSize, near, far).withCenter(principalPoint))
+    else
+      FrustumPinholeProjection(Frustum.fromFocalWithSensor(focalLength, sensorSize, near, far).withCenter(principalPoint))
+  }
+
+  /** viewing frustum of this scene */
+  def frustum: Frustum = Frustum.fromFocalWithSensor(focalLength, sensorSize, near, far).withCenter(principalPoint)
+}
+
+object Camera {
+  val sensor35mm = Vector(36, 24)
+
+  def for35mmFilm(focalLength: Double) = Camera(focalLength, Point2D.origin, sensor35mm, orthographic = false, near = 10, far = 1000e3)
+}

--- a/src/main/scala/scalismo/faces/parameters/ColorTransform.scala
+++ b/src/main/scala/scalismo/faces/parameters/ColorTransform.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import scalismo.faces.color.RGB
+import scalismo.faces.render.ColorTransformWithColorContrast
+
+/** parametrization of color transform in image after rendering (color gain, offset and color contrast) */
+case class ColorTransform(gain: RGB, colorContrast: Double, offset: RGB) {
+  def transform: ColorTransformWithColorContrast = ColorTransformWithColorContrast(gain, colorContrast, offset)
+}
+
+object ColorTransform {
+  val neutral = ColorTransform(RGB.White, 1f, RGB.Black)
+}

--- a/src/main/scala/scalismo/faces/parameters/Illumination.scala
+++ b/src/main/scala/scalismo/faces/parameters/Illumination.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import breeze.linalg.DenseVector
+import scalismo.faces.color.{RGB, RGBA}
+import scalismo.faces.mesh.ColorNormalMesh3D
+import scalismo.faces.numerics.SphericalHarmonics
+import scalismo.faces.render.PixelShaders.SphericalHarmonicsLambertShader
+import scalismo.faces.render.{PixelShader, PixelShaders}
+import scalismo.geometry.{Point, Vector, Vector3D, _3D}
+
+/** Illumination to shade meshes */
+sealed trait Illumination {
+  def shader(worldMesh: ColorNormalMesh3D, eyePosition: Point[_3D]): PixelShader[RGBA]
+}
+
+/** directional illumination with Phong reflectance */
+case class DirectionalLight(ambient: RGB,
+                            diffuse: RGB,
+                            direction: Vector[_3D],
+                            specular: RGB,
+                            shininess: Double = 10.0) extends Illumination {
+
+  override def shader(worldMesh: ColorNormalMesh3D, eyePosition: Point[_3D]): PixelShader[RGBA] = {
+    val diffuseShader = PixelShaders.LambertShader(worldMesh.color, ambient, diffuse, direction.normalize, worldMesh.normals)
+    val specularShader = PixelShaders.BlinnPhongSpecularShader(specular, direction, worldMesh.shape.position, worldMesh.normals, eyePosition, shininess)
+    diffuseShader + specularShader
+  }
+}
+
+object DirectionalLight {
+  /** default ambient-only light, direct reproduction of color values, no shading */
+  val ambient = DirectionalLight(RGB.White, RGB.Black, Vector3D.unitZ, RGB.Black, 10.0)
+
+  val off = DirectionalLight(RGB.Black, RGB.Black, Vector3D.unitZ, RGB.Black, 10.0)
+}
+
+/** Spherical Harmonics illumination parameters, environment map */
+case class SphericalHarmonicsLight(coefficients: IndexedSeq[Vector[_3D]]) extends Illumination {
+  val nonEmpty: Boolean = coefficients.nonEmpty
+
+  override def shader(worldMesh: ColorNormalMesh3D, eyePosition: Point[_3D]): SphericalHarmonicsLambertShader = shader(worldMesh)
+
+  /** SH shader for a given mesh and this environment map */
+  def shader(worldMesh: ColorNormalMesh3D): SphericalHarmonicsLambertShader = {
+    PixelShaders.SphericalHarmonicsLambertShader(worldMesh.color, coefficients, worldMesh.normals)
+  }
+
+  /** linearize coefficients to a Breeze vector (r, g, b, r, g, b ... ) */
+  def toBreezeVector: DenseVector[Double] = DenseVector(coefficients.flatMap(v => IndexedSeq(v.x, v.y, v.z)).toArray)
+
+  /** total coefficients energy */
+  def energy: Double = coefficients.map(_.norm2).sum
+
+  /** number of bands */
+  def bands: Int = SphericalHarmonics.numberOfBandsForCoefficients(coefficients.size)
+
+  /** change number of bands */
+  def withNumberOfBands(numberOfBands: Int): SphericalHarmonicsLight = {
+    if (numberOfBands < bands)
+      SphericalHarmonicsLight(
+        coefficients.take(SphericalHarmonics.totalCoefficients(numberOfBands))
+      )
+    else if (numberOfBands > bands)
+      SphericalHarmonicsLight(
+        coefficients ++
+          IndexedSeq.fill(SphericalHarmonics.totalCoefficients(numberOfBands) - coefficients.length)(Vector3D.zero)
+      )
+    else
+      this
+  }
+}
+
+object SphericalHarmonicsLight {
+
+  import scalismo.geometry.Vector._
+
+  /** values of the Lambertian reflectance kernel expressed in SH */
+  val lambertKernel = Array(
+    3.141593,
+    2.094395,
+    2.094395,
+    2.094395,
+    0.785398,
+    0.785398,
+    0.785398,
+    0.785398,
+    0.785398
+  )
+
+  /** neutral ambient white light (renders pure albedo) */
+  val ambientWhite = SphericalHarmonicsLight(IndexedSeq(Vector(
+    1.0 / lambertKernel(0) / SphericalHarmonics.N0,
+    1.0 / lambertKernel(0) / SphericalHarmonics.N0,
+    1.0 / lambertKernel(0) / SphericalHarmonics.N0
+  )))
+
+  /** default frontal illumination */
+  val frontal: SphericalHarmonicsLight = fromAmbientDiffuse(RGB(0.8), RGB(0.2), Vector3D.unitZ)
+
+  /** construct from directional light source with diffuse reflectance */
+  def fromAmbientDiffuse(ambient: RGB, diffuse: RGB, direction: Vector[_3D]): SphericalHarmonicsLight = {
+    val n0 = SphericalHarmonics.N0
+    val n1 = SphericalHarmonics.N1
+
+    val dir: Vector[_3D] = direction.normalize
+    val amb = Vector(ambient.r, ambient.g, ambient.b)
+    val diff = Vector(diffuse.r, diffuse.g, diffuse.b)
+
+    SphericalHarmonicsLight(IndexedSeq(
+      (1f / n0 / lambertKernel(0)) *: amb,
+      (dir.y / n1 / lambertKernel(1)) *: diff,
+      (dir.z / n1 / lambertKernel(2)) *: diff,
+      (dir.x / n1 / lambertKernel(3)) *: diff
+    ))
+  }
+
+  /** Finds the principal light direction in the spherical harmonics with respect to light intensity.
+    * lightIntensity(n) = \sum_{i=0} Y_i(n) * lambertKernel_i * ( shl_r(i) + shl_g(i) + shl_b(i) ) */
+  def directionFromSHLightIntensity(shl: SphericalHarmonicsLight): Option[Vector[_3D]] = {
+    if (shl.coefficients.length >= 4) {
+      //Need shl with first band for a directional part
+      val c1 = shl.coefficients(1).x + shl.coefficients(1).y + shl.coefficients(1).z
+      val c2 = shl.coefficients(2).x + shl.coefficients(2).y + shl.coefficients(2).z
+      val c3 = shl.coefficients(3).x + shl.coefficients(3).y + shl.coefficients(3).z
+      val y = c1 * SphericalHarmonics.N1 / SphericalHarmonicsLight.lambertKernel(1)
+      val z = c2 * SphericalHarmonics.N1 / SphericalHarmonicsLight.lambertKernel(2)
+      val x = c3 * SphericalHarmonics.N1 / SphericalHarmonicsLight.lambertKernel(3)
+      val v = Vector(x, y, z)
+      val len = v.norm //directedness
+      val eps = 1e-12
+      if(len > eps)
+        Some(v.normalize)
+      else
+        None
+    }else{
+      None
+    }
+  }
+
+  /** number of coefficients in n bands */
+  def coefficientsInBands(n: Int): Int = SphericalHarmonics.totalCoefficients(n)
+
+  /** empty coefficients vector */
+  val empty = SphericalHarmonicsLight(IndexedSeq.empty[Vector[_3D]])
+
+  /** empty coefficients vector */
+  def zero(numberOfBands: Int) = SphericalHarmonicsLight(IndexedSeq.fill(SphericalHarmonics.totalCoefficients(numberOfBands))(Vector3D.zero))
+}

--- a/src/main/scala/scalismo/faces/parameters/ImageSize.scala
+++ b/src/main/scala/scalismo/faces/parameters/ImageSize.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import scalismo.faces.color.RGBA
+import scalismo.faces.image.PixelImageDomain
+import scalismo.faces.render.{RenderBuffer, WindowTransform, ZBuffer}
+
+/** parameters of the image size */
+case class ImageSize(width: Int, height: Int) {
+  val domain = PixelImageDomain(width, height)
+
+  def aspectRatio: Double = width.toDouble / height
+
+  /** create an empty ZBuffer for rendering */
+  def zBuffer(bgColor: RGBA): RenderBuffer[RGBA] = ZBuffer[RGBA](width, height, bgColor)
+
+  def screenTransform = WindowTransform(width, height)
+
+  /** scale the image size, keeps aspect ratio */
+  def scaleImage(scale: Double): ImageSize = copy(
+    width = (width * scale).toInt,
+    height = (height * scale).toInt
+  )
+}
+

--- a/src/main/scala/scalismo/faces/parameters/ParametricRenderer.scala
+++ b/src/main/scala/scalismo/faces/parameters/ParametricRenderer.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import scalismo.faces.color.RGBA
+import scalismo.faces.image.PixelImage
+import scalismo.faces.mesh.{ColorNormalMesh3D, VertexColorMesh3D}
+import scalismo.faces.render.{TriangleFilters, TriangleRenderer, ZBuffer}
+import scalismo.mesh.{MeshSurfaceProperty, TriangleMesh3D}
+
+import scala.reflect.ClassTag
+
+object ParametricRenderer {
+  /**
+    * render a mesh with specified colors and normals according to scene description parameter
+    *
+    * @param parameter scene description
+    * @param mesh mesh to render, has positions, colors and normals
+    * @param clearColor background color of buffer
+    * @return
+    */
+  def renderParameterMesh(parameter: RenderParameter,
+                          mesh: ColorNormalMesh3D,
+                          clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+    val buffer = ZBuffer(parameter.imageSize.width, parameter.imageSize.height, clearColor)
+
+    val worldMesh = mesh.transform(parameter.modelViewTransform)
+    val backfaceCullingFilter = TriangleFilters.backfaceCullingFilter(worldMesh.shape, parameter.view.eyePosition)
+
+    TriangleRenderer.renderMesh(
+      mesh.shape,
+      backfaceCullingFilter,
+      parameter.pointShader,
+      parameter.imageSize.screenTransform,
+      parameter.pixelShader(mesh),
+      buffer).toImage
+  }
+
+  /**
+    * render according to parameters, convenience for vertex color mesh with vertex normals
+    *
+    * @param parameter scene description
+    * @param mesh mesh to render, vertex color, vertex normals
+    * @param clearColor background color of buffer
+    * @return
+    */
+  def renderParameterVertexColorMesh(parameter: RenderParameter,
+                                     mesh: VertexColorMesh3D,
+                                     clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+    renderParameterMesh(parameter, ColorNormalMesh3D(mesh), clearColor)
+  }
+
+  /**
+    * render the object described by the render parameters
+    *
+    * @param parameter scene description, including the object
+    * @param clearColor background color of scene/buffer
+    * @return
+    */
+  def renderParameter(parameter: RenderParameter,
+                      clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+    val mesh = RenderObject.instance(parameter.momo)
+    renderParameterMesh(parameter, mesh, clearColor)
+  }
+
+  /**
+    * render an arbitrary property on the mesh into buffer (rasterization)
+    *
+    * @param renderParameter scene description
+    * @param mesh mesh to render, positions
+    * @param property surface property to rasterize
+    * @tparam A type of surface property
+    * @return
+    */
+  def renderPropertyImage[A: ClassTag](renderParameter: RenderParameter,
+                                       mesh: TriangleMesh3D,
+                                       property: MeshSurfaceProperty[A]): PixelImage[Option[A]] = {
+    TriangleRenderer.renderPropertyImage(mesh,
+      renderParameter.pointShader,
+      property,
+      renderParameter.imageSize.width,
+      renderParameter.imageSize.height
+    )
+  }
+}

--- a/src/main/scala/scalismo/faces/parameters/Pose.scala
+++ b/src/main/scala/scalismo/faces/parameters/Pose.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import scalismo.faces.render._
+import scalismo.geometry.{Vector, _3D}
+
+/** face pose parameters */
+case class Pose(scaling: Double,
+                translation: Vector[_3D],
+                roll: Double,
+                yaw: Double,
+                pitch: Double) {
+
+  /** change scaling */
+  def withScaling(scaling: Double): Pose = copy(scaling = scaling)
+
+  /** change translation */
+  def withTranslation(translation: Vector[_3D]): Pose = copy(translation = translation)
+
+  /** change roll angle */
+  def withRoll(roll: Double): Pose = copy(roll = roll)
+
+  /** change yaw angle */
+  def withYaw(yaw: Double): Pose = copy(yaw = yaw)
+
+  /** change pitch angle */
+  def withPitch(pitch: Double): Pose = copy(pitch = pitch)
+
+  /** reset scaling */
+  def noScaling: Pose = copy(scaling = 1.0)
+
+  /** transform: usually the model transform known from computer graphics which transforms the object to world coordinates */
+  def transform: Affine3D = RenderTransforms.modelTransform(translation, scaling, pitch, yaw, roll)
+
+  def rotation: Rotation3D = Rotation3D.fromEulerXYZ(pitch, yaw, roll)
+
+  def compose(inner: Pose): Pose = {
+    val scComp = scaling * inner.scaling
+
+    val rot: Rotation3D = Rotation3D.fromEulerXYZ(pitch, yaw, roll)
+    val (scPitch, scYaw, scRoll) = Rotation3D.decomposeRotationXYZ(
+      rot compose Rotation3D.fromEulerXYZ(inner.pitch, inner.yaw, inner.roll))
+
+    val tComp = translation + rot(scaling *: inner.translation)
+
+    Pose(
+      scaling = scComp,
+      translation = tComp,
+      roll = scRoll,
+      yaw = scYaw,
+      pitch = scPitch
+    )
+  }
+}
+
+object Pose {
+  val neutral = Pose(1.0, Vector(0.0, 0.0, 0.0), 0.0, 0.0, 0.0)
+  val away1m = Pose(1.0, Vector(0.0, 0.0, -1000.0), 0.0, 0.0, 0.0)
+
+  def fromTransform3D(t: Transform3D): Option[Pose] = {
+    t match {
+      case r: Rotation3D =>
+        val (pitch, yaw, roll) = Rotation3D.decomposeRotationXYZ(r)
+        Some(Pose.neutral.copy(pitch = pitch, yaw = yaw, roll = roll))
+      case t: Translation3D =>
+        Some(Pose.neutral.copy(translation = t.t))
+      case Scaling3D(sx, sy, sz) if sx == sy && sx == sz =>
+        Some(Pose.neutral.copy(scaling = sx))
+      case _ => None
+    }
+  }
+}

--- a/src/main/scala/scalismo/faces/parameters/RenderObject.scala
+++ b/src/main/scala/scalismo/faces/parameters/RenderObject.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import java.io.File
+import java.net.URI
+import java.util.Map.Entry
+
+import scalismo.faces.io.MoMoIO
+import scalismo.faces.io.msh.MSHMeshIO
+import scalismo.faces.mesh.{ColorNormalMesh3D, VertexColorMesh3D}
+import scalismo.faces.momo.{MoMo, MoMoCoefficients}
+
+import scala.util.Try
+
+/** parametric description of a renderable object */
+sealed trait RenderObject
+
+
+object RenderObject {
+  object MeshCache {
+    /** cache to hold open models, identified by their URL */
+    private val cacheSizeHint = 10
+    private val openMeshes = new java.util.LinkedHashMap[URI, Object](cacheSizeHint, 0.75f, false) {
+      override def removeEldestEntry(eldest: Entry[URI, Object]): Boolean = size() > cacheSizeHint
+    }
+
+    /**
+      * clears all cached meshes
+      * */
+    def clearURICache(): Unit = openMeshes.synchronized( openMeshes.clear() )
+
+    /**
+      * load a mesh from an URI (cached)
+      *
+      * @param uri URI of model to open, must be a file currently
+      * @return
+      */
+    def loadMesh(uri: URI): Try[ColorNormalMesh3D] = Try {
+      // look in cache
+      val meshLookUp: Option[(ColorNormalMesh3D, Long)] =
+        openMeshes.synchronized {
+          val meshObj: Option[Object] = Option(openMeshes.get(uri))
+          meshObj.map{obj => obj.asInstanceOf[(ColorNormalMesh3D, Long)]}
+        }.flatMap{ (stampedMesh: (ColorNormalMesh3D, Long)) =>
+          if (timestamp(uri) <= stampedMesh._2)
+            Some(stampedMesh)
+          else
+            None
+        }
+
+      // open if necessary
+      meshLookUp.map{_._1}.getOrElse {
+        val mesh = forceLoad(uri).get
+        openMeshes.synchronized {
+          openMeshes.put(uri, mesh)
+        }
+        mesh._1
+      }
+    }
+
+    private def timestamp(uri: URI): Long = new File(uri).lastModified()
+
+    private def forceLoad(uri: URI): Try[(ColorNormalMesh3D, Long)] = Try {
+      val file = new File(uri)
+      (MSHMeshIO.read(file).get.colorNormalMesh.get, timestamp(uri))
+    }
+
+  }
+
+  def instance(renderObject: RenderObject): ColorNormalMesh3D = {
+    renderObject match {
+      case MeshFile(meshURI) =>
+        MeshCache.loadMesh(meshURI).get
+      case momo: MoMoInstance =>
+        val model = MoMoIO.read(momo.modelURI).get
+        val m = model.instance(momo.coefficients)
+        ColorNormalMesh3D(m.shape, m.color, m.shape.vertexNormals)
+      case MeshColorNormals(mesh) => mesh
+      case MeshVertexColor(mesh) => ColorNormalMesh3D(mesh)
+    }
+  }
+}
+
+/** parameters of a Morphable Model instance, consists of shape and color */
+case class MoMoInstance(shape: IndexedSeq[Double],
+                        color: IndexedSeq[Double],
+                        expression: IndexedSeq[Double],
+                        modelURI: URI) extends RenderObject {
+
+  /** coefficients as MoMoCoefficients, compatible with MoMo class */
+  def coefficients = MoMoCoefficients(shape, color, expression)
+
+  /** resize coefficient vectors (fills with 0 or drops) */
+  def withNumberOfCoefficients(nShape: Int, nColor: Int, nExpress: Int): MoMoInstance = {
+    def ensureLength(seq: IndexedSeq[Double], n: Int): IndexedSeq[Double] = {
+      if (seq.length > n) seq.slice(0, n)
+      else if (seq.length < n) seq ++ IndexedSeq.fill(n - seq.length)(0.0)
+      else seq
+    }
+    val newShape = ensureLength(shape, nShape)
+    val newColor = ensureLength(color, nColor)
+    val newExpress = ensureLength(expression, nExpress)
+    copy(shape = newShape, color = newColor, expression = newExpress)
+  }
+}
+
+object MoMoInstance {
+  val empty = MoMoInstance(IndexedSeq.empty[Double], IndexedSeq.empty[Double], IndexedSeq.empty[Double], new URI(""))
+
+  /** create a MoMoInstance from a set of MoMoCoefficients */
+  def fromCoefficients(momoCoefficients: MoMoCoefficients, modelURI: URI): MoMoInstance = {
+    new MoMoInstance(
+      momoCoefficients.shape.toArray,
+      momoCoefficients.color.toArray,
+      momoCoefficients.expression.toArray,
+      modelURI)
+  }
+
+  /** create a zero MoMoInstance (usually corresponds to mean) matching a model's rank */
+  def zero(model: MoMo, modelURI: URI): MoMoInstance = fromCoefficients(model.zeroCoefficients, modelURI)
+
+  /** create a zero MoMoInstance (usually corresponds to mean) of specified size */
+  def zero(shapeComponents: Int,
+           colorComponents: Int,
+           expressionComponents: Int,
+           modelURI: URI): MoMoInstance = {
+    fromCoefficients(MoMoCoefficients.zeros(shapeComponents, colorComponents, expressionComponents), modelURI)
+  }
+}
+
+/** mesh file reference to render */
+case class MeshFile(meshURI: URI) extends RenderObject
+
+/** direct mesh to render with vertex color */
+case class MeshColorNormals(colorNormalMesh: ColorNormalMesh3D) extends RenderObject
+
+/** direct mesh to render with vertex color */
+case class MeshVertexColor(vertexColorMesh3D: VertexColorMesh3D) extends RenderObject

--- a/src/main/scala/scalismo/faces/parameters/RenderParameter.scala
+++ b/src/main/scala/scalismo/faces/parameters/RenderParameter.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import scalismo.faces.color.RGBA
+import scalismo.faces.mesh.{ColorNormalMesh3D, VertexColorMesh3D}
+import scalismo.faces.render.{Affine3D, PixelShader, PointShader}
+import scalismo.geometry.{Point, Point2D, Vector, _3D}
+
+/** main parameter to describe a 3D scene setup with a face for rendering and fitting */
+case class RenderParameter(pose: Pose,
+                           view: ViewParameter,
+                           camera: Camera,
+                           environmentMap: SphericalHarmonicsLight,
+                           directionalLight: DirectionalLight,
+                           momo: MoMoInstance,
+                           imageSize: ImageSize,
+                           colorTransform: ColorTransform) {
+
+  /** change illumination to specified illumination */
+  def withDirectionalLight(light: DirectionalLight): RenderParameter = copy(directionalLight = light)
+
+  /** change illumination to specified illumination */
+  def withEnvironmentMap(light: SphericalHarmonicsLight): RenderParameter = copy(environmentMap = light)
+
+  /** change the face object */
+  def withMoMo(momo: MoMoInstance): RenderParameter = copy(momo = momo)
+
+  /** change the camera setting */
+  def withCamera(camera: Camera): RenderParameter = copy(camera = camera)
+
+  /** change the pose */
+  def withPose(pose: Pose): RenderParameter = copy(pose = pose)
+
+  /** change the viewing setup */
+  def withView(view: ViewParameter): RenderParameter = copy(view = view)
+
+  /** change image size (without rescaling anything!! - also refer to forImage*) */
+  def withImageSize(imageSize: ImageSize): RenderParameter = copy(imageSize = imageSize)
+
+  /** change the color transform */
+  def withColorTransform(colorTransform: ColorTransform): RenderParameter = copy(colorTransform = colorTransform)
+
+  /** remove directional light */
+  def noDirectionalLight: RenderParameter = copy(directionalLight = DirectionalLight.off)
+
+  /** remove spherical harmonics illumination */
+  def noEnvironmentMap: RenderParameter = copy(environmentMap = SphericalHarmonicsLight.empty)
+
+  /** disable color transform */
+  def noColorTransform: RenderParameter = withColorTransform(ColorTransform.neutral)
+
+  /** disable illumination, render pure albedo color */
+  def noLightAndColor: RenderParameter = copy(
+    colorTransform = ColorTransform.neutral,
+    environmentMap = SphericalHarmonicsLight.ambientWhite,
+    directionalLight = DirectionalLight.off
+  )
+
+  /** model and view transforms: pose and camera (transforms from object to eye coordinates) */
+  def modelViewTransform: Affine3D = view.viewTransform compose pose.transform
+
+  /** complete render transform, transforms from object to buffer coordinates (includes y inversion in image) */
+  def renderTransform: Point[_3D] => Point[_3D] = {p => imageSize.screenTransform(pointShader(p))}
+
+  /** complete shader of this scene, includes point and pixel shaders (ParametricShader) */
+  def pixelShader(mesh: ColorNormalMesh3D): PixelShader[RGBA] = {
+    val worldMesh = mesh.transform(pose.transform)
+    val ctRGB = colorTransform.transform
+    val ct = (c: RGBA) => ctRGB(c.toRGB).toRGBA
+    // default: both illumination sources active
+    (environmentMap.shader(worldMesh, view.eyePosition) + directionalLight.shader(worldMesh, view.eyePosition)).map(ct)
+    // old compatibility
+    if (environmentMap.nonEmpty)
+      environmentMap.shader(worldMesh, view.eyePosition).map(ct)
+    else
+      directionalLight.shader(worldMesh, view.eyePosition).map(ct)
+  }
+
+  /** complete shader of this scene for a vertex color mesh with vertex normals, includes point and pixel shaders (ParametricShader) */
+  def pixelShader(mesh: VertexColorMesh3D): PixelShader[RGBA] = pixelShader(ColorNormalMesh3D(mesh))
+
+  /** point shader: transform from object to canonical viewing volume/NDC */
+  def pointShader: PointShader = camera.projection.pointShader(modelViewTransform)
+
+  /** change rendering output - corresponds to a restricted or enlarged view, does not change size of head */
+  def forImageSize(width: Int, height: Int): RenderParameter = {
+    val sw = width.toDouble / imageSize.width
+    val sh = height.toDouble / imageSize.height
+    copy(
+      imageSize = ImageSize(width, height),
+      camera = camera.copy(sensorSize = Vector(camera.sensorSize.x * sw, camera.sensorSize.y * sh))
+    )
+  }
+
+  /** adapt the target image size, rescales output, keeps aspect ratio of original face */
+  def fitToImageSize(width: Int, height: Int): RenderParameter = {
+    val sw = width.toDouble / imageSize.width
+    val sh = height.toDouble / imageSize.height
+    // find maximal scaling (to fit both sides into the new image)
+    val isoScale = math.min(sw, sh)
+    // additional scale necessary to adapt to new pixel ratio, extend view
+    copy(imageSize = imageSize.scaleImage(isoScale)).forImageSize(width, height)
+  }
+}
+
+object RenderParameter {
+  /** default setting, corresponds to a full format (35mm, aspect 3/2) DSL camera with 50mm lens, object distance 1m */
+  val default: RenderParameter = RenderParameter(
+    pose = Pose.away1m,
+    view = ViewParameter.neutral,
+    camera = Camera.for35mmFilm(50.0),
+    environmentMap = SphericalHarmonicsLight.frontal.withNumberOfBands(2),
+    directionalLight = DirectionalLight.off,
+    momo = MoMoInstance.empty,
+    imageSize = ImageSize(720, 480),
+    colorTransform = ColorTransform.neutral)
+
+  /** old square rendering default, 1m distance */
+  val defaultSquare = RenderParameter(
+    pose = Pose.away1m,
+    view = ViewParameter.neutral,
+    camera = Camera(
+      focalLength = 7.5,
+      principalPoint = Point2D.origin,
+      sensorSize = Vector(2.0, 2.0),
+      near = 10,
+      far = 1000e3,
+      orthographic = false),
+    environmentMap = SphericalHarmonicsLight.frontal.withNumberOfBands(2),
+    directionalLight = DirectionalLight.off,
+    momo = MoMoInstance.empty,
+    imageSize = ImageSize(512, 512),
+    colorTransform = ColorTransform.neutral)
+}
+
+
+
+

--- a/src/main/scala/scalismo/faces/parameters/SceneParameter.scala
+++ b/src/main/scala/scalismo/faces/parameters/SceneParameter.scala
@@ -1,0 +1,198 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import scalismo.faces.color.RGBA
+import scalismo.faces.image.PixelImage
+import scalismo.geometry._
+import scalismo.mesh._
+import scalismo.faces.mesh._
+import scalismo.faces.render._
+
+/**
+  * structure to represent a scene tree with pose nodes and render objects
+  */
+sealed trait SceneTree extends Traversable[SceneTree] {
+  /**
+    * get all properly transformed meshes in the scene
+    *
+    * @return
+    */
+  def worldMeshes: IndexedSeq[ColorNormalMesh3D] = {
+    val objects: IndexedSeq[(Transform3D, RenderObject)] = posedObjects
+    objects.map{case(pose, renderObject) => RenderObject.instance(renderObject).transform(pose)}
+  }
+
+  /**
+    * flatten the tree (recursive), collect all render objects with their model-to-world transformation
+    *
+    * @return
+    */
+  def posedObjects: IndexedSeq[(Transform3D, RenderObject)] = {
+    // recursive scene traversal
+    def treeWalker(node: SceneTree, trafo: Transform3D): IndexedSeq[(Transform3D, RenderObject)] = {
+      node match {
+        case pn: PoseNode =>
+          pn.children.flatMap{child => treeWalker(child, pn.pose.transform compose trafo)}
+        case so: SceneObject => IndexedSeq((trafo, so.renderObject))
+      }
+    }
+    // start traversal here at root
+    treeWalker(this, Pose.neutral.transform)
+  }
+
+  /**
+    * recursive tree walker for Traversable
+    *
+    * @param f function to execute for each node of the tree
+    */
+  override def foreach[U](f: (SceneTree) => U): Unit = this match {
+    case pn: PoseNode =>
+      f(pn)
+      pn.children.foreach{f}
+    case so: SceneObject =>
+      f(so)
+  }
+}
+
+case class PoseNode(pose: Pose, children: IndexedSeq[SceneTree]) extends SceneTree
+
+case class SceneObject(renderObject: RenderObject) extends SceneTree
+
+//case class SceneTree(renderObject: RenderObject, pose: Pose, children: IndexedSeq[SceneTree])
+
+case class SceneParameter(view: ViewParameter,
+                          camera: Camera,
+                          illuminations: IndexedSeq[Illumination],
+                          sceneTree: SceneTree,
+                          imageSize: ImageSize,
+                          colorTransform: ColorTransform) {
+
+  /**
+    * render a scene according to the scene parameter description
+    *
+    * @param buffer buffer to render into (mutated/updated! through RenderBuffer interface)
+    * @return render buffer with rendered scene
+    */
+  def renderSceneToBuffer(buffer: RenderBuffer[RGBA]): RenderBuffer[RGBA] = {
+    // color transform (nasty rgb/rgba conversion)
+    val ct = colorTransform.transform
+    val colT: RGBA => RGBA = (col: RGBA) => ct(col.toRGB).toRGBA
+
+    // pixel shader for given illumination setting
+    def makePixelShader(mesh: ColorNormalMesh3D): PixelShader[RGBA] = {
+      val shaders = illuminations.map {
+        case dl: DirectionalLight => dl.shader(mesh, view.eyePosition)
+        case shl: SphericalHarmonicsLight => shl.shader(mesh)
+        case ill => throw new Exception(s"Uknown illumination: $ill")
+      }
+      shaders.reduce {_ + _}.map(colT)
+    }
+
+    // triangle filters for a mesh, back face culling
+    def makeFilters(mesh: TriangleMesh[_3D]): TriangleId => Boolean = {
+      val culling = TriangleFilters.backfaceCullingFilter(mesh, view.eyePosition)
+      culling
+    }
+
+    // transform meshes to world space
+    val worldMeshes = sceneTree.posedObjects.map{case(t, renderObject) =>
+      RenderObject.instance(renderObject).transform(t)
+    }
+
+    // point shader: view and projection (model is handled explicitly)
+    val viewProjection = camera.projection.pointShader(view.viewTransform)
+
+    // screen transform / window transform
+    val screenTransform = WindowTransform(imageSize.width, imageSize.height)
+
+    // setup triangle filters: backface culling and outside clipping
+    val culling = TriangleFilters
+
+    // render all to buffer
+    worldMeshes.foreach { mesh =>
+      val triangleFilters = makeFilters(mesh.shape)
+      val pixelShader = makePixelShader(mesh)
+      TriangleRenderer.renderMesh(mesh.shape, triangleFilters, viewProjection, screenTransform, pixelShader, buffer)
+    }
+
+    // done, return filled buffer
+    buffer
+  }
+
+  /**
+    * render a scene according to the scene parameter description
+    *
+    * @return render buffer with rendered scene
+    */
+  def renderSceneToBuffer: RenderBuffer[RGBA] = {
+    val buffer = ZBuffer[RGBA](imageSize.width, imageSize.height, RGBA.BlackTransparent)
+    renderSceneToBuffer(buffer)
+  }
+
+  /**
+    * render a scene according to the scene parameter description, produces an image
+    *
+    * @return rendered image of the scene
+    */
+  def renderScene(clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+    val buffer = ZBuffer[RGBA](imageSize.width, imageSize.height, clearColor)
+    renderSceneToBuffer(buffer).toImage
+  }
+
+
+  /**
+    * convert to a RenderParameter, only works for a single object with single illumination
+    *
+    * @return RenderParameter describing this simple scene
+    */
+  def toRenderParameter: Option[RenderParameter] = {
+    for {
+      light <- illuminations match {
+        case IndexedSeq(envMap: SphericalHarmonicsLight, dirLight: DirectionalLight) => Some((envMap, dirLight))
+        case _ => None
+      }
+      (pose, face) <- sceneTree match {
+        case PoseNode(pose, IndexedSeq(SceneObject(face: MoMoInstance))) => Some((pose, face))
+        case _ => None
+      }
+    } yield
+      RenderParameter(
+        pose = pose,
+        view = view,
+        camera = camera,
+        environmentMap = light._1,
+        directionalLight = light._2,
+        momo = face,
+        imageSize = imageSize,
+        colorTransform = colorTransform)
+  }
+}
+
+/**
+  * Renderer for scene descriptions
+  */
+object SceneParameter {
+
+  def apply(renderParameter: RenderParameter): SceneParameter = SceneParameter(
+    view = renderParameter.view,
+    camera = renderParameter.camera,
+    illuminations = IndexedSeq(renderParameter.environmentMap, renderParameter.directionalLight),
+    sceneTree = PoseNode(renderParameter.pose, IndexedSeq(SceneObject(renderParameter.momo))),
+    imageSize = renderParameter.imageSize,
+    colorTransform = renderParameter.colorTransform)
+}

--- a/src/main/scala/scalismo/faces/parameters/ViewParameter.scala
+++ b/src/main/scala/scalismo/faces/parameters/ViewParameter.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import scalismo.faces.render.{Affine3D, RenderTransforms}
+import scalismo.geometry.{Point, Point3D, Vector, _3D}
+
+/** parameters describing the view setup (camera transform) */
+case class ViewParameter(translation: Vector[_3D],
+                         pitch: Double,
+                         yaw: Double,
+                         roll: Double) {
+
+  /** model transform: object to world coordinates */
+  def viewTransform: Affine3D = RenderTransforms.viewTransform(translation, pitch = pitch, yaw = yaw, roll = roll)
+
+  /** camera origin in world coordinate system */
+  def eyePosition: Point[_3D] = Point3D.origin + translation
+
+  /** camera pose in the world */
+  def cameraPose = Pose(1.0, translation = translation, pitch = pitch, yaw = yaw, roll = roll)
+}
+
+object ViewParameter {
+  val neutral = ViewParameter(Vector(0f, 0f, 0f), 0f, 0f, 0f)
+  val away1m = ViewParameter(Vector(0f, 0f, 1000f), 0f, 0f, 0f)
+
+  def fromPose(pose: Pose): ViewParameter = ViewParameter(pose.translation, pitch = pose.pitch, yaw = pose.yaw, roll = pose.roll)
+}

--- a/src/main/scala/scalismo/faces/render/Affine3D.scala
+++ b/src/main/scala/scalismo/faces/render/Affine3D.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import breeze.linalg.DenseMatrix
+import scalismo.geometry.{Point, SquareMatrix, Vector, _3D}
+
+/** affine transform in 3D */
+case class Affine3D(A: SquareMatrix[_3D], b: Vector[_3D]) extends InvertibleTransform3D with Transform4x4 {
+  /** inverted version of this transform */
+  override def inverted: Affine3D = {
+    val Ainv = SquareMatrix.inv(A)
+    Affine3D(Ainv, Affine3D.mult(Ainv, -b))
+  }
+
+  /** apply transform to a 3d point */
+  override def apply(x: Point[_3D]): Point[_3D] = (Affine3D.mult(A, x.toVector) + b).toPoint
+
+  /** apply transform to a 3d vector */
+  override def apply(v: Vector[_3D]): Vector[_3D] = Affine3D.mult(A, v)
+
+  override def matrix4: DenseMatrix[Double] =
+    DenseMatrix.vertcat(
+      DenseMatrix.horzcat(
+        A.toBreezeMatrix,
+        DenseMatrix(b.x, b.y, b.z)),
+      DenseMatrix((0.0, 0.0, 0.0, 1.0))
+    )
+
+  /** compose with other invertible transform */
+  def compose(other: Affine3D): Affine3D = Affine3D(A * other.A, Affine3D.mult(A, other.b) + b)
+}
+
+object Affine3D {
+  def apply(rotation: Rotation3D): Affine3D = rotation.toAffine3D
+  def apply(translation3D: Translation3D): Affine3D = translation3D.toAffine3D
+  def apply(scaling3D: Scaling3D): Affine3D = scaling3D.toAffine3D
+
+  /** fast matrix multiplication for 3D (scalismo generic is not optimal) */
+  @inline
+  private def mult(m: SquareMatrix[_3D], v: Vector[_3D]): Vector[_3D] = {
+    Vector(
+      m(0, 0) * v.x + m(0, 1) * v.y + m(0, 2) * v.z,
+      m(1, 0) * v.x + m(1, 1) * v.y + m(1, 2) * v.z,
+      m(2, 0) * v.x + m(2, 1) * v.y + m(2, 2) * v.z)
+  }
+}

--- a/src/main/scala/scalismo/faces/render/BRDF.scala
+++ b/src/main/scala/scalismo/faces/render/BRDF.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.geometry.{Vector, _3D}
+
+/** a bidirectional reflectance distribution function to describe reflectance models */
+trait BRDF[A] {
+  def apply(lightDirection: Vector[_3D], viewDirection: Vector[_3D]): A
+}

--- a/src/main/scala/scalismo/faces/render/ColorTransform.scala
+++ b/src/main/scala/scalismo/faces/render/ColorTransform.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import breeze.linalg.{DenseMatrix, DenseVector, inv}
+import scalismo.faces.color.RGB
+import scalismo.geometry.{SquareMatrix, _3D}
+
+/** color transform: map color values */
+trait ColorTransform extends (RGB => RGB)
+
+/** General color transform, affine with matrix and shift */
+case class AffineColorTransform(A: SquareMatrix[_3D], b: RGB) extends ColorTransform {
+  def apply(c: RGB): RGB = RGB(A * c.toVector[_3D]) + b
+  def invert: AffineColorTransform = {
+    val Ainv = SquareMatrix.inv(A)
+    AffineColorTransform(Ainv, RGB(Ainv * (-b.toVector[_3D])))
+  }
+}
+
+/** Color transform to adapt white point and black point (gain and offset) */
+case class WhiteAndBlackPointColorTransform(white: RGB, black: RGB) extends ColorTransform {
+  override def apply(color: RGB): RGB = white x color + black
+  def invert: WhiteAndBlackPointColorTransform = {
+    val Winv = RGB(1f / white.r, 1f / white.g, 1f / white.b)
+    WhiteAndBlackPointColorTransform(Winv, Winv x black * (-1f))
+  }
+}
+
+/** Color transform which adapts the white point (through scaling, "gain"), the color contrast (mixing with gray) and the black point (offset) */
+case class ColorTransformWithColorContrast(gain: RGB, colorContrast: Double, offset: RGB) extends ColorTransform { self =>
+  def apply(color: RGB): RGB = {
+    val colorMixed = color * colorContrast + RGB(color.luminance * (1 - colorContrast))
+    RGB(
+      gain.r * colorMixed.r + offset.r,
+      gain.g * colorMixed.g + offset.g,
+      gain.b * colorMixed.b + offset.b
+    )
+  }
+
+  /** get the inverse transform, note: only exists if colorConstrast != 0 */
+  def invert: ColorTransform = new ColorTransform {
+    private val c = colorContrast
+    private val A = DenseMatrix(
+      (c * (1 - 0.3) + 0.3, 0.59 - 0.59 * c, 0.11 - 0.11 * c),
+      (0.3 - 0.3 * c, c * (1 - 0.59) + 0.59, 0.11 - 0.11 * c),
+      (0.3 - 0.3 * c, 0.59 - 0.59 * c, c * (1 - 0.11) + 0.11))
+
+    private val Ainv = inv(A)
+
+    override def apply(color: RGB): RGB = {
+      val mixed = (color - offset) / gain
+      val b: DenseVector[Double] = Ainv * DenseVector[Double](mixed.r, mixed.g, mixed.b)
+      RGB(b(0), b(1), b(2))
+    }
+
+    def invert: ColorTransformWithColorContrast = self
+  }
+}
+

--- a/src/main/scala/scalismo/faces/render/Frustum.scala
+++ b/src/main/scala/scalismo/faces/render/Frustum.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.geometry.Point._
+import scalismo.geometry.{Point, Vector, _2D}
+
+/** viewing frustum for camera projections, defines the viewing volume, see also: OpenGL */
+case class Frustum(left: Double, right: Double, bottom: Double, top: Double, near: Double, far: Double) {
+  require(left < right, "left is right of right")
+  require(bottom < top, "bottom is above top")
+  require(near < far, "near is further than far")
+
+  /**
+   * get closest orthographic frustum, matches the behaviour at the given z distance, defaults to near plane
+   *
+   * @param z z position of plane with identical transformation behavior (depth, units identical to near and far)
+   */
+  def closestOrthographic(z: Double = near): Frustum = {
+    Frustum(left * z / near, right * z / near, bottom * z / near, top * z / near, near, far)
+  }
+
+  /**
+   * move scene in this frustum through an off-center projection, center point in NDC [-1,1]x[-1,1]
+   *
+   * @param center center position, in NDC [-1, 1]x[-1, 1] (outside is possible)
+   */
+  def withCenter(center: Point[_2D]): Frustum = {
+    val Frustum(l, r, b, t, n, f) = centered
+    Frustum(l * (center.x + 1), r * (1 - center.x), b * (center.y + 1), t * (1 - center.y), n, f)
+  }
+
+  /** center of projection expressed in NDC of the corresponding symmetric frustum */
+  def center = Point((2 * -left / (right - left)) - 1, (2 * -bottom / (top - bottom)) - 1)
+
+  /** center this frustum (symmetrize), balances left/right and top/bottom */
+  def centered: Frustum = {
+    val w = right - left
+    val h = top - bottom
+    Frustum(-w / 2, w / 2, -h / 2, h / 2, near, far)
+  }
+
+  /**
+   * scale this frustum (near plane is not scaled), larger frustum -> smaller image
+   *
+   * @param horizontal horizontal scale factor
+   * @param vertical   vertical scale factor
+   */
+  def scale(horizontal: Double, vertical: Double): Frustum = Frustum(left * horizontal, right * horizontal, bottom * vertical, top * vertical, near, far)
+
+  /**
+   * scale this frustum (near plane is not scaled), larger frustum -> smaller image
+   *
+   * @param f scale factor
+   */
+  def scale(f: Double): Frustum = scale(f, f)
+
+  /** change the near clipping plane, leave the image view scaling unaltered */
+  def withNear(near: Double): Frustum = {
+    require(near < far, "near is farther than far")
+    val f = near / this.near
+    Frustum(left * f, right * f, bottom * f, top * f, near, far)
+  }
+}
+
+object Frustum {
+  import scalismo.geometry.Vector._
+  /**
+   * construct frustum from field of view, both horizontal and vertical
+   *
+   * @param fovX horizontal field of view (radians)
+   * @param fovY vertical field of view (radians)
+   * @param near near plane (absolute value)
+   * @param far  far plane (absolute value)
+   */
+  def fromFOV(fovX: Double, fovY: Double, near: Double, far: Double): Frustum = {
+    require(fovX > 0.0, "field of view must be positive")
+    require(fovY > 0.0, "field of view must be positive")
+    val width = math.abs(near) * math.tan(fovX / 2)
+    val height = math.abs(near) * math.tan(fovY / 2)
+    Frustum(-width / 2, width / 2, -height / 2, height / 2, near, far)
+  }
+
+  /**
+   * construct frustum from vertical field of view and aspect ratio (w/h)
+   *
+   * @param fovY   vertical field of view (radians)
+   * @param aspect aspect ratio: width/height
+   * @param near   near plane (absolute value)
+   * @param far    far plane (absolute value)
+   */
+  def fromVerticalFOV(fovY: Double, aspect: Double, near: Double, far: Double): Frustum = {
+    fromFocal(1.0 / math.tan(fovY / 2), aspect, near, far)
+  }
+
+  /**
+   * construct frustum from focal length and aspect ratio (w/h)
+   *
+   * @param focalLength focal length corresponding to a unit sensor size of 1
+   * @param aspect      aspect ratio: width/height
+   * @param near        near plane (absolute value)
+   * @param far         far plane (absolute value)
+   */
+  def fromFocal(focalLength: Double, aspect: Double, near: Double, far: Double): Frustum = {
+    require(focalLength > 0.0, "focal length must be strictly positive")
+    require(aspect > 0.0, "aspect must be positive")
+    val height = math.abs(near) / focalLength
+    val width = aspect * height
+    Frustum(-width / 2, width / 2, -height / 2, height / 2, near, far)
+  }
+
+  /**
+   * construct frustum from focal length and sensor size
+   *
+   * @param focalLength focal length of lens
+   * @param sensorSize  sensor size, same units as focalLength, usually mm
+   * @param near        near plane (absolute value)
+   * @param far         far plane (absolute value)
+   */
+  def fromFocalWithSensor(focalLength: Double, sensorSize: Vector[_2D], near: Double, far: Double): Frustum = {
+    require(sensorSize.x > 0.0 && sensorSize.y > 0.0, "sensor size must be positive")
+    fromFocal(focalLength / sensorSize.y, sensorSize.x / sensorSize.y, near, far)
+  }
+
+  /** construct frustum from a given height and aspect (w/h) */
+  def fromHeight(height: Double, aspect: Double, near: Double, far: Double): Frustum = {
+    require(height > 0.0, "height must be positive")
+    require(aspect > 0.0, "aspect must be positive")
+    val width = height * aspect
+    Frustum(-width / 2, width / 2, -height / 2, height / 2, near, far)
+  }
+}

--- a/src/main/scala/scalismo/faces/render/FrustumProjection.scala
+++ b/src/main/scala/scalismo/faces/render/FrustumProjection.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import breeze.linalg.DenseMatrix
+import scalismo.geometry.{Point, _3D}
+import scalismo.mesh.BarycentricCoordinates
+
+/** geometric projection to create an image of a 3D scene */
+trait Projection {
+  /** apply the projection, returns normalized device coordinates [-1,1]x[-1,1]x[-1,1] */
+  def apply(p: Point[_3D]): Point[_3D]
+
+  def pointShader(modelView: Transform3D): PointShader
+
+  /** viewing ray starting from given point in NDC */
+  def ray(x: Double, y: Double): (Double => Point[_3D]) = z => inverse(Point(x, y, z))
+
+  /** inverse projection into eye space */
+  def inverse(point: Point[_3D]): Point[_3D]
+}
+
+/** projection described by a frustum */
+trait FrustumProjection extends Projection {
+  def frustum: Frustum
+}
+
+/** project a scene onto the image plane: perspective */
+case class FrustumPinholeProjection(override val frustum: Frustum) extends FrustumProjection with Transform4x4 {
+  self =>
+
+  private val Frustum(l, r, b, t, n, f) = frustum
+
+  /** apply transform to a 3d point */
+  override def apply(p: Point[_3D]): Point[_3D] = {
+    val d = -p.z
+    Point(
+      (p.x * 2 * n / (r - l) + (r + l) / (r - l) * p.z) / d,
+      (p.y * 2 * n / (t - b) + (t + b) / (t - b) * p.z) / d,
+      (-(f + n) / (f - n) * p.z - 2 * f * n / (f - n)) / d)
+  }
+
+  override val matrix4: DenseMatrix[Double] = DenseMatrix(
+    (2 * n / (r - l), 0.0, (r + l) / (r - l), 0.0),
+    (0.0, 2 * n / (t - b), (t + b) / (t - b), 0.0),
+    (0.0, 0.0, -(f + n) / (f - n), -2 * f * n / (f - n)),
+    (0.0, 0.0, -1.0, 0.0)
+  )
+
+  /** create a point shader with a given model view transform and this projection, does correct BCC appropriately */
+  override def pointShader(modelView: Transform3D): PointShader = {
+    // create a po
+    new PointShader {
+      def invZ(p: Point[_3D]): Double = 1.0 / ((p.z - (f + n) / (f - n)) * (f - n) / (2 * f * n))
+
+      override def apply(p: Point[_3D]): Point[_3D] = self(modelView(p))
+
+      override def bccScreenToWorld(screenBCC: BarycentricCoordinates, a: Point[_3D], b: Point[_3D], c: Point[_3D]): BarycentricCoordinates = {
+        FrustumPinholeProjection.bccScreenToWorldCorrection(screenBCC, invZ(a), invZ(b), invZ(c))
+      }
+
+      override def bccWorldToScreen(worldBCC: BarycentricCoordinates, a: Point[_3D], b: Point[_3D], c: Point[_3D]): BarycentricCoordinates = {
+        FrustumPinholeProjection.bccWorldToScreenCorrection(worldBCC, invZ(a), invZ(b), invZ(c))
+      }
+    }
+  }
+
+  /** inverse projection into eye space */
+  override def inverse(p: Point[_3D]): Point[_3D] = {
+    val z = 1.0 / ((p.z - (f + n) / (f - n)) * (f - n) / (2 * f * n))
+    Point(
+      -z * (r - l) / (2 * n) * (p.x + (r + l) / (r - l)),
+      -z * (t - b) / (2 * n) * (p.y + (t + b) / (t - b)),
+      z)
+  }
+}
+
+object FrustumPinholeProjection {
+  def bccScreenToWorldCorrection(bccScreen: BarycentricCoordinates, z1: Double, z2: Double, z3: Double): BarycentricCoordinates = {
+    val d = z2 * z3 + z3 * bccScreen.b * (z1 - z2) + z2 * bccScreen.c * (z1 - z3)
+    if (d == 0.0) {
+      bccScreen
+    } else {
+      val b = z1 * z3 * bccScreen.b / d
+      val c = z1 * z2 * bccScreen.c / d
+      BarycentricCoordinates(1.0 - b - c, b, c) //lambda world
+    }
+  }
+
+  def bccWorldToScreenCorrection(bccWorld: BarycentricCoordinates, z1: Double, z2: Double, z3: Double): BarycentricCoordinates = {
+    val d = z1 - (z1 - z2) * bccWorld.b - (z1 - z3) * bccWorld.c
+    if (d == 0.0)
+      bccWorld
+    else {
+      val c = bccWorld.c * z3 / d
+      val b = bccWorld.b * z2 / d
+      BarycentricCoordinates(1.0 - b - c, b, c)
+    }
+  }
+}
+
+/** project a scene onto the image plane: orthographic */
+case class FrustumOrthographicProjection(override val frustum: Frustum) extends FrustumProjection with Transform4x4 {
+  self =>
+
+  private val Frustum(l, r, b, t, n, f) = frustum
+
+  /** apply transform to a 3d point */
+  override def apply(p: Point[_3D]): Point[_3D] = Point(
+    p.x * 2 / (r - l) - (r + l) / (r - l),
+    p.y * 2 / (t - b) - (t + b) / (t - b),
+    -2 / (f - n) * p.z - (f + n) / (f - n))
+
+  override val matrix4: DenseMatrix[Double] = DenseMatrix(
+    (2 / (r - l), 0.0, 0.0, -(r + l) / (r - l)),
+    (0.0, 2 / (t - b), 0.0, -(t + b) / (t - b)),
+    (0.0, 0.0, -2 / (f - n), -(f + n) / (f - n)),
+    (0.0, 0.0, 0.0, 1.0)
+  )
+
+  /** inverse projection into eye space */
+  override def inverse(p: Point[_3D]): Point[_3D] = Point(
+    (r - l) / 2 * (p.x + (r + l) / (r - l)),
+    (t - b) / 2 * (p.y + (t + b) / (t - b)),
+    (f - n) / 2 * (-p.z - (f + n) / (f - n))
+  )
+
+  override def pointShader(modelView: Transform3D) = new PointShader {
+    override def apply(p: Point[_3D]): Point[_3D] = self(modelView(p))
+  }
+}

--- a/src/main/scala/scalismo/faces/render/PixelShaders.scala
+++ b/src/main/scala/scalismo/faces/render/PixelShaders.scala
@@ -1,0 +1,350 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.faces.color.{RGB, RGBA}
+import scalismo.faces.numerics.SphericalHarmonics
+import scalismo.faces.parameters.SphericalHarmonicsLight
+import scalismo.faces.render.TriangleRenderer.TriangleFragment
+import scalismo.geometry._
+import scalismo.mesh.{BarycentricCoordinates, MeshSurfaceProperty, TriangleId, TriangleMesh}
+
+/** collection of common pixel shaders */
+object PixelShaders {
+
+  /** "shade" with a property value, renders property value directly into image */
+  case class PropertyShader[A](property: MeshSurfaceProperty[A]) extends PixelShader[A] {
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): A = {
+      property(triangleId, worldBCC)
+    }
+  }
+
+  /** Lambertian reflectance shader, with additional ambient term */
+  case class LambertShader(albedo: MeshSurfaceProperty[RGBA],
+                           ambientLight: RGB,
+                           diffuseLight: RGB,
+                           lightDirection: Vector[_3D],
+                           normals: MeshSurfaceProperty[Vector[_3D]]) extends PixelShader[RGBA] {
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): RGBA = {
+      val c = albedo(triangleId, worldBCC)
+      val n = normals(triangleId, worldBCC).normalize
+      val diffuseFactor: Double = math.max(n.dot(lightDirection.normalize), 0.0)
+      val diffuse: RGB = diffuseLight * diffuseFactor
+      val combined = ambientLight + diffuse
+      RGBA(c.r * combined.r, c.g * combined.g, c.b * combined.b, c.a) // radiance
+    }
+
+    def invert(reflectance: MeshSurfaceProperty[RGBA]) = InverseDiffuseShader(reflectance, ambientLight, diffuseLight, lightDirection, normals)
+  }
+
+  object LambertShader {
+    /** Lambertian BRDF, constant value */
+    case class LambertBRDF(albedo: RGB) extends BRDF[RGB] {
+      override def apply(lightDirection: Vector[_3D], viewDirection: Vector[_3D]): RGB = albedo
+    }
+  }
+
+  /** shader to invert diffuse lighting for de-illumination */
+  case class InverseDiffuseShader(reflectance: MeshSurfaceProperty[RGBA],
+                                  ambientLight: RGB,
+                                  diffuseLight: RGB,
+                                  lightDirection: Vector[_3D],
+                                  normals: MeshSurfaceProperty[Vector[_3D]]) extends PixelShader[RGBA] {
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): RGBA = {
+      val r = reflectance(triangleId, worldBCC)
+      val n = normals(triangleId, worldBCC).normalize
+      val diffuseFactor: Double = math.max(n.dot(lightDirection.normalize), 0.0)
+      val diffuse: RGB = diffuseLight * diffuseFactor
+      val combined = ambientLight + diffuse
+      RGBA(r.r / combined.r, r.g / combined.g, r.b / combined.b, r.a)
+    }
+  }
+
+  /**
+    * Blinn-Phong specular shader
+    *
+    * @param positions mesh point positions in world space
+    * @param normals   normals in world space
+    */
+  case class BlinnPhongSpecularShader(specularLight: RGB,
+                                      lightDirection: Vector[_3D],
+                                      positions: MeshSurfaceProperty[Point[_3D]],
+                                      normals: MeshSurfaceProperty[Vector[_3D]],
+                                      eyePosition: Point[_3D],
+                                      shininess: Double) extends PixelShader[RGBA] {
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): RGBA = {
+      val v = (eyePosition - positions(triangleId, worldBCC)).normalize
+      val spec = BlinnPhongSpecularShader.brdf(shininess, normals(triangleId, worldBCC), lightDirection, v)
+      (specularLight * spec).toRGBA
+    }
+  }
+
+  object BlinnPhongSpecularShader {
+
+    case class BlinnPhongBRDF(shininess: Double, normal: Vector[_3D]) extends BRDF[Double] {
+      override def apply(lightDirection: Vector[_3D], viewDirection: Vector[_3D]): Double = {
+        BlinnPhongSpecularShader.brdf(shininess, normal, lightDirection, viewDirection)
+      }
+    }
+
+    def brdf(shininess: Double, normal: Vector[_3D], lightDirection: Vector[_3D], viewDirection: Vector[_3D]): Double = {
+      val h = (viewDirection + lightDirection).normalize
+      val cos = normal.normalize.dot(h)
+      math.pow(math.max(cos, 0.0), shininess)
+    }
+  }
+
+  /** Lambertian shader with efficient Spherical Harmonics environment map representation */
+  case class SphericalHarmonicsLambertShader(albedo: MeshSurfaceProperty[RGBA],
+                                             environmentMap: IndexedSeq[Vector[_3D]],
+                                             normals: MeshSurfaceProperty[Vector[_3D]]) extends PixelShader[RGBA] {
+    override def apply(triangleId: TriangleId,
+                       worldBCC: BarycentricCoordinates,
+                       screenCoordinates: Point[_3D]): RGBA = SphericalHarmonicsLambertShader.shade(
+      albedo(triangleId, worldBCC),
+      normals(triangleId, worldBCC),
+      environmentMap)
+  }
+
+  object SphericalHarmonicsLambertShader {
+    def shade(c: RGBA, n: Vector[_3D], environmentMap: IndexedSeq[Vector[_3D]]): RGBA = {
+      val numCoeffs = math.min(environmentMap.size, 9)
+      var radiance = Vector3D.zero
+
+      var r = 0.0
+      var g = 0.0
+      var b = 0.0
+      var i = 0
+      while (i < numCoeffs) {
+        val ksh = SphericalHarmonics.shBasisFunctionDirect(i, n) * SphericalHarmonicsLight.lambertKernel(i)
+        val l = environmentMap(i)
+        r += ksh * l.x
+        g += ksh * l.y
+        b += ksh * l.z
+        i += 1
+      }
+      RGBA(r * c.r, g * c.g, b * c.b, c.a)
+    }
+  }
+
+  /**
+    * Phong illumination using Spherical Harmonics as Environment map.
+    * Instead of using directional light we can use an environment map for lighting in the phong illumination model.
+    * The specular part consists of: I_spec = I_in * specularFactor
+    * We use this specular factor (phong):
+    *    specularFactor = ( view dot reflected(view, normal) ) ^ shininess
+    * But we take the light intensity from the SH environment map.
+    *    I_l = SH(reflected(view, normal))
+    * Because the environment map is smooth this approximation should not be too bad.
+    */
+  case class SphericalHarmonicsSpecularShader(specularExp: Double,
+                                              environmentMap: IndexedSeq[Vector[_3D]],
+                                              normalsWorld: MeshSurfaceProperty[Vector[_3D]],
+                                              positionsWorld: MeshSurfaceProperty[Point[_3D]]) extends PixelShader[RGBA] {
+    override def apply(triangleId: TriangleId,
+                       worldBCC: BarycentricCoordinates,
+                       screenCoordinates: Point[_3D]): RGBA = {
+      SphericalHarmonicsSpecularShader.specularPart(positionsWorld(triangleId, worldBCC), normalsWorld(triangleId, worldBCC), specularExp, environmentMap)
+    }
+  }
+
+  object SphericalHarmonicsSpecularShader {
+    def specularPart(posWorld: Point[_3D], normalWorld: Vector[_3D], specularExp: Double, environmentMap: IndexedSeq[Vector[_3D]]): RGBA = {
+      /** BRDF: find outgoing vector for given view vector (reflect) */
+      val vecToEye: Vector3D = (Point3D(0, 0, 0) - posWorld).normalize
+      val viewAdjusted = vecToEye * vecToEye.dot(normalWorld)
+      val reflected = normalWorld + (normalWorld - viewAdjusted)
+      /** Read out value in environment map in out direction for specularity */
+      val lightInOutDirection = SphericalHarmonicsLambertShader.shade(RGBA(1.0, 1.0, 1.0), reflected, environmentMap)
+      val specularFactor = math.pow(vecToEye.dot(reflected).toDouble, specularExp)
+      specularFactor *: lightInOutDirection
+    }
+  }
+
+  /** calculates triangle correspondence information per shaded pixel */
+  case class CorrespondenceShader(mesh: TriangleMesh[_3D]) extends PixelShader[Option[TriangleFragment]] {
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): Some[TriangleFragment] = {
+      Some(TriangleFragment(mesh, triangleId, worldBCC, screenCoordinates.x.toInt, screenCoordinates.y.toInt, screenCoordinates.z, ccwWinding = true))
+    }
+
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D], ccwWinding: Boolean): Some[TriangleFragment] = {
+      Some(TriangleFragment(mesh, triangleId, worldBCC, screenCoordinates.x.toInt, screenCoordinates.y.toInt, screenCoordinates.z, ccwWinding))
+    }
+  }
+
+  /** Oren-Nayar reflectance model for diffuse reflectance with micro-facets */
+  case class OrenNayarShader(albedo: MeshSurfaceProperty[RGBA],
+                             roughness: MeshSurfaceProperty[Double],
+                             normals: MeshSurfaceProperty[Vector[_3D]],
+                             position: MeshSurfaceProperty[Point[_3D]],
+                             ambientLight: RGB,
+                             diffuseLight: RGB,
+                             lightDirection: Vector[_3D],
+                             eyePosition: Point[_3D]) extends PixelShader[RGBA] {
+
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): RGBA = {
+      OrenNayarShader.shade(
+        albedo(triangleId, worldBCC),
+        roughness(triangleId, worldBCC),
+        position(triangleId, worldBCC),
+        ambientLight,
+        diffuseLight,
+        lightDirection,
+        normals(triangleId, worldBCC),
+        eyePosition
+      )
+    }
+  }
+
+  object OrenNayarShader {
+
+    case class OrenNayarBRDF(normal: Vector[_3D], albedo: RGB, roughness: Double) extends BRDF[RGB] {
+      override def apply(lightDirection: Vector[_3D], view: Vector[_3D]): RGB = {
+        val r = OrenNayarShader.reflectanceFactor(roughness, normal, lightDirection, view)
+        albedo * r
+      }
+    }
+
+    def reflectanceFactor(roughness: Double, normal: Vector[_3D], lightDirection: Vector[_3D], view: Vector[_3D]): Double = {
+      val A = 1.0 - 0.5 * (roughness / (roughness + 0.33))
+      val B = 0.45 * (roughness / (roughness + 0.09))
+
+      val cosPhiIn = normal.dot(lightDirection)
+      val cosPhiOut = normal.dot(view)
+
+      val cosAlpha = math.abs(math.min(cosPhiIn, cosPhiOut))
+      val cosBeta = math.abs(math.max(cosPhiIn, cosPhiOut))
+
+      val sinAlpha = math.sqrt(1.0 - cosAlpha * cosAlpha)
+      val sinBeta = Math.sqrt(1.0 - cosBeta * cosBeta)
+
+      val tanBeta = sinBeta / (cosBeta + 1e-5)
+
+      val cosPhiInMinusPhiOut = cosAlpha * cosBeta + sinAlpha * sinBeta
+      val G = A + (B * Math.max(0.0, cosPhiInMinusPhiOut) * sinAlpha * tanBeta)
+      G
+    }
+
+    def shade(albedo: RGBA,
+              roughness: Double,
+              position: Point[_3D],
+              lightAmbient: RGB,
+              lightDiffuse: RGB,
+              lightDirection: Vector[_3D],
+              normal: Vector[_3D],
+              eyePosition: Point[_3D]): RGBA = {
+
+      val view = (eyePosition - position).normalize
+      val reflectance = OrenNayarShader.reflectanceFactor(roughness, normal, lightDirection, view)
+      val cosFactor = normal dot lightDirection
+
+      val illum = lightDiffuse * (reflectance * math.max(0, cosFactor)) + lightAmbient
+      RGBA(albedo.toRGB x illum, albedo.a)
+    }
+  }
+
+  /** Cook-Torrance reflectance model for specular reflectance with micro-facets */
+  case class CookTorranceSpecularShader(lightSpecular: RGB,
+                                        frontalReflectance: MeshSurfaceProperty[Double],
+                                        roughness: MeshSurfaceProperty[Double],
+                                        normals: MeshSurfaceProperty[Vector[_3D]],
+                                        positions: MeshSurfaceProperty[Point[_3D]],
+                                        lightDirection: Vector[_3D],
+                                        eyePosition: Point[_3D]) extends PixelShader[RGBA] {
+
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): RGBA = {
+      CookTorranceSpecularShader.shade(
+        lightSpecular,
+        frontalReflectance(triangleId, worldBCC),
+        roughness(triangleId, worldBCC),
+        normals(triangleId, worldBCC),
+        positions(triangleId, worldBCC),
+        lightDirection,
+        eyePosition
+      )
+    }
+  }
+
+  object CookTorranceSpecularShader {
+
+    case class CookTorranceBRDF(frontalReflectance: Double, roughness: Double, normal: Vector[_3D]) extends BRDF[Double] {
+      override def apply(lightDirection: Vector[_3D], viewDirection: Vector[_3D]): Double = {
+        CookTorranceSpecularShader.brdf(frontalReflectance, roughness, normal, lightDirection, viewDirection)
+      }
+    }
+
+    def brdf(frontalReflectance: Double, roughness: Double, normal: Vector[_3D], lightDirection: Vector[_3D], viewDirection: Vector[_3D]): Double = {
+      val eps = 1e-5
+      val en = math.max(eps, viewDirection.dot(normal))
+      val h: Vector[_3D] = {
+        val d = lightDirection + viewDirection
+        if (d.norm2 > eps * eps)
+          d.normalize
+        else
+          normal
+      }
+
+      val D = ReflectanceHelper.beckmann(normal, h, roughness, 1e-4)
+      val F = ReflectanceHelper.schlickFresnel(viewDirection, h, frontalReflectance)
+
+      val hn2 = 2.0 * math.abs(h.dot(normal))
+      val eh = math.max(eps, h.dot(viewDirection))
+      val ln = math.abs(lightDirection.dot(normal))
+
+      val G = math.min(1.0, math.min(hn2 * en / eh, hn2 * ln / eh))
+      0.25 * D * F * G / en
+    }
+
+    def shade(lightSpecular: RGB,
+              frontalReflectance: Double,
+              roughness: Double,
+              normal: Vector[_3D],
+              position: Point[_3D],
+              lightDirection: Vector[_3D],
+              eyePosition: Point[_3D]): RGBA = {
+      val view = (eyePosition - position).normalize
+      val r = CookTorranceSpecularShader.brdf(frontalReflectance, roughness, normal, lightDirection, view)
+      (lightSpecular * r).toRGBA
+    }
+  }
+
+  /** paint pixels according to their triangle winding order, useful to debug your mesh normals */
+  case class TriangleWindingShader[A](ccwColor: A, cwColor: A) extends PixelShader[A] {
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D], ccwWinding: Boolean): A = if (ccwWinding) ccwColor else cwColor
+
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): A = ccwColor
+  }
+}
+
+object ReflectanceHelper {
+  // Note the removal of the 1/pi factor from the Beckmann distribution
+  /** Beckmann distribution */
+  def beckmann(n: Vector[_3D], h: Vector[_3D], m: Double, eps: Double): Double = {
+    val cosAlpha = math.max(eps, n.dot(h))
+    math.exp(-(1.0 - cosAlpha * cosAlpha) / (cosAlpha * cosAlpha * m * m)) / (m * m * cosAlpha * cosAlpha * cosAlpha * cosAlpha)
+  }
+
+  /** Schlick approximation to Fresnel terms */
+  def schlickFresnel(e: Vector[_3D], h: Vector[_3D], r0: Double, lambda: Double): Double = {
+    r0 + (1.0 - r0) * math.pow(1.0 - math.abs(e.dot(h)), 5.0)
+  }
+
+  /** Schlick approximation to Fresnel terms */
+  def schlickFresnel(e: Vector[_3D], h: Vector[_3D], r0: Double): Double = {
+    schlickFresnel(e, h, r0, 5.0)
+  }
+}

--- a/src/main/scala/scalismo/faces/render/RenderBuffer.scala
+++ b/src/main/scala/scalismo/faces/render/RenderBuffer.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.faces.color.RGBA
+import scalismo.faces.image.{ImageBuffer, PixelImage}
+
+import scala.reflect.ClassTag
+
+/**
+  * general structure for a rendering target buffer: stores result and handles multiple fragments per position, this is the renderer's viewport
+  * y orientation is upwards! (Coordinate system of an OpenGL viewport)
+  */
+trait RenderBuffer[A] {
+  def update(x: Int, y: Int, z: Double, v: A): Unit
+
+  def isDefinedAt(x: Int, y: Int): Boolean
+
+  def width: Int
+
+  def height: Int
+
+  def toImage: PixelImage[A]
+}
+
+/** simple z buffer administrator - standard render buffer for most applications */
+case class ZBuffer[A: ClassTag](override val width: Int, override val height: Int, background: A, zInit: Double = Double.PositiveInfinity) extends RenderBuffer[A] {
+  private val buffer = ImageBuffer.makeConstantBuffer(width, height, background)
+  private val zBuffer = ImageBuffer.makeConstantBuffer(width, height, zInit)
+
+  override def update(x: Int, y: Int, z: Double, v: A): Unit = {
+    if (isDefinedAt(x, y)) {
+      if (z < zBuffer(x, y)) {
+        buffer(x, y) = v
+        zBuffer(x, y) = z
+      }
+    }
+  }
+
+  override def toImage: PixelImage[A] = buffer.toImage
+
+  override def isDefinedAt(x: Int, y: Int): Boolean = x >= 0 && x < width && y >= 0 && y < height
+}
+
+/** synchronized z buffer for parallel rendering */
+case class SyncedZBuffer[A: ClassTag](override val width: Int, override val height: Int, background: A, zInit: Double = Double.PositiveInfinity) extends RenderBuffer[A] {
+  private val buffer = ImageBuffer.makeConstantBuffer(width, height, background)
+  private val zBuffer = ImageBuffer.makeConstantBuffer(width, height, zInit)
+
+  override def update(x: Int, y: Int, z: Double, v: A): Unit = {
+    if (isDefinedAt(x, y)) {
+      buffer.synchronized {
+        if (z < zBuffer(x, y)) {
+          buffer(x, y) = v
+          zBuffer(x, y) = z
+        }
+      }
+    }
+  }
+
+  override def toImage: PixelImage[A] = buffer.toImage
+
+  override def isDefinedAt(x: Int, y: Int): Boolean = x >= 0 && x < width && y >= 0 && y < height
+}
+
+/** blend colors onto each other (use A channel for transparency) - respects depth: only fg pixels overlay bg pixels */
+case class BlendingBufferWithDepth(override val width: Int, override val height: Int, background: RGBA, zInit: Double = Double.PositiveInfinity) extends RenderBuffer[RGBA] {
+  private val buffer = ImageBuffer.makeConstantBuffer(width, height, background)
+  private val zBuffer = ImageBuffer.makeConstantBuffer(width, height, zInit)
+
+  override def update(x: Int, y: Int, z: Double, v: RGBA): Unit = {
+    if (isDefinedAt(x, y)) {
+      synchronized {
+        if (z < zBuffer(x, y)) {
+          buffer(x, y) = v over buffer(x, y)
+          zBuffer(x, y) = z
+        }
+      }
+    }
+  }
+
+  override def toImage: PixelImage[RGBA] = buffer.toImage
+
+  override def isDefinedAt(x: Int, y: Int): Boolean = x >= 0 && x < width && y >= 0 && y < height
+}
+
+/** blend colors onto each other (use A channel for transparency) */
+case class BlendingBuffer(override val width: Int, override val height: Int, background: RGBA, zInit: Double = Double.PositiveInfinity) extends RenderBuffer[RGBA] {
+  private val buffer = ImageBuffer.makeConstantBuffer(width, height, background)
+
+  override def update(x: Int, y: Int, z: Double, v: RGBA): Unit = {
+    if (isDefinedAt(x, y)) this.synchronized {
+      buffer(x, y) = v over buffer(x, y)
+    }
+  }
+
+  override def toImage: PixelImage[RGBA] = buffer.toImage
+
+  override def isDefinedAt(x: Int, y: Int): Boolean = x >= 0 && x < width && y >= 0 && y < height
+}
+
+/** simple plain render buffer, does not manage fragment collapse, last is kept */
+case class PlainRenderBuffer[A: ClassTag](override val width: Int, override val height: Int, clearColor: A) extends RenderBuffer[A] {
+  val buffer: ImageBuffer[A] = ImageBuffer.makeInitializedBuffer(width, height)(clearColor)
+
+  override def update(x: Int, y: Int, z: Double, v: A): Unit = {
+    if (isDefinedAt(x, y)) buffer(x, y) = v
+  }
+
+  override def toImage: PixelImage[A] = buffer.toImage
+
+  override def isDefinedAt(x: Int, y: Int): Boolean = x >= 0 && x < width && y >= 0 && y < height
+}

--- a/src/main/scala/scalismo/faces/render/RenderTransforms.scala
+++ b/src/main/scala/scalismo/faces/render/RenderTransforms.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.geometry._
+import scalismo.mesh.BarycentricCoordinates
+
+object RenderTransforms {
+  /** default model transform, consisting of scaling, 3 (Euler) rotations (x, y, z) and translation */
+  def modelTransform(translation: Vector[_3D], scaling: Double, pitch: Double, yaw: Double, roll: Double): Affine3D = {
+    val rotX = Rotation3D.rotationX(pitch)
+    val rotY = Rotation3D.rotationY(yaw)
+    val rotZ = Rotation3D.rotationZ(roll)
+    val t = Translation3D(translation)
+    val scale = Scaling3D(scaling)
+    t.toAffine3D compose (rotZ compose rotY compose rotX).toAffine3D compose scale.toAffine3D
+  }
+
+  /**
+   * camera/view transform to look at a certain point, see gluLookAt
+   *
+   * @param position position of the camera center
+   * @param lookAt   center point of the camera, looks at given point
+   * @param upright  upwards direction of camera
+   */
+  def viewTransformLookAt(position: Point[_3D], lookAt: Point[_3D], upright: Vector[_3D]): Affine3D = {
+    // rotations according to lookAt and upright, as in gluLookAt
+    val f = (lookAt - position).normalize
+    val up = upright.normalize
+    val s = (f crossproduct up).normalize
+    val u = (s crossproduct f).normalize
+    val M = SquareMatrix(
+      (s.x, s.y, s.z),
+      (u.x, u.y, u.z),
+      (-f.x, -f.y, -f.z)
+    )
+    // translation: camera center
+    val p = position.toVector
+    val t = Vector(-s dot p, -u dot p, f dot p)
+    Affine3D(M, t)
+  }
+
+  /** default camera/view transform, consists of three rotations (Euler, xyz) and a translation of the camera center (inverts) */
+  def viewTransform(translation: Vector[_3D], pitch: Double, yaw: Double, roll: Double): Affine3D = {
+    val rotX = Rotation3D.rotationX(pitch)
+    val rotY = Rotation3D.rotationY(yaw)
+    val rotZ = Rotation3D.rotationZ(roll)
+    val t = Translation3D(translation)
+    (t.toAffine3D compose (rotZ compose rotY compose rotX).toAffine3D).inverted
+  }
+
+  /** default correction of barycentric coordinates in screen space to world (3d) space for a perspective projection */
+  def bccScreenToWorldCorrectionPerspective(bccScreen: BarycentricCoordinates, z1: Double, z2: Double, z3: Double): BarycentricCoordinates = {
+    val d = z2 * z3 + z3 * bccScreen.b * (z1 - z2) + z2 * bccScreen.c * (z1 - z3)
+    if (d == 0f) {
+      bccScreen
+    } else {
+      val b = z1 * z3 * bccScreen.b / d
+      val c = z1 * z2 * bccScreen.c / d
+      BarycentricCoordinates(1f - b - c, b, c) //lambda world
+    }
+  }
+
+  /** default correction of barycentric coordinates from world (3d) space to screen space for a perspective projection */
+  def bccWorldToScreenCorrectionPerspective(bccWorld: BarycentricCoordinates, z1: Double, z2: Double, z3: Double): BarycentricCoordinates = {
+    val d = z1 - (z1 - z2) * bccWorld.b - (z1 - z3) * bccWorld.c
+    if (d == 0f)
+      bccWorld
+    else {
+      val c = bccWorld.c * z3 / d
+      val b = bccWorld.b * z2 / d
+      BarycentricCoordinates(1f - b - c, b, c)
+    }
+  }
+}
+

--- a/src/main/scala/scalismo/faces/render/Rotation3D.scala
+++ b/src/main/scala/scalismo/faces/render/Rotation3D.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import breeze.linalg.DenseMatrix
+import scalismo.geometry._
+
+/** quaternion to handle rotation */
+case class Quaternion(r: Double, v: Vector[_3D]) {
+  def norm: Double = math.sqrt(r*r + v.norm2)
+
+  def normalize: Quaternion = this / norm
+
+  def *(other: Quaternion): Quaternion = {
+    val Quaternion(s, w) = other
+    Quaternion(r * s - v.dot(w), r *: w + s *: v + v.crossproduct(w))
+  }
+
+  def *(scale: Double) = Quaternion(r * scale, v * scale)
+
+  def /(scale: Double) = Quaternion(r / scale, v / scale)
+
+  def *:(scale: Double): Quaternion = this * scale
+
+  def conjugate = Quaternion(r, -v)
+
+  def unary_- = Quaternion(-r, -v)
+
+  def dot(other: Quaternion): Double = r * other.r + v.dot(other.v)
+}
+
+/** rotation in 3D in angle/axis parameterization */
+case class Rotation3D(phi: Double, axis: Vector[_3D]) extends InvertibleTransform3D with Transform4x4 {
+  private val normalizedAxis = axis.normalize // axis must be normalized
+
+  /** quaternion describing this rotation */
+  lazy val quaternion: Quaternion = Quaternion(math.cos(phi / 2.0), math.sin(phi / 2.0) *: normalizedAxis)
+
+  /** rotation matrix describing action in 3D space */
+  val rotationMatrix: SquareMatrix[_3D] = {
+    val c = math.cos(phi)
+    val s = math.sin(phi)
+    val uu = normalizedAxis.outer(normalizedAxis)
+    val ux = SquareMatrix((0.0, -normalizedAxis.z, normalizedAxis.y), (normalizedAxis.z, 0.0, -normalizedAxis.x), (-normalizedAxis.y, normalizedAxis.x, 0.0))
+    SquareMatrix.eye[_3D] * c + ux * s + uu * (1.0 - c)
+  }
+
+  /** rotate point */
+  override def apply(x: Point[_3D]): Point[_3D] = (rotationMatrix * x.toVector).toPoint
+
+  /** rotate vector */
+  override def apply(v: Vector[_3D]): Vector[_3D] = rotationMatrix * v
+
+  /** inverted rotation */
+  override def inverted: Rotation3D = Rotation3D(-phi, normalizedAxis)
+
+  /** compose with other rotation */
+  def compose(other: Rotation3D): Rotation3D = {
+    Rotation3D.fromQuaternion(quaternion * other.quaternion)
+  }
+
+  /** compose as affine transform */
+  def compose(other: Affine3D): Affine3D = toAffine3D compose other
+
+  /** rotation matrix expressed in homogenuous coordinates */
+  override def matrix4: DenseMatrix[Double] =
+    DenseMatrix.vertcat(
+      DenseMatrix.horzcat(
+        rotationMatrix.toBreezeMatrix,
+        DenseMatrix(0.0, 0.0, 0.0)),
+      DenseMatrix((0.0, 0.0, 0.0, 1.0))
+    )
+
+  def toAffine3D: Affine3D = Affine3D(rotationMatrix, Vector(0.0, 0.0, 0.0))
+}
+
+object Rotation3D {
+  /** build rotation from quaternion */
+  def fromQuaternion(q: Quaternion): Rotation3D = {
+    val Quaternion(r: Double, v: Vector[_3D]) = q
+    val phi = 2 * math.atan2(v.norm, r)
+    val axis = if (phi != 0.0) v / math.sin(phi / 2.0) else Vector3D.unitX
+    Rotation3D(phi, axis)
+  }
+
+  /** build rotation from Euler angles */
+  def fromEulerXYZ(x: Double, y: Double, z: Double): Rotation3D = {
+    rotationZ(z) compose rotationY(y) compose rotationX(x)
+  }
+
+  def rotationX(phi: Double) = Rotation3D(phi, Vector3D.unitX)
+
+  def rotationY(phi: Double) = Rotation3D(phi, Vector3D.unitY)
+
+  def rotationZ(phi: Double) = Rotation3D(phi, Vector3D.unitZ)
+
+  /** find Euler angles for given rotation */
+  def decomposeRotationXYZ(rotation: Rotation3D): (Double, Double, Double) = {
+    val r = rotation.rotationMatrix
+    val pitch = math.atan2(r(2, 1), r(2, 2))
+    val yaw = math.atan2(-r(2, 0), math.sqrt(r(2, 1) * r(2, 1) + r(2, 2) * r(2, 2)))
+    val roll = math.atan2(r(1, 0), r(0, 0))
+    (pitch, yaw, roll)
+  }
+}

--- a/src/main/scala/scalismo/faces/render/Scaling3D.scala
+++ b/src/main/scala/scalismo/faces/render/Scaling3D.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import breeze.linalg.DenseMatrix
+import scalismo.geometry.{Point, SquareMatrix, Vector, _3D}
+
+/** scaling transfrom in 3D */
+case class Scaling3D(fx: Double, fy: Double, fz: Double) extends InvertibleTransform3D with Transform4x4 {
+
+  override def apply(x: Point[_3D]): Point[_3D] = this(x.toVector).toPoint
+  override def apply(v: Vector[_3D]): Vector[_3D] = Vector(v.x * fx, v.y * fy, v.z * fz)
+
+  override def inverted: Scaling3D = Scaling3D(1.0 / fx, 1.0 / fy, 1.0 / fz)
+
+  def compose(other: Scaling3D): Scaling3D = Scaling3D(other.fx * fx, other.fy * fy, other.fz * fz)
+
+  override def matrix4 = DenseMatrix(
+    (fx, 0.0, 0.0, 0.0),
+    (0.0, fy, 0.0, 0.0),
+    (0.0, 0.0, fz, 0.0),
+    (0.0, 0.0, 0.0, 1.0)
+  )
+
+  def toAffine3D: Affine3D = Affine3D(
+    SquareMatrix(
+      (fx, 0.0, 0.0),
+      (0.0, fy, 0.0),
+      (0.0, 0.0, fz)),
+    Vector(0.0, 0.0, 0.0)
+  )
+}
+
+object Scaling3D {
+  /** isotropic scaling */
+  def apply(s: Double) = new Scaling3D(s, s, s)
+}

--- a/src/main/scala/scalismo/faces/render/Shaders.scala
+++ b/src/main/scala/scalismo/faces/render/Shaders.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.faces.color.ColorSpaceOperations
+import scalismo.faces.render.TriangleRenderer.TriangleFragment
+import scalismo.geometry.{Point, _3D}
+import scalismo.mesh.{BarycentricCoordinates, TriangleId}
+
+/** transform a point from 3D space to normalized device coordinates: [-1,1]x[-1,1]x[-1,1] (normalized to viewing frustum) */
+trait PointShader extends (Point[_3D] => Point[_3D]) {
+  def bccScreenToWorld(screenBCC: BarycentricCoordinates, a: Point[_3D], b: Point[_3D], c: Point[_3D]): BarycentricCoordinates = screenBCC
+  def bccWorldToScreen(worldBCC: BarycentricCoordinates, a: Point[_3D], b: Point[_3D], c: Point[_3D]): BarycentricCoordinates = worldBCC
+}
+
+object PointShader {
+  val identity = new PointShader {
+    override def apply(p: Point[_3D]): Point[_3D] = p
+  }
+}
+
+/** paint a pixel during rendering */
+trait PixelShader[A] { self =>
+  /**
+   * paint the pixel, has access to
+   *
+   * @param triangleId Id of the current triangle
+   * @param worldBCC Barycentric coordinates of the pixel within the triangle (in *world* space -- corrected)
+   * @param screenCoordinates Coordinates of the pixel on the screen (x, y: image coordinates, z: depth value)
+   */
+  def apply(triangleId: TriangleId,
+    worldBCC: BarycentricCoordinates,
+    screenCoordinates: Point[_3D]): A
+
+  /**
+   * paint the pixel, has access to
+   *
+   * @param triangleId Id of the current triangle
+   * @param worldBCC Barycentric coordinates of the pixel within the triangle (in *world* space -- corrected)
+   * @param screenCoordinates Coordinates of the pixel on the screen (x, y: image coordinates, z: depth value)
+   * @param ccwWinding true if the triangle has counter clock-wise winding (default)
+   */
+  def apply(triangleId: TriangleId,
+    worldBCC: BarycentricCoordinates,
+    screenCoordinates: Point[_3D],
+    ccwWinding: Boolean): A = this(triangleId, worldBCC, screenCoordinates)
+
+  def apply(fragment: TriangleFragment): A = this(fragment.triangleId, fragment.worldBCC, Point(fragment.x, fragment.y, fragment.z))
+
+  def +(other: PixelShader[A])(implicit ops: ColorSpaceOperations[A]) = new PixelShader[A] {
+    import ColorSpaceOperations.implicits._
+    override def apply(triangleId: TriangleId,
+      worldBCC: BarycentricCoordinates,
+      screenCoordinates: Point[_3D]): A = self(triangleId, worldBCC, screenCoordinates) + other(triangleId, worldBCC, screenCoordinates)
+  }
+
+  def *(other: PixelShader[A])(implicit ops: ColorSpaceOperations[A]) = new PixelShader[A] {
+    import ColorSpaceOperations.implicits._
+    override def apply(triangleId: TriangleId,
+      worldBCC: BarycentricCoordinates,
+      screenCoordinates: Point[_3D]): A = self(triangleId, worldBCC, screenCoordinates) multiply other(triangleId, worldBCC, screenCoordinates)
+  }
+
+  def map[B](f: A => B) = new PixelShader[B] {
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): B = f(self(triangleId, worldBCC, screenCoordinates))
+  }
+
+}
+
+object PixelShader {
+  def apply[A](f: (TriangleId, BarycentricCoordinates) => A) = new PixelShader[A] {
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): A = f(triangleId, worldBCC)
+  }
+
+  def apply[A](f: (TriangleId, BarycentricCoordinates, Point[_3D]) => A) = new PixelShader[A] {
+    override def apply(triangleId: TriangleId, worldBCC: BarycentricCoordinates, screenCoordinates: Point[_3D]): A = f(triangleId, worldBCC, screenCoordinates)
+  }
+}

--- a/src/main/scala/scalismo/faces/render/TextureExtraction.scala
+++ b/src/main/scala/scalismo/faces/render/TextureExtraction.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.faces.color.ColorSpaceOperations
+import scalismo.faces.image.{InterpolatedPixelImage, PixelImage, PixelImageDomain}
+import scalismo.faces.mesh.TextureMappedProperty
+import scalismo.geometry.{Point, _2D, _3D}
+import scalismo.mesh._
+
+/** methods to extract texture from images when rendering a mesh */
+object TextureExtraction {
+  /**
+    * Texture Extraction from Image.
+    * 1. Find correspondence between mesh and target image
+    * Render Points on image plane according to pointShader
+    * Put the 2D coordinates of the image onto the mesh. This is the texture mapping.
+    */
+  def imageAsSurfaceProperty[Pixel](mesh: TriangleMesh3D,
+                                    pointShader: PointShader,
+                                    targetImage: PixelImage[Pixel])(implicit ops: ColorSpaceOperations[Pixel]): MeshSurfaceProperty[Option[Pixel]] = {
+    val visible: MeshSurfaceProperty[Boolean] = TriangleRenderer.visibilityAsSurfaceProperty(mesh, pointShader, targetImage.domain, 1e-3, boundaryAlwaysVisible = false)
+
+    new MeshSurfaceProperty[Option[Pixel]] {
+      val target: InterpolatedPixelImage[Pixel] = targetImage.interpolate
+
+      override def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): Option[Pixel] = {
+        val vis: Boolean = visible(triangleId, bcc)
+        if (vis) {
+          val imagePoint: Point[_3D] = TriangleRenderer.transformPoint(mesh.position(triangleId, bcc), pointShader, targetImage.domain)
+          Some(target(imagePoint.x + 0.5, imagePoint.y + 0.5)) // interpolated image access is shifted by 0.5/0.5
+        } else
+          None
+      }
+
+      override def triangulation: TriangleList = mesh.triangulation
+    }
+  }
+
+  /**
+    * Texture Extraction from Image.
+    * 1. Find correspondence between mesh and target image.
+    * Render Points on image plane according to pointShader.
+    * Put the 2D coordinates of the image onto the mesh. This is the texture mapping.
+    */
+  def imageAsTexture[Pixel](mesh: TriangleMesh3D,
+                            pointShader: PointShader,
+                            targetImage: PixelImage[Pixel])(implicit ops: ColorSpaceOperations[Pixel]): TextureMappedProperty[Pixel] = {
+
+    // get canonical mapping: projected points in image (image itself becomes texture)
+    val projectedPoints: IndexedSeq[Point[_2D]] = mesh.pointSet.points.map(p => {
+      val p2d = TriangleRenderer.transformPoint(p, pointShader, targetImage.domain)
+      Point(p2d.x, p2d.y)
+    }).toIndexedSeq
+
+    val projectedUVPoints = projectedPoints.map(p => TextureMappedProperty.imageCoordinatesToUV(p, targetImage.width, targetImage.height))
+    val imageTextureCoordinates: SurfacePointProperty[Point[_2D]] = SurfacePointProperty(mesh.triangulation, projectedUVPoints)
+    TextureMappedProperty(mesh.triangulation, imageTextureCoordinates, targetImage)
+  }
+
+  /** full texture extraction: texture image extracted through a mesh rendered to an image, image "pulled back" from image to texture domain using texture mapping */
+  def extractTextureAsImage[A](mesh: TriangleMesh3D,
+                               pointShader: PointShader,
+                               targetImage: PixelImage[A],
+                               textureDomain: PixelImageDomain,
+                               textureMap: MeshSurfaceProperty[Point[_2D]])(implicit ops: ColorSpaceOperations[A]): PixelImage[Option[A]] = {
+    val imgOnSurface = imageAsSurfaceProperty(mesh, pointShader, targetImage)
+    val texturedSurface: TextureMappedProperty[Option[A]] = TextureMappedProperty.fromSurfaceProperty(imgOnSurface, textureMap, textureDomain, None)
+    texturedSurface.texture
+  }
+}

--- a/src/main/scala/scalismo/faces/render/Transform3D.scala
+++ b/src/main/scala/scalismo/faces/render/Transform3D.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import scalismo.geometry._
+
+trait Transform3D { self =>
+  /** apply transform to a 3d point */
+  def apply(x: Point[_3D]): Point[_3D]
+  /** apply transform to a 3d vector */
+  def apply(v: Vector[_3D]): Vector[_3D]
+  /** compose with other transform */
+  def compose(t: Transform3D): Transform3D = new Transform3D {
+    override def apply(x: Point[_3D]): Point[_3D] = self(t(x))
+    override def apply(v: Vector[_3D]): Vector[_3D] = self(t(v))
+  }
+}
+
+object Transform3D {
+  val identity = new Transform3D {
+    override def apply(x: Point[_3D]): Point[_3D] = x
+    override def apply(v: Vector[_3D]): Vector[_3D] = v
+  }
+}
+
+trait InvertibleTransform3D extends Transform3D { self: Transform3D =>
+  /** inverted version of this transform */
+  def inverted: InvertibleTransform3D
+
+  /** compose with other invertible transform */
+  def compose(u: InvertibleTransform3D): InvertibleTransform3D = {
+    val t = self
+    new InvertibleTransform3D {
+      thisTransform =>
+      override def apply(x: Point[_3D]): Point[_3D] = t(u(x))
+      override def apply(v: Vector[_3D]): Vector[_3D] = t(u(v))
+      override def inverted = new InvertibleTransform3D {
+        override def apply(x: Point[_3D]): Point[_3D] = u.inverted(t.inverted(x))
+        override def apply(v: Vector[_3D]): Vector[_3D] = u.inverted(t.inverted(v))
+        override def inverted: InvertibleTransform3D {
+          def inverted: InvertibleTransform3D with Object {
+            def inverted: Any
+
+            def apply(v: Vector[_3D]): Vector[_3D]
+
+            def apply(x: Point[_3D]): Point[_3D]
+          }
+
+          def apply(v: Vector[_3D]): Vector[_3D]
+
+          def apply(x: Point[_3D]): Point[_3D]
+        } = thisTransform
+      }
+    }
+  }
+}
+
+trait Transform4x4 {
+  def matrix4: DenseMatrix[Double]
+
+  def compose(other: Transform4x4): Transform4x4 = Matrix4Transform(matrix4 * other.matrix4)
+}
+
+case class Matrix4Transform(override val matrix4: DenseMatrix[Double]) extends Transform4x4 with InvertibleTransform3D {
+  require(matrix4.rows == 4 && matrix4.cols == 4, "transformation matrix must 4x4 (homogenuous coordinates)")
+
+  override def apply(p: Point[_3D]): Point[_3D] = {
+    val p4 = DenseVector(p.x, p.y, p.z, 1.0)
+    val tp = matrix4 * p4
+    Point(tp(0) / tp(3), tp(1) / tp(3), tp(2) / tp(3))
+  }
+
+  override def apply(v: Vector[_3D]): Vector[_3D] = {
+    val v4 = DenseVector(v.x, v.y, v.z, 0.0)
+    val tp = matrix4 * v4
+    Vector(tp(0), tp(1), tp(2))
+  }
+
+  /** inverted version of this transform */
+  override def inverted: InvertibleTransform3D = Matrix4Transform(breeze.linalg.inv(matrix4))
+}

--- a/src/main/scala/scalismo/faces/render/Translation3D.scala
+++ b/src/main/scala/scalismo/faces/render/Translation3D.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import breeze.linalg.DenseMatrix
+import scalismo.geometry.Vector._
+import scalismo.geometry.{Point, SquareMatrix, Vector, _3D}
+
+/** 3D translation */
+case class Translation3D(t: Vector[_3D]) extends InvertibleTransform3D with Transform4x4 {
+  override def apply(x: Point[_3D]): Point[_3D] = x + t
+  override def apply(v: Vector[_3D]): Vector[_3D] = v // a vector is not changed by a translation
+
+  override def inverted: Translation3D = Translation3D(-t)
+
+  def compose(other: Translation3D) = Translation3D(t + other.t)
+
+  override def matrix4 = DenseMatrix(
+    (1.0, 0.0, 0.0, t.x),
+    (0.0, 1.0, 0.0, t.y),
+    (0.0, 0.0, 1.0, t.z),
+    (0.0, 0.0, 0.0, 1.0)
+  )
+
+  def toAffine3D: Affine3D = Affine3D(SquareMatrix.eye[_3D], t)
+}

--- a/src/main/scala/scalismo/faces/render/TriangleFilters.scala
+++ b/src/main/scala/scalismo/faces/render/TriangleFilters.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.geometry.{Point, Vector, _3D}
+import scalismo.mesh.{TriangleId, TriangleMesh}
+
+/** methods to create useful triangle filters to use in TriangleRenderer, e.g. culling and clipping */
+object TriangleFilters {
+  /** remove triangles which face backwards, use as triangleFilter in renderMesh */
+  def backfaceCullingFilter(worldMesh: TriangleMesh[_3D], eyePosition: Point[_3D]): TriangleId => Boolean = {
+    triangleId =>
+      val triangle = worldMesh.triangulation.triangle(triangleId)
+      val a = worldMesh.pointSet.point(triangle.ptId1)
+      worldMesh.cellNormals(triangleId).dot(a - eyePosition) <= 0.0
+  }
+
+  /** remove triangles *partially* behind clipping plane, use as triangleFilter in renderMesh */
+  def clippingFilter(worldMesh: TriangleMesh[_3D], point: Point[_3D], normal: Vector[_3D]): TriangleId => Boolean = {
+    triangleId =>
+      val triangle = worldMesh.triangulation.triangle(triangleId)
+      val a = worldMesh.pointSet.point(triangle.ptId1)
+      val b = worldMesh.pointSet.point(triangle.ptId2)
+      val c = worldMesh.pointSet.point(triangle.ptId3)
+      def inFront(pt: Point[_3D]): Boolean = (pt - point).dot(normal) >= 0.0
+      inFront(a) && inFront(b) && inFront(c)
+  }
+
+  /** remove triangles *completely* behind clipping plane, use as triangleFilter in renderMesh */
+  def completeClippingFilter(worldMesh: TriangleMesh[_3D], point: Point[_3D], normal: Vector[_3D]): TriangleId => Boolean = {
+    triangleId =>
+      val triangle = worldMesh.triangulation.triangle(triangleId)
+      val a = worldMesh.pointSet.point(triangle.ptId1)
+      val b = worldMesh.pointSet.point(triangle.ptId2)
+      val c = worldMesh.pointSet.point(triangle.ptId3)
+      def inFront(pt: Point[_3D]): Boolean = (pt - point).dot(normal) >= 0.0
+      inFront(a) || inFront(b) || inFront(c)
+  }
+}

--- a/src/main/scala/scalismo/faces/render/TriangleRenderer.scala
+++ b/src/main/scala/scalismo/faces/render/TriangleRenderer.scala
@@ -1,0 +1,302 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.faces.image._
+import scalismo.geometry._
+import scalismo.mesh._
+
+import scala.reflect.ClassTag
+
+/** main renderer object to render images of triangle meshes */
+object TriangleRenderer {
+  @inline
+  private def vs2D(p: Point[_3D]): Point[_2D] = Point(p.x, p.y)
+
+  /**
+    * rasterize a single triangle
+    *
+    * @param triangleId  triangle id in triangulation
+    * @param a           point A in triangle
+    * @param b           point B in triangle
+    * @param c           point C in triangle
+    * @param pointShader performs correction of BCC from screen space to eye space
+    * @param pixelShader called to paint each pixel of the triangle
+    * @param buffer      render buffer, stores the painted values and does depth management
+    */
+  def rasterTriangle[A](triangleId: TriangleId,
+                        a: Point[_3D],
+                        b: Point[_3D],
+                        c: Point[_3D],
+                        pointShader: PointShader,
+                        pixelShader: PixelShader[A],
+                        buffer: RenderBuffer[A]): Unit = {
+    // bounding box
+    val minX = math.min(a.x, math.min(b.x, c.x)).floor.toInt
+    val maxX = math.max(a.x, math.max(b.x, c.x)).ceil.toInt
+    val minY = math.min(a.y, math.min(b.y, c.y)).floor.toInt
+    val maxY = math.max(a.y, math.max(b.y, c.y)).ceil.toInt
+
+    // determine winding order
+    val signedArea = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+    val ccwWinding = signedArea > 0
+
+    // point inside? careful with ccw/cw windings, shader decides what to do in each case
+    @inline
+    def inTriangle(x: Int, y: Int): Boolean = {
+      val xf = x.toDouble
+      val yf = y.toDouble
+      // all "left of line"? or all "right of line"?
+      if (ccwWinding)
+        (b.x - a.x) * (yf - a.y) - (b.y - a.y) * (xf - a.x) >= 0 &&
+          (c.x - b.x) * (yf - b.y) - (c.y - b.y) * (xf - b.x) >= 0 &&
+          (a.x - c.x) * (yf - c.y) - (a.y - c.y) * (xf - c.x) >= 0
+      else
+        (b.x - a.x) * (yf - a.y) - (b.y - a.y) * (xf - a.x) <= 0 &&
+          (c.x - b.x) * (yf - b.y) - (c.y - b.y) * (xf - b.x) <= 0 &&
+          (a.x - c.x) * (yf - c.y) - (a.y - c.y) * (xf - c.x) <= 0
+    }
+
+    // reduce z interpolation to two multiplications only, using z differences
+    val z10 = b.z - a.z
+    val z20 = c.z - a.z
+
+    // inner loop over pixels in bounding box
+    var y = minY
+    while (y <= maxY) {
+      var x = minX
+      while (x <= maxX) {
+        if (inTriangle(x, y) && buffer.isDefinedAt(x, y)) {
+          val screenBCC = BarycentricCoordinates.pointInTriangle(Point(x, y), vs2D(a), vs2D(b), vs2D(c))
+          val worldBCC = pointShader.bccScreenToWorld(screenBCC, a, b, c)
+          val z: Double = a.z + z10 * worldBCC.b + z20 * worldBCC.c
+          buffer(x, y, z) = pixelShader(triangleId, worldBCC, Point(x, y, z), ccwWinding)
+        }
+        x += 1
+      }
+      y += 1
+    }
+  }
+
+  /**
+    * render a mesh, renders each triangle into the rendering buffer
+    *
+    * @param mesh        mesh to render, a collection of triangles
+    * @param pointShader called to transform points from object space to NDC in the canonical viewing volume
+    * @param pixelShader called to paint the pixels of the rendered image
+    * @param buffer      holds the rendered values, does z management
+    */
+  def renderMesh[A](mesh: TriangleMesh[_3D],
+                    pointShader: PointShader,
+                    pixelShader: PixelShader[A],
+                    buffer: RenderBuffer[A]): RenderBuffer[A] = {
+    // viewport transform
+    val screenTransform = WindowTransform(buffer.width, buffer.height)
+
+    renderMesh(mesh, pointShader, screenTransform, pixelShader, buffer)
+  }
+
+  /**
+    * render a mesh, renders each triangle into the rendering buffer. This function uses a user-defined screenTransform.
+    * NOTE: Use this function only when you know what you are doing.
+    *
+    * @param mesh        mesh to render, a collection of triangles
+    * @param pointShader called to transform points from object space to NDC in the canonical viewing volume
+    * @param pixelShader called to paint the pixels of the rendered image
+    * @param buffer      holds the rendered values, does z management
+    */
+  def renderMesh[A](mesh: TriangleMesh[_3D],
+                    pointShader: PointShader,
+                    screenTransform: InvertibleTransform3D,
+                    pixelShader: PixelShader[A],
+                    buffer: RenderBuffer[A]): RenderBuffer[A] = {
+
+    // render all points
+    val points = new Array[Point[_3D]](mesh.pointSet.numberOfPoints)
+    mesh.pointSet.pointIds.foreach { pId =>
+      val pointOnPlane = pointShader(mesh.pointSet.point(pId))
+      points(pId.id) = screenTransform(pointOnPlane)
+    }
+    // render all fragments: painting/shading
+    mesh.triangulation.triangleIds.foreach { tid =>
+      val t = mesh.triangulation.triangle(tid)
+      val a = points(t.ptId1.id)
+      val b = points(t.ptId2.id)
+      val c = points(t.ptId3.id)
+      rasterTriangle(tid, a, b, c, pointShader, pixelShader, buffer)
+    }
+    buffer // return reference to buffer: works with anonymous buffers
+  }
+
+  /**
+    * render a mesh, renders each triangle which passes the filter into the rendering buffer.
+    * This function uses a user-defined screenTransform and a triangle filter to select triangles.
+    * NOTE: Use this function only when you know what you are doing.
+    *
+    * @param mesh        mesh to render, a collection of triangles
+    * @param triangleFilter filter triangles to render, use for culling and clipping
+    * @param pointShader called to transform points from object space to NDC in the canonical viewing volume
+    * @param pixelShader called to paint the pixels of the rendered image
+    * @param buffer      holds the rendered values, does z management
+    */
+  def renderMesh[A](mesh: TriangleMesh[_3D],
+                    triangleFilter: (TriangleId) => Boolean,
+                    pointShader: PointShader,
+                    screenTransform: InvertibleTransform3D,
+                    pixelShader: PixelShader[A],
+                    buffer: RenderBuffer[A]): RenderBuffer[A] = {
+
+    // render all points
+    val points = new Array[Point[_3D]](mesh.pointSet.numberOfPoints)
+    mesh.pointSet.pointIds.foreach { pId =>
+      val pointOnPlane = pointShader(mesh.pointSet.point(pId))
+      points(pId.id) = screenTransform(pointOnPlane)
+    }
+    // render all fragments: painting/shading
+    mesh.triangulation.triangleIds.filter(triangleFilter).foreach { tid =>
+      val t = mesh.triangulation.triangle(tid)
+      val a = points(t.ptId1.id)
+      val b = points(t.ptId2.id)
+      val c = points(t.ptId3.id)
+      rasterTriangle(tid, a, b, c, pointShader, pixelShader, buffer)
+    }
+    buffer // return reference to buffer: works with anonymous buffers
+  }
+
+  /**
+    * render an arbitrary mesh surface property
+    *
+    * @param mesh        mesh on which the property is defined
+    * @param pointShader called to transform points from object space to NDC in the canonical viewing volume
+    * @param property    the surface property to render
+    * @param buffer      holds the rendered values, does z management
+    */
+  def renderProperty[A: ClassTag](mesh: TriangleMesh[_3D],
+                                  pointShader: PointShader,
+                                  property: MeshSurfaceProperty[A],
+                                  buffer: RenderBuffer[Option[A]]): RenderBuffer[Option[A]] = {
+    renderMesh(
+      mesh,
+      pointShader,
+      new PixelShader[Option[A]] {
+        override def apply(triangleId: TriangleId, bcc: BarycentricCoordinates, screenCoordinates: Point[_3D]) = Some(property(triangleId, bcc))
+      },
+      buffer)
+  }
+
+  /** a triangle fragment, with information about triangle origin and the position within */
+  case class TriangleFragment(mesh: TriangleMesh[_3D],
+                              triangleId: TriangleId,
+                              worldBCC: BarycentricCoordinates,
+                              x: Int,
+                              y: Int,
+                              z: Double,
+                              ccwWinding: Boolean)
+
+  /** render a correspondence image into a buffer, contains information about triangle rasterization */
+  def renderCorrespondence(mesh: TriangleMesh[_3D],
+                           pointShader: PointShader,
+                           buffer: RenderBuffer[Option[TriangleFragment]]): RenderBuffer[Option[TriangleFragment]] = {
+    renderMesh[Option[TriangleFragment]](
+      mesh,
+      pointShader,
+      PixelShaders.CorrespondenceShader(mesh),
+      buffer
+    )
+  }
+
+  /** render window depth values (as used by Z buffer, in range [0, 1]) */
+  def renderDepthWindow(mesh: TriangleMesh[_3D],
+                        pointShader: PointShader,
+                        buffer: RenderBuffer[Double]): RenderBuffer[Double] = {
+    val screen = WindowTransform(buffer.width, buffer.height)
+    renderMesh(mesh,
+      pointShader,
+      new PixelShader[Double] {
+        override def apply(triangleId: TriangleId,
+                           worldBCC: BarycentricCoordinates,
+                           screenCoordinates: Point[_3D]): Double = screen(pointShader(mesh.position(triangleId, worldBCC))).z
+      },
+      buffer)
+  }
+
+  /**
+    * Creates a Surface Property which tells on every point on the mesh surface its visibility according to the pointShader.
+    * Procedure:
+    * 1. Render surface coordinates with pointShader.
+    * 2. Because we want visibility of coordinates between two pixels, we interpolate between the pixels.
+    * 3. Compare if the z component of the mesh surface point is smaller than the z component of the corresponding rendered point.
+    * pt.z <= renderedPoint.z + offset
+    * An offset > 0 is necessary.
+    *
+    * boundaryAlwaysVisible:
+    * Problem: At mesh boundaries we interpolate the z value with the buffer bg value.
+    * Case 1, bgValue is NegativeInfinity: boundaryAlwaysVisible = false
+    * Interpolation yields always NegativeInfinity. Thus, the boundary pixels are always invisible.
+    * Case 2, bgValue is PositiveInfinity:
+    * Interpolation yields always PositiveInfinity, thus the boundary pixels are always visible.
+    *
+    * @param mesh                  mesh to render
+    * @param pointShader           called to to transform object space points to NDC in the cononical view volume
+    * @param pixelImageDomain      domain of buffer to evaluate visibility (sampled with a z buffer)
+    * @param offset                numerical z buffer value offset ~1e-3
+    * @param boundaryAlwaysVisible make boundary pixels (at occluding contours vs background) always visible
+    */
+  def visibilityAsSurfaceProperty(mesh: TriangleMesh[_3D],
+                                  pointShader: PointShader,
+                                  pixelImageDomain: PixelImageDomain,
+                                  offset: Double,
+                                  boundaryAlwaysVisible: Boolean): MeshSurfaceProperty[Boolean] = {
+    val zBufferImageDisc = renderDepthWindow(mesh, pointShader, ZBuffer[Double](pixelImageDomain.width, pixelImageDomain.height, if (boundaryAlwaysVisible) Double.PositiveInfinity else Double.NegativeInfinity)).toImage
+    val zBufferImage = zBufferImageDisc.interpolate
+    new MeshSurfaceProperty[Boolean] {
+      override def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): Boolean = {
+        val currentWorld = mesh.position(triangleId, bcc)
+        val currentVP = transformPoint(currentWorld, pointShader, pixelImageDomain)
+        val zBufferValue = zBufferImage(currentVP.x + 0.5, currentVP.y + 0.5)
+        currentVP.z <= zBufferValue + offset //these values are handpicked.
+      }
+
+      override def triangulation: TriangleList = mesh.triangulation
+    }
+  }
+
+  /** render an arbitrary mesh surface property as an image */
+  def renderPropertyImage[A: ClassTag](mesh: TriangleMesh[_3D],
+                                       pointShader: PointShader,
+                                       property: MeshSurfaceProperty[A],
+                                       width: Int,
+                                       height: Int): PixelImage[Option[A]] = {
+    renderProperty(mesh, pointShader, property, ZBuffer[Option[A]](width, height, None)).toImage
+  }
+
+  /** render a correspondence image for a given mesh into a new buffer, contains information about triangle rasterization */
+  def renderCorrespondenceImage(mesh: TriangleMesh[_3D], pointShader: PointShader, width: Int, height: Int): PixelImage[Option[TriangleFragment]] = {
+    renderCorrespondence(mesh, pointShader, ZBuffer[Option[TriangleFragment]](width, height, None)).toImage
+  }
+
+  /** render a point position in the given buffer domain using a point shader */
+  def transformPoint(point: Point[_3D], pointShader: PointShader, bufferDomain: PixelImageDomain): Point[_3D] = {
+    val screenTrafo = WindowTransform(bufferDomain.width, bufferDomain.height)
+    screenTrafo(pointShader(point))
+  }
+
+  /** render a point position in the given buffer domain using a point shader */
+  def transformPoint(point: Point[_3D], pointShader: PointShader, screenTrafo: Transform3D): Point[_3D] = {
+    screenTrafo(pointShader(point))
+  }
+}

--- a/src/main/scala/scalismo/faces/render/WindowTransform.scala
+++ b/src/main/scala/scalismo/faces/render/WindowTransform.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.geometry.{Point, Vector, _3D}
+
+/** transform a point from normalized coordinates [-1,1]x[-1,1]x[-1,1] to window coordinates [0,w]x[0,h]x[near,far] (y still upwards!) used by renderer */
+case class WindowTransform(width: Int, height: Int, near: Double = 0.0, far: Double = 1.0) extends InvertibleTransform3D {
+  override def apply(p: Point[_3D]): Point[_3D] = Point(
+    width / 2.0 * (p.x + 1.0),
+    height / 2.0 * (-p.y + 1.0),
+    (far - near) / 2.0 * p.z + (far + near) / 2.0
+  )
+
+  /** apply transform to a 3d vector */
+  override def apply(v: Vector[_3D]): Vector[_3D] = Vector(
+    width / 2.0 * (v.x + 1.0),
+    height / 2.0 * (-v.y + 1.0),
+    (far - near) / 2.0 * v.z + (far + near) / 2.0
+  )
+
+  /** inverted version of this transform */
+  override def inverted: InvertibleTransform3D = InverseWindowTransform(width, height, near, far)
+}
+
+/** inverse window transform: from [0,width]x[0,height]x[near,far] to [-1,1]x[-1,1]x[-1,1] */
+case class InverseWindowTransform(width: Int, height: Int, near: Double = 0.0, far: Double = 1.0) extends InvertibleTransform3D {
+  override def apply(x: Point[_3D]): Point[_3D] = Point(
+    x.x * 2.0 / width - 1,
+    - (x.y * 2.0 / height - 1),
+    (x.z - (far + near) / 2) * 2.0 / (far - near)
+  )
+
+  /** apply transform to a 3d vector */
+  override def apply(v: Vector[_3D]): Vector[_3D] = Vector(
+    v.x * 2.0 / width - 1,
+    - (v.y * 2.0 / height - 1),
+    (v.z - (far + near) / 2) * 2.0 / (far - near)
+  )
+
+  override def inverted: InvertibleTransform3D = WindowTransform(width, height, near, far)
+}
+
+
+/** Use for rendering only the contents within a defined bounding box.
+  * transforms a point from normalized coordinates [-1,1]x[-1,1]x[-1,1] to window coordinates [0,widthBox]x[0,heightBox]x[near,far] (y still upwards!)
+  *
+  * @param width of the full image
+  * @param height of the full image
+  * @param widthBox
+  * @param heightBox
+  * @param posX top right corner of box
+  * @param posY top right corner of box
+  * @param near
+  * @param far
+  */
+case class WindowBoxTransform(width: Int, height: Int, widthBox: Int, heightBox: Int, posX: Int, posY: Int, near: Double = 0.0, far: Double = 1.0) extends InvertibleTransform3D {
+
+  /**
+    * ratioWidth/Height: scales full image width to box width
+    */
+  val ratioWidth: Double = width.toDouble / widthBox.toDouble / 2.0
+  val ratioHeight: Double = height.toDouble / heightBox.toDouble / 2.0
+
+  /**
+    * box scaled normalized coordinates go from [-1*ratioWidth/2 to 1*ratioWidth/2]
+    * boxScaledCoords = ((posX.toDouble / width.toDouble)-0.5) * ratioWidth
+    * the box is located at (xInBoxScaledCoords, yInBoxScaleCoords)
+    */
+  val xInBoxScaledCoords: Double = (1.0 / widthBox.toDouble) * (posX.toDouble - width / 2.0)
+  val yInBoxScaledCoords: Double = (1.0 / heightBox.toDouble) * (posY.toDouble - height / 2.0)
+
+  override def apply(p: Point[_3D]): Point[_3D] = Point(
+    (p.x * ratioWidth - xInBoxScaledCoords) * widthBox,
+    (-p.y * ratioHeight - yInBoxScaledCoords) * heightBox,
+    (far - near) / 2.0 * p.z + (far + near) / 2.0 // z same as WindowTransform
+  )
+
+  override def apply(p: Vector[_3D]): Vector[_3D] = Vector(
+    (p.x * ratioWidth - xInBoxScaledCoords) * widthBox,
+    (-p.y * ratioHeight - yInBoxScaledCoords) * heightBox,
+    (far - near) / 2.0 * p.z + (far + near) / 2.0 // z same as WindowTransform
+  )
+
+  override def inverted: InverseWindowBoxTransform = InverseWindowBoxTransform(width, height, widthBox, heightBox, posX, posY, near, far)
+}
+
+case class InverseWindowBoxTransform(width: Int, height: Int, widthBox: Int, heightBox: Int, posX: Int, posY: Int, near: Double = 0.0, far: Double = 1.0) extends InvertibleTransform3D {
+  val ratioWidth: Double = width.toDouble / widthBox.toDouble / 2.0
+  val ratioHeight: Double = height.toDouble / heightBox.toDouble / 2.0
+  val xInBoxScaledCoords: Double = (1.0 / widthBox.toDouble) * (posX.toDouble - width / 2.0)
+  val yInBoxScaledCoords: Double = (1.0 / heightBox.toDouble) * (posY.toDouble - height / 2.0)
+
+  override def apply(p: Point[_3D]): Point[_3D] = Point(
+    (p.x / widthBox + xInBoxScaledCoords) / ratioWidth,
+    -(p.y / heightBox + yInBoxScaledCoords) / ratioHeight,
+    (p.z - (far + near) / 2) * 2.0 / (far - near) // z same as WindowTransform
+  )
+
+  override def apply(p: Vector[_3D]): Vector[_3D] = Vector(
+    (p.x / widthBox + xInBoxScaledCoords) / ratioWidth,
+    -(p.y / heightBox + yInBoxScaledCoords) / ratioHeight,
+    (p.z - (far + near) / 2) * 2.0 / (far - near) // z same as WindowTransform
+  )
+
+  override def inverted: WindowBoxTransform = WindowBoxTransform(width, height, widthBox, heightBox, posX, posY, near, far)
+}

--- a/src/test/scala/scalismo/faces/io/ParametersIOTests.scala
+++ b/src/test/scala/scalismo/faces/io/ParametersIOTests.scala
@@ -1,0 +1,409 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.io
+
+import java.io._
+import java.net.URI
+
+import scalismo.faces.FacesTestSuite
+import scalismo.faces.color.{RGB, RGBA}
+import scalismo.faces.image.PixelImageDomain
+import scalismo.faces.io.renderparameters.{RenderParameterJSONFormat, RenderParameterJSONFormatV4}
+import scalismo.faces.mesh._
+import scalismo.faces.parameters._
+import scalismo.faces.render._
+import scalismo.faces.utils.ResourceManagement
+import scalismo.geometry._
+import scalismo.mesh.SurfacePointProperty
+import spray.json._
+
+import scala.io.Source
+import scala.reflect.ClassTag
+
+class ParametersIOTests extends FacesTestSuite {
+
+  private def d = rnd.scalaRandom.nextDouble()
+  private def randomAngle(range: Double = 2 * math.Pi) = d * range
+  private def randomList(n: Int) = IndexedSeq.fill(n)(rnd.scalaRandom.nextGaussian())
+
+  def randomParameter(): RenderParameter = {
+    val w = rnd.scalaRandom.nextInt(2048)
+    val h = rnd.scalaRandom.nextInt(2048)
+    val n = rnd.scalaRandom.nextInt(400)
+
+    RenderParameter(
+      pose = Pose(
+        scaling = d * 2 + 1f,
+        translation = Vector(d * 100, d * 100, -10000 * d),
+        pitch = randomAngle(),
+        yaw = randomAngle(),
+        roll = randomAngle()),
+      view = ViewParameter(
+        translation = Vector(d * 100, d * 100, d * 1000),
+        pitch = randomAngle(),
+        yaw = randomAngle(),
+        roll = randomAngle()),
+      camera = Camera(
+        focalLength = d * 40,
+        principalPoint = Point(d * 2 - 1, d * 2 - 1),
+        sensorSize = Vector(d * 100, d * 100),
+        near = d * 0.1,
+        far = 1e12,
+        orthographic = rnd.scalaRandom.nextBoolean()),
+      environmentMap = SphericalHarmonicsLight(IndexedSeq.fill(9)(Vector(d, d, d))),
+      directionalLight = DirectionalLight.off,
+      momo = MoMoInstance(
+        shape = randomList(n),
+        color = randomList(n),
+        expression = randomList(n),
+        randomURI(20)),
+      imageSize = ImageSize(
+        width = w,
+        height = h),
+      colorTransform = ColorTransform(
+        gain = randomRGB,
+        colorContrast = d,
+        offset = randomRGB))
+  }
+
+  def vec2Close(v1: Vector[_2D], v2: Vector[_2D]): Unit = {
+    math.abs(v1.x - v2.x) should be < 1e-5
+    math.abs(v1.y - v2.y) should be < 1e-5
+  }
+
+  def cameraEqual(c1: Camera, c2: Camera): Unit = {
+    c1.far shouldBe c2.far
+    c1.focalLength shouldBe c2.focalLength
+    c1.near shouldBe c2.near
+    c1.orthographic shouldBe c2.orthographic
+    c1.principalPoint shouldBe c2.principalPoint
+    vec2Close(c1.sensorSize, c2.sensorSize)
+  }
+
+  def viewEqual(v1: ViewParameter, v2: ViewParameter): Unit = {
+    v1.pitch shouldBe v2.pitch
+    v1.roll shouldBe v2.roll
+    v1.yaw shouldBe v2.yaw
+    v1.translation shouldBe v2.translation
+  }
+
+  def identical(p1: RenderParameter, p2: RenderParameter): Unit = {
+    cameraEqual(p1.camera, p2.camera)
+    p1.colorTransform shouldBe p2.colorTransform
+    p1.momo shouldBe p2.momo
+    p1.imageSize shouldBe p2.imageSize
+    p1.environmentMap shouldBe p2.environmentMap
+    p1.directionalLight shouldBe p2.directionalLight
+    p1.pose shouldBe p2.pose
+    p1.view shouldBe p2.view
+  }
+
+  def writeReadTest[A: ClassTag](a: A)(implicit format: JsonFormat[A]): Unit = {
+    val tag = implicitly[ClassTag[A]]
+    it(s"consistently writes/reads ${tag.runtimeClass.getName}"){
+      a.toJson.convertTo[A] shouldBe a
+    }
+  }
+
+  // choose a random parameter for this test: "ensures" different values for each field
+  val randomParam: RenderParameter = randomParameter()
+
+  describe("RenderParameters JSON Formats V3") {
+
+    import scalismo.faces.io.renderparameters.RenderParameterJSONFormatV3._
+
+    describe("View parameterization") {
+      writeReadTest(ViewParameter(randomVector3D, randomDouble, randomDouble, randomDouble))
+    }
+
+    describe("RenderObject JSON format") {
+      val mesh: VertexColorMesh3D = randomGridMesh()
+
+      writeReadTest(MeshVertexColor(mesh))
+
+      writeReadTest(MeshColorNormals(ColorNormalMesh3D(mesh)))
+
+      writeReadTest(MeshFile(randomURI(10)))
+
+      writeReadTest(MoMoInstance(
+        shape = IndexedSeq.fill(10)(rnd.scalaRandom.nextDouble()),
+        color = IndexedSeq.fill(10)(rnd.scalaRandom.nextDouble()),
+        expression = IndexedSeq.empty,
+        modelURI = randomURI(10)))
+    }
+
+    describe("JSON format for MeshSurfaceProperties") {
+      val mesh: VertexColorMesh3D = randomGridMesh()
+      writeReadTest(mesh.color)
+
+      val textureMapping: SurfacePointProperty[Point[_2D]] = {
+        val boundingBox = mesh.shape.boundingBox
+        val ll = boundingBox.origin
+        val ex = boundingBox.extent
+
+        def pnorm(pt: Point[_3D]): Point[_2D] = {
+          val cent = pt - ll
+          Point(cent.x / ex.x, cent.y / ex.y)
+        }
+
+        val uvPoints = mesh.shape.pointSet.points.map{pnorm}.toIndexedSeq
+        SurfacePointProperty(mesh.shape.triangulation, uvPoints)
+      }
+
+      val colTex = TextureMappedProperty.fromSurfaceProperty(mesh.color, textureMapping, PixelImageDomain(10, 10), RGBA(1, 1, 0, 1))
+      writeReadTest(colTex)
+
+      val vcPerTriangle = VertexPropertyPerTriangle.fromPointProperty(mesh.shape.vertexNormals)
+      writeReadTest(vcPerTriangle)
+
+      val indirect = IndirectProperty(mesh.shape.triangulation, IndexedSeq.fill(mesh.shape.triangulation.triangles.length)(0), IndexedSeq(mesh.color))
+      writeReadTest(indirect)
+    }
+
+    describe("Illumination JSON format") {
+      writeReadTest(DirectionalLight(randomRGB, randomRGB, randomVector3D.normalize, randomRGB, rnd.scalaRandom.nextDouble()))
+      writeReadTest(randomParam.environmentMap)
+    }
+
+    describe("SceneParameter") {
+      it("can convert between RenderParameter and SceneParameter") {
+        val sp = SceneParameter(randomParam)
+        val rp = sp.toRenderParameter.get
+        rp shouldBe randomParam
+      }
+
+      it("can write/read a SceneParameter") {
+        val sp = SceneParameter(randomParam)
+
+        val f = File.createTempFile("ParametersIOTest", ".rps")
+        f.deleteOnExit()
+        ResourceManagement.using(new PrintWriter(new FileOutputStream(f))) { wr =>
+          wr.print(sp.toJson.prettyPrint)
+        }
+
+        val rsp = Source.fromFile(f).mkString.parseJson.convertTo[SceneParameter]
+        rsp shouldBe sp
+      }
+    }
+
+    describe("SceneTree") {
+      def randomPose() = Pose(randomDouble, randomVector3D, randomAngle() - math.Pi, randomAngle() - math.Pi, randomAngle() - math.Pi)
+
+      def checkTrafoEqual(t1: Transform3D, t2: Transform3D): Unit = {
+        def d() = 2 * rnd.scalaRandom.nextDouble() - 1
+        def randomPoint() = Point3D(d(), d(), d())
+        for(i <- 0 until 20) {
+          val p = randomPoint()
+          val v = p.toVector
+          t1(v) shouldBe t2(v)
+          t1(p) shouldBe t2(p)
+        }
+      }
+
+      def quaternionEqual(q1: Quaternion, q2: Quaternion): Unit = {
+        if (q1.r * q2.r >= 0) {
+          q1.r shouldBe q2.r +- 1e-14
+          (q1.v - q2.v).norm should be < 1e-14
+        } else
+          quaternionEqual(q1, -q2)
+      }
+
+      def rotationEqual(r1: Rotation3D, r2: Rotation3D): Unit = {
+        val q1 = r1.quaternion
+        val q2 = r2.quaternion
+        quaternionEqual(q1, q2)
+      }
+
+      def poseEqual(p1: Pose, p2: Pose): Unit = {
+        p1.translation shouldBe p2.translation
+        p1.scaling shouldBe p2.scaling +- 1e-14
+        val r1 = Rotation3D.fromEulerXYZ(p1.pitch, p1.yaw, p1.roll)
+        val r2 = Rotation3D.fromEulerXYZ(p2.pitch, p2.yaw, p2.roll)
+        rotationEqual(r1, r2)
+      }
+
+      it("random pose composes with neutral pose") {
+        val p1 = Pose.neutral
+        val p2 = randomPose()
+        poseEqual(p1 compose p2, p2)
+      }
+
+      it("rotation poses compose (yaw)") {
+        val p1 = Pose.neutral.copy(yaw = 0.5)
+        val p2 = Pose.neutral.copy(yaw = -0.25)
+        (p1 compose p2).yaw shouldBe 0.25 +- 1e-10
+      }
+
+      it("rotation poses compose (roll)") {
+        val p1 = Pose.neutral.copy(roll = 0.5)
+        val p2 = Pose.neutral.copy(roll = -0.25)
+        (p1 compose p2).roll shouldBe 0.25 +- 1e-10
+      }
+
+      it("rotation poses compose (pitch)") {
+        val p1 = Pose.neutral.copy(pitch = 0.5)
+        val p2 = Pose.neutral.copy(pitch = -0.25)
+        (p1 compose p2).pitch shouldBe 0.25 +- 1e-10
+      }
+
+      it("rotation poses compose (all)") {
+        val p1 = randomPose()
+        val p2 = randomPose()
+        val composed = p1 compose p2
+
+        // check with direct rotation composition
+        val r1 = Rotation3D.fromEulerXYZ(p1.pitch, p1.yaw, p1.roll)
+        val r2 = Rotation3D.fromEulerXYZ(p2.pitch, p2.yaw, p2.roll)
+        val rotationComposed = r1 compose r2
+        rotationEqual(Rotation3D.fromEulerXYZ(composed.pitch, composed.yaw, composed.roll), rotationComposed)
+      }
+
+      it("flattens the scene tree with the right transformations") {
+        val so = SceneObject(MeshVertexColor(randomGridMesh()))
+
+        val px = Pose.neutral.copy(translation = Vector3D.unitX)
+        val py = Pose.neutral.copy(translation = Vector3D.unitY)
+        val pz = Pose.neutral.copy(translation = Vector3D.unitZ)
+
+        val targetObjects: IndexedSeq[(Transform3D, RenderObject)] = IndexedSeq(
+          (px.transform compose py.transform compose pz.transform, so.renderObject),
+          (px.transform compose py.transform, so.renderObject),
+          (px.transform, so.renderObject)
+        )
+
+        val sp: SceneTree =
+          PoseNode(pose = px, children = IndexedSeq(
+            PoseNode(pose = py, children = IndexedSeq(
+              PoseNode(pose = pz, children = IndexedSeq(
+                so)),
+              so)),
+            so))
+
+        val posedObjects = sp.posedObjects
+
+        for{
+          ((pose, renderObject), (targetPose, targetObject)) <- posedObjects.zip(targetObjects)
+        }{
+          checkTrafoEqual(pose, targetPose)
+          renderObject shouldBe targetObject
+        }
+      }
+    }
+  }
+
+  describe("RenderParameters JSON Formats V4") {
+    import RenderParameterJSONFormat.version4._
+
+    describe("MoMoInstance JSON format") {
+      writeReadTest(MoMoInstance(
+        shape = IndexedSeq.fill(10)(rnd.scalaRandom.nextDouble()),
+        color = IndexedSeq.fill(10)(rnd.scalaRandom.nextDouble()),
+        expression = IndexedSeq.empty,
+        modelURI = randomURI(10)))
+    }
+  }
+
+  describe("Render Parameter JSON Reader") {
+
+    import RenderParameterJSONFormat.defaultFormat._
+
+    it("default format is V4.0") {
+      RenderParameterJSONFormat.defaultFormat shouldBe RenderParameterJSONFormatV4
+    }
+
+    it("reader can read spray json (versioned dispatcher)") {
+      val jstr = randomParam.toJson
+      val pRead = jstr.convertTo[RenderParameter]
+      identical(pRead, randomParam)
+    }
+
+    // explicit json to parse with target
+    val targetParam = RenderParameter(
+      view = ViewParameter(
+        translation = Vector(10.0, 20.0, 2000.0),
+        pitch = 0.75,
+        roll = -0.125,
+        yaw = 1.5),
+      camera = Camera(
+        far = 100000.0,
+        focalLength = 50.0,
+        near = 1.0,
+        orthographic = false,
+        principalPoint = Point(0.005555555555555556, -0.016666666666666666),
+        sensorSize = Vector(36.0, 24.0)),
+      colorTransform = ColorTransform(RGB(1.0, 0.5, 0.25), 1.0, RGB(0.25, 0.125, 0.75)),
+      environmentMap = SphericalHarmonicsLight(IndexedSeq(Vector(0.5, 0.25, 0.125), Vector(0.125, 0.25, 0.5), Vector(0.25, 0.5, 0.125), Vector(0.5, 0.125, 0.25))),
+      directionalLight = DirectionalLight(RGB.Black, RGB.Black, Vector3D.unitZ, RGB.Black, 10.0),
+      imageSize = ImageSize(width = 720, height = 480),
+      momo = MoMoInstance(IndexedSeq(-1.0, 0.5, -0.25), IndexedSeq(1.0, 0.0, 0.5), IndexedSeq(), new URI("modelPath1")),
+      pose = Pose(1.0, Vector(0.0, 0.0, -1000.0), roll = 0.125, yaw = -0.125, pitch = 0.25))
+
+    def readResourceAsString(resource: String): String = {
+      Source.fromURL(this.getClass.getResource("/" + resource)).toString()
+    }
+
+    it("can be written to and read from a stream") {
+      val os = new ByteArrayOutputStream()
+      RenderParameterIO.writeToStream(randomParam, os).get
+      val is = new ByteArrayInputStream(os.toByteArray)
+      val readParam = RenderParameterIO.readFromStream(is).get
+      identical(readParam, randomParam)
+    }
+
+    it("can read old C++ json") {
+      import RenderParameterJSONFormat.version1._
+      val cxxParam = Source.fromURL(this.getClass.getResource("/renderParametersV1.rps")).mkString.parseJson.convertTo[RenderParameter]
+      cxxParam shouldBe targetParam
+    }
+
+    it("can read V2 example json") {
+      import RenderParameterJSONFormat.version2._
+      val v2Param = Source.fromURL(this.getClass.getResource("/renderParametersV2.rps")).mkString.parseJson.convertTo[RenderParameter]
+      v2Param shouldBe targetParam
+    }
+
+    it("can read V3 example json") {
+      import RenderParameterJSONFormat.version3._
+      val v3Param = Source.fromURL(this.getClass.getResource("/renderParametersV3.rps")).mkString.parseJson.convertTo[RenderParameter]
+      v3Param shouldBe targetParam
+    }
+
+    it("can read V4 example json") {
+      import RenderParameterJSONFormat.version4._
+      val v4Param = Source.fromURL(this.getClass.getResource("/renderParametersV4.rps")).mkString.parseJson.convertTo[RenderParameter]
+      v4Param shouldBe targetParam
+    }
+
+    it("can be written to and read from a file") {
+      val f = File.createTempFile("ParameterIOTest", ".rps")
+      f.deleteOnExit()
+      RenderParameterIO.write(randomParam, f).get
+      val readParam = RenderParameterIO.read(f).get
+      identical(readParam, randomParam)
+    }
+
+    it("can be written to and read from a file at a certain path") {
+      val path = IndexedSeq.fill(4){rnd.scalaRandom.alphanumeric.take(6).mkString("")}.mkString("/")
+      val f = File.createTempFile("ParameterIOTest", ".rps")
+      f.deleteOnExit()
+      RenderParameterIO.writeWithPath(randomParam, f, path).get
+      val readParam = RenderParameterIO.readWithPath[RenderParameter](f, path).get
+      identical(readParam, randomParam)
+    }
+
+  }
+}

--- a/src/test/scala/scalismo/faces/parameters/MoMoInstanceTest.scala
+++ b/src/test/scala/scalismo/faces/parameters/MoMoInstanceTest.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import java.net.URI
+
+import scalismo.faces.FacesTestSuite
+import scalismo.faces.momo.MoMoCoefficients
+
+class MoMoInstanceTest extends FacesTestSuite {
+
+  describe("A MoMoInstance") {
+
+    it("can be created empty") {
+      val emptyInstance = MoMoInstance.empty
+      assert(emptyInstance.shape.isEmpty)
+      assert(emptyInstance.color.isEmpty)
+      assert(emptyInstance.expression.isEmpty)
+      assert(emptyInstance.modelURI.toString.isEmpty)
+    }
+
+    it("can deliver MoMoCoefficients with the same coefficient numbers") {
+      val shapeCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+      val colorCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+      val expressionCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+
+      val instance = MoMoInstance(shapeCoeffs, colorCoeffs, expressionCoeffs, new URI(""))
+      val coeffs = instance.coefficients
+      coeffs.shape.toArray should contain theSameElementsInOrderAs shapeCoeffs
+      coeffs.color.toArray should contain theSameElementsInOrderAs colorCoeffs
+      coeffs.expression.toArray should contain theSameElementsInOrderAs expressionCoeffs
+    }
+
+    it("can be constructed from MoMoCoefficients with the same coefficient numbers") {
+      val shapeCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+      val colorCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+      val expressionCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+
+      val coeffs = MoMoCoefficients(shapeCoeffs, colorCoeffs, expressionCoeffs)
+      val momoInstance = MoMoInstance.fromCoefficients(coeffs, new URI("protocol://randomURI"))
+      momoInstance.shape should contain theSameElementsInOrderAs shapeCoeffs
+      momoInstance.color should contain theSameElementsInOrderAs colorCoeffs
+      momoInstance.expression should contain theSameElementsInOrderAs expressionCoeffs
+      momoInstance.modelURI shouldBe new URI("protocol://randomURI")
+    }
+
+    it("can be constructed with a specified size") {
+      val momoInstance = MoMoInstance.zero(3, 7, 9, new URI("protocol://randomURI"))
+      momoInstance.shape.length shouldBe 3
+      momoInstance.color.length shouldBe 7
+      momoInstance.expression.length shouldBe 9
+      momoInstance.modelURI shouldBe new URI("protocol://randomURI")
+    }
+
+    it("can be resized to a smaller size, keeping its valid entries") {
+      val shapeCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+      val colorCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+      val expressionCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+
+      val instance = MoMoInstance(shapeCoeffs, colorCoeffs, expressionCoeffs, new URI(""))
+      val smallerInstance = instance.withNumberOfCoefficients(3, 3, 3)
+      smallerInstance.shape.length shouldBe 3
+      smallerInstance.color.length shouldBe 3
+      smallerInstance.expression.length shouldBe 3
+      smallerInstance.shape should contain theSameElementsInOrderAs shapeCoeffs.take(3)
+      smallerInstance.color should contain theSameElementsInOrderAs colorCoeffs.take(3)
+      smallerInstance.expression should contain theSameElementsInOrderAs expressionCoeffs.take(3)
+    }
+
+    it("can be resized to a larger size, keeping its entries") {
+      val shapeCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+      val colorCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+      val expressionCoeffs = IndexedSeq.fill(5)(rnd.scalaRandom.nextGaussian())
+
+      val instance = MoMoInstance(shapeCoeffs, colorCoeffs, expressionCoeffs, new URI(""))
+      val largerInstance = instance.withNumberOfCoefficients(7, 7, 7)
+      largerInstance.shape.length shouldBe 7
+      largerInstance.color.length shouldBe 7
+      largerInstance.expression.length shouldBe 7
+
+      largerInstance.shape.take(5) should contain theSameElementsInOrderAs shapeCoeffs
+      largerInstance.color.take(5) should contain theSameElementsInOrderAs colorCoeffs
+      largerInstance.expression.take(5) should contain theSameElementsInOrderAs expressionCoeffs
+
+      largerInstance.shape.slice(5, 7) should contain theSameElementsInOrderAs Seq(0.0, 0.0)
+      largerInstance.color.slice(5, 7) should contain theSameElementsInOrderAs Seq(0.0, 0.0)
+      largerInstance.expression.slice(5, 7) should contain theSameElementsInOrderAs Seq(0.0, 0.0)
+    }
+
+  }
+}

--- a/src/test/scala/scalismo/faces/parameters/RenderParameterTest.scala
+++ b/src/test/scala/scalismo/faces/parameters/RenderParameterTest.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import scalismo.faces.FacesTestSuite
+
+class RenderParameterTest extends FacesTestSuite {
+
+  describe("RenderParameters") {
+    it("provide a defaultSquare setting with 9 spherical harmonics coefficients") {
+      val init = RenderParameter.defaultSquare
+      init.environmentMap.coefficients.length shouldBe 9
+    }
+
+    it("provide a default setting with 9 spherical harmonics coefficients") {
+      val init = RenderParameter.default
+      init.environmentMap.coefficients.length shouldBe 9
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
+++ b/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.parameters
+
+import scalismo.faces.FacesTestSuite
+import scalismo.faces.color.RGB
+import scalismo.geometry.{Vector, Vector3D, _3D}
+
+class SphericalHarmonicsLightTests extends FacesTestSuite {
+
+  describe("SphericalHarmonicsLight parameters") {
+    it("can be constructed with specific number of bands") {
+      val sh5 = SphericalHarmonicsLight.zero(5)
+      sh5.bands shouldBe 5
+      sh5.coefficients.length shouldBe SphericalHarmonicsLight.coefficientsInBands(5)
+    }
+
+    it("can be rescaled to more components") {
+      val sh = SphericalHarmonicsLight.frontal
+      assert(sh.bands == 1)
+
+      val band2 = sh.withNumberOfBands(2)
+      band2.coefficients.length shouldBe 9
+      band2.bands shouldBe 2
+
+      band2.coefficients.take(4) shouldBe sh.coefficients
+      band2.coefficients.drop(4) shouldBe IndexedSeq.fill(5)(Vector3D.zero)
+    }
+
+    it("can be rescaled to fewer components") {
+      val sh = SphericalHarmonicsLight.frontal
+      assert(sh.bands == 1)
+
+      val band0 = sh.withNumberOfBands(0)
+      band0.coefficients.length shouldBe 1
+      band0.bands shouldBe 0
+
+      band0.coefficients(0) shouldBe sh.coefficients(0)
+    }
+
+    describe("To recover a principal direction of illumination, SphericalHarmonicsLight") {
+      it("extracts consistently the direction from randomly generated directed spherical harmonics.") {
+
+        /** Measures direction discrepancy between fromAmbientDiffuse and directionFromSH.
+          * Creates directed illuminations for random directions with fromAmbientDiffuse and solves for the direction with directionFromSH. */
+        def testDirectionFromSH(eps: Double, repeat: Int): Boolean = {
+          def genDirLight(v: Vector[_3D]) = SphericalHarmonicsLight.fromAmbientDiffuse(RGB(rnd.scalaRandom.nextDouble(), rnd.scalaRandom.nextDouble(), rnd.scalaRandom.nextDouble()), RGB(rnd.scalaRandom.nextDouble(), rnd.scalaRandom.nextDouble(), rnd.scalaRandom.nextDouble()), v)
+          def randDirection = Vector.fromSpherical(1.0, rnd.scalaRandom.nextDouble() * math.Pi, rnd.scalaRandom.nextDouble() * math.Pi * 2.0)//non-uniform on the sphere! Does not matter for the test.
+          (0 until repeat).forall { _ =>
+            val v = randDirection.normalize
+            val rec = SphericalHarmonicsLight.directionFromSHLightIntensity(genDirLight(v))
+            if(rec.isDefined) { // if we find a direction
+            val d = (v - rec.get).norm
+              d < eps
+            }else // if no direction is found. Should always find a direction in this test.
+              false
+          }
+        }
+
+        testDirectionFromSH(1e-14, 50) shouldBe true
+      }
+
+      it("gives sensible results for undirected SHL.") {
+        val rec = SphericalHarmonicsLight.directionFromSHLightIntensity(SphericalHarmonicsLight.ambientWhite)
+        rec.isDefined shouldBe false
+      }
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/render/ProjectionTests.scala
+++ b/src/test/scala/scalismo/faces/render/ProjectionTests.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import breeze.linalg.DenseVector
+import scalismo.faces.FacesTestSuite
+import scalismo.geometry.{Point, Vector, _2D, _3D}
+
+class ProjectionTests extends FacesTestSuite {
+
+  val frustum: Frustum = Frustum.fromFocalWithSensor(50, Vector(35, 26), 0.5e3, 50e3)
+
+  def p2d(p: Point[_3D]): Point[_2D] = Point(p.x, p.y)
+
+  describe("A Frustum") {
+    // simple frustum
+    val fr = Frustum(-1, 1, -1, 1, 1, 3)
+    val Frustum(l, r, b, t, n, f) = fr
+
+    val x3d = Point(0.5, -0.5, -2)
+
+    it("should lead to a known and valid pinhole projection") {
+      val p = FrustumPinholeProjection(fr)
+      val x3dp = p(x3d)
+      x3dp shouldBe Point(0.25, -0.25, 0.5)
+    }
+
+    it("should lead to a known and valid orthographic projection") {
+      val p = FrustumOrthographicProjection(fr)
+      val x3dp = p(x3d)
+      x3dp shouldBe Point(0.5, -0.5, 0.0)
+    }
+
+    it("can be scaled") {
+      val sF = fr.scale(0.3, 1.5)
+      sF shouldBe Frustum(l * 0.3, r * 0.3, b * 1.5, t * 1.5, n, f)
+    }
+
+    it("can change its near clipping plane without affecting the transformation") {
+      val nF = fr.copy(far = 100).withNear(10)
+      val p = FrustumPinholeProjection(fr)
+      val nP = FrustumPinholeProjection(nF)
+      p2d(nP(x3d)) shouldBe p2d(p(x3d))
+    }
+
+    describe("should be movable off-center") {
+      val c = Point(rnd.scalaRandom.nextDouble() * 2 - 1, rnd.scalaRandom.nextDouble() * 2 - 1)
+      val ocF = fr.withCenter(c)
+
+      it("with a proper new center") {
+        val vCenter = ocF.center
+        vCenter shouldBe c
+      }
+
+      it("with shifted projections") {
+        val ph = FrustumPinholeProjection(fr)
+        val or = FrustumOrthographicProjection(fr)
+        val ocph = FrustumPinholeProjection(ocF)
+        val ocor = FrustumOrthographicProjection(ocF)
+        val xph = ph(x3d)
+        val xor = or(x3d)
+        val xocph = ocph(x3d)
+        val xocor = ocor(x3d)
+        p2d(xocor) - c.toVector shouldBe p2d(xor)
+        p2d(xocph) - c.toVector shouldBe p2d(xph)
+      }
+
+      it("can be re-centered") {
+        ocF.centered shouldBe fr
+      }
+    }
+  }
+
+  describe("FrustumPinholeProjection") {
+    val p = FrustumPinholeProjection(frustum)
+
+    it("is properly inverted") {
+      val x3d = Point(rnd.scalaRandom.nextDouble() * 1e3, rnd.scalaRandom.nextDouble() * 1e3, rnd.scalaRandom.nextDouble() * 10e3 + 1e3)
+      val x3dp = p.inverse(p(x3d))
+      (x3d - x3dp).norm should be < 1.0
+    }
+
+    it("works properly for known points") {
+      val pointsWithTarget = IndexedSeq(
+        (Point(0f, 0f, -2e3), Point(0f, 0f, 0.515151515)),
+        (Point(100f, -50f, -1.5e3), Point(0.1904762, -0.12820514, 0.34680134))
+      )
+      pointsWithTarget.foreach {
+        case (x, target) =>
+          (p(x) - target).norm should be < 1.0
+      }
+    }
+
+    it("provides a result which is consistent with homogeneous coordinates") {
+      val m4 = p.matrix4
+      val x = Point(rnd.scalaRandom.nextDouble() * 1e3, rnd.scalaRandom.nextDouble() * 1e3, rnd.scalaRandom.nextDouble() * 10e3 + 1e3)
+      val xh: DenseVector[Double] = DenseVector(x.x, x.y, x.z, 1.0)
+      val xhp: DenseVector[Double] = m4 * xh
+      val xp = Point(xhp(0) / xhp(3), xhp(1) / xhp(3), xhp(2) / xhp(3))
+      (p(x) - xp).norm should be < 1.0
+    }
+  }
+
+  describe("FrustumOrthographicProjection") {
+    val p = FrustumOrthographicProjection(frustum)
+
+    it("is properly inverted") {
+      val x3d = Point(rnd.scalaRandom.nextDouble() * 1e3, rnd.scalaRandom.nextDouble() * 1e3, rnd.scalaRandom.nextDouble() * 10e3 + 1e3)
+      val x3dp = p.inverse(p(x3d))
+      (x3d - x3dp).norm should be < 1.0
+    }
+
+    it("works properly for known points") {
+      val pointsWithTarget = IndexedSeq(
+        (Point(0f, 0f, -2e3), Point(0.0, 0.0, -0.93939394)),
+        (Point(100f, -50f, -1.5e3), Point(0.5714286, -0.3846154, -0.959596))
+      )
+
+      val projected = pointsWithTarget.map(x => (p(x._1), x._2))
+
+      projected.foreach {
+        case (x, px) =>
+          (x - px).norm should be < 1.0
+      }
+    }
+
+    it("provides a result which is consistent with homogeneous coordinates") {
+      val m4 = p.matrix4
+      val x = Point(rnd.scalaRandom.nextDouble() * 1e3, rnd.scalaRandom.nextDouble() * 1e3, rnd.scalaRandom.nextDouble() * 10e3 + 1e3)
+      val xh: DenseVector[Double] = DenseVector(x.x, x.y, x.z, 1.0)
+      val xhp: DenseVector[Double] = m4 * xh
+      val xp = Point(xhp(0) / xhp(3), xhp(1) / xhp(3), xhp(2) / xhp(3))
+      (p(x) - xp).norm should be < 1.0
+    }
+
+    it("gives an identical x,y result as the projective projection at a constant depth (and adjusted frustum)") {
+      val z = -1.5e3
+      val fp = frustum.closestOrthographic(math.abs(z))
+
+      val perspP = FrustumPinholeProjection(frustum)
+      val closestP = FrustumOrthographicProjection(fp)
+
+      val x = Point(10f, -5f, -1.5e3)
+
+      val pxPersp = perspP(x)
+      val pxOrtho = closestP(x)
+
+      (p2d(pxPersp) - p2d(pxOrtho)).norm should be < 1.0
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/render/TextureExtractionTests.scala
+++ b/src/test/scala/scalismo/faces/render/TextureExtractionTests.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.faces.FacesTestSuite
+import scalismo.faces.color.{RGB, RGBA}
+import scalismo.faces.image.InterpolationKernel.BilinearKernel
+import scalismo.faces.image.PixelImage
+import scalismo.faces.mesh.{ColorNormalMesh3D, TextureMappedProperty}
+import scalismo.faces.parameters.{Camera, Pose, RenderParameter}
+import scalismo.faces.render.PixelShaders.PropertyShader
+import scalismo.geometry.Vector
+import scalismo.mesh.{MeshSurfaceProperty, SurfacePointProperty, TriangleMesh3D}
+
+class TextureExtractionTests extends FacesTestSuite {
+  import scalismo.faces.image.PixelImage.implicits._
+
+  val w = 100
+  val h = 100
+
+  val texW = 123
+  val texH = 91
+
+  val gridMesh: ColorNormalMesh3D = randomGridMeshWithTexture(200, 200)
+  val mesh: TriangleMesh3D = gridMesh.shape
+  val vertexColor: SurfacePointProperty[RGBA] = SurfacePointProperty.averagedPointProperty(gridMesh.color)
+  val texture: TextureMappedProperty[RGBA] = gridMesh.color.asInstanceOf[TextureMappedProperty[RGBA]]
+
+  val texImage: PixelImage[RGBA] = texture.texture
+  val rndTexture: PixelImage[RGBA] = PixelImage(texImage.width / 20, texImage.height / 20, (x, y) => randomRGBA).resample(texImage.width, texImage.height, BilinearKernel)
+
+  val rps: RenderParameter = RenderParameter.default.copy(
+    camera = Camera.for35mmFilm(focalLength = 100),
+    pose = Pose.neutral.copy(translation = Vector(-100, -100, -1000))).noLightAndColor
+
+  val renderedImage: PixelImage[RGBA] = TriangleRenderer.renderMesh(mesh, rps.pointShader, PropertyShader(texture), ZBuffer[RGBA](rps.imageSize.width, rps.imageSize.height, RGBA(1, 0, 1, 0))).toImage
+
+  val frustum = Frustum(-1, 1, -1, 1, 0.1, 2)
+  val perspP = FrustumPinholeProjection(frustum)
+  val pointShaderPP: PointShader = perspP.pointShader(Transform3D.identity)
+  val orthoP = FrustumOrthographicProjection(frustum)
+  val pointShaderOP: PointShader = orthoP.pointShader(Transform3D.identity)
+
+  def imDiffRGB(img1: PixelImage[RGB], img2: PixelImage[RGB]): Double = (img1 - img2).norm
+
+  def imDiffRGBA(img1: PixelImage[RGBA], img2: PixelImage[RGBA]): Double = {
+    val diff = PixelImage(img1.width, img1.height, (x, y) => (img1(x, y).a * img2(x, y).a) *: (img1(x, y) - img2(x, y)))
+    diff.norm
+  }
+
+  describe("TextureExtractionTests") {
+    // make random image
+    val rndImage: PixelImage[RGBA] = randomImage(rps.imageSize.width / 10, rps.imageSize.height / 10).resample(rps.imageSize.width, rps.imageSize.height).mapLazy(_.toRGBA)
+
+    // imageAsSurfaceProperty
+    it("should extract and re-render an image as surface property consistently") {
+      // extract texture as surface property
+      val imageAsSurfaceProp: MeshSurfaceProperty[RGBA] = TextureExtraction.imageAsSurfaceProperty(mesh, rps.pointShader, rndImage).map(_.getOrElse(RGBA(1, 1, 0, 0)))
+      // render extracted texture as surface property
+      val rendImageAsProperty = TriangleRenderer.renderMesh(mesh, rps.pointShader, PropertyShader(imageAsSurfaceProp), rps.imageSize.zBuffer(RGBA.BlackTransparent)).toImage
+      // images should match
+      imDiffRGBA(rendImageAsProperty, rndImage) should be < 1.0
+    }
+
+    // imageAsTexture
+    it("should use the image as a texture using the rendered points as texture mapping and re-render consistently") {
+      // extract texture
+      val imageAsTexture: TextureMappedProperty[RGBA] = TextureExtraction.imageAsTexture(mesh, rps.pointShader, rndImage)
+      // render with given texture
+      val rendImageAsTexture = TriangleRenderer.renderMesh(mesh, rps.pointShader, PropertyShader(imageAsTexture), rps.imageSize.zBuffer(RGBA.BlackTransparent)).toImage
+      // images should match
+      imDiffRGBA(rendImageAsTexture, rndImage) should be < 1.0
+    }
+
+    // sample TextureMappedProperty from imageAsSurface property
+    it("should extract an image as surface property, raster it into a texture map representation and re-render it consistently") {
+      // extract texture as surface property
+      val imageAsSurfaceProp: MeshSurfaceProperty[RGBA] = TextureExtraction.imageAsSurfaceProperty(mesh, rps.pointShader, rndImage).map(_.getOrElse(RGBA(1, 1, 0, 1)))
+      // texture map representation
+      val tex = TextureMappedProperty.fromSurfaceProperty(imageAsSurfaceProp, texture.textureMapping, texture.texture.domain, RGBA(0, 1, 0, 1))
+      // render extracted texture as surface property
+      val rendImageTex = TriangleRenderer.renderMesh(mesh, rps.pointShader, PropertyShader(tex), rps.imageSize.zBuffer(RGBA.BlackTransparent)).toImage
+      // images should match
+      imDiffRGBA(rendImageTex, rndImage) should be < 32.0
+    }
+
+    // sample TextureMappedProperty from imageAsSurface property
+    it("should extract an image as texture, raster it into a texture map representation and re-render it consistently") {
+      // extract texture as surface property
+      val imageAsTexture: MeshSurfaceProperty[RGBA] = TextureExtraction.imageAsTexture(mesh, rps.pointShader, rndImage)
+      // texture map representation
+      val tex: TextureMappedProperty[RGBA] = TextureMappedProperty.fromSurfaceProperty(imageAsTexture, texture.textureMapping, texture.texture.domain, RGBA(0, 1, 0, 1))
+      // render extracted texture as surface property
+      val rendImageTex = TriangleRenderer.renderMesh(mesh, rps.pointShader, PropertyShader(tex), rps.imageSize.zBuffer(RGBA.BlackTransparent)).toImage
+      // images should match
+      imDiffRGBA(rendImageTex, rndImage) should be < 30.0
+    }
+
+    // extractTextureAsImage
+    it("should extract and re-render an image into a texture map representation consistently") {
+      // extract texture image
+      val texImg = TextureExtraction.extractTextureAsImage(mesh, rps.pointShader, rndImage, texture.texture.domain, texture.textureMapping).map(_.getOrElse(RGBA(1, 1, 0, 1)))
+      // render extracted texture
+      val tex = texture.copy(texture = texImg)
+      val rendImageTexEx = TriangleRenderer.renderMesh(mesh, rps.pointShader, PropertyShader(tex), rps.imageSize.zBuffer(RGBA.BlackTransparent)).toImage
+      // images should match
+      imDiffRGBA(rendImageTexEx, rndImage) should be < 32.0
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/render/TransformationTests.scala
+++ b/src/test/scala/scalismo/faces/render/TransformationTests.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.render
+
+import scalismo.faces.FacesTestSuite
+import scalismo.faces.color.RGBA
+import scalismo.faces.image.{PixelImage, PixelImageOperations}
+import scalismo.faces.parameters.RenderParameter
+import scalismo.geometry._
+
+class TransformationTests extends FacesTestSuite {
+  describe("decompose rotation around unit vectors with random angles") {
+    it("decomposes corectly with angles from -pi/2 to pi/2") {
+      def randomEulerDifference() = {
+        val x = (rnd.scalaRandom.nextDouble() - 0.5) * math.Pi
+        val y = (rnd.scalaRandom.nextDouble() - 0.5) * math.Pi
+        val z = (rnd.scalaRandom.nextDouble() - 0.5) * math.Pi
+        val dec = Rotation3D.decomposeRotationXYZ(Rotation3D.fromEulerXYZ(x, y, z))
+        val diff = Vector(x, y, z) - Vector(dec._1, dec._2, dec._3)
+        val res = diff.x + diff.y + diff.z
+        res
+      }
+      val differences = IndexedSeq.fill(1000)(randomEulerDifference())
+      all(differences) should be < 1e-3
+    }
+
+    it("composes correctly with angles from -2pi to 2pi") {
+      def randomEulerMatrixDifference(): Double = {
+        val x = (rnd.scalaRandom.nextDouble() - 0.5) * 4.0 * math.Pi
+        val y = (rnd.scalaRandom.nextDouble() - 0.5) * 4.0 * math.Pi
+        val z = (rnd.scalaRandom.nextDouble() - 0.5) * 4.0 * math.Pi
+        val rot = Rotation3D.fromEulerXYZ(x, y, z)
+        val decrot = Rotation3D.decomposeRotationXYZ(rot)
+        val rotA = rot.rotationMatrix
+        val rotB = (Rotation3D.fromEulerXYZ _).tupled(decrot).rotationMatrix
+        val diff = (0 until 3).zip(0 until 3).map((idx) => rotA(idx._1, idx._2) - rotB(idx._1, idx._2))
+        val res = diff.sum
+        res
+      }
+      val differences = IndexedSeq.fill(1000)(randomEulerMatrixDifference())
+      all(differences) should be < 1e-3
+    }
+  }
+
+  def isClose(p: Point[_3D], q: Point[_3D], tolerance: Double = 1e-5): Boolean = (p - q).norm < tolerance
+
+  describe("view lookAt transform") {
+    val origin = Point3D.origin
+    val x = Point(1.0, 2.0, 3.0)
+    val y = Point(1.0, 1.0, 3.0)
+    it("centers on correct point") {
+      val vT = RenderTransforms.viewTransformLookAt(origin, x, Vector3D.unitY)
+      val d = x.toVector.norm
+      isClose(vT(x), Point(0.0, 0.0, -d)) shouldBe true
+    }
+
+    it("respects upright vector direction") {
+      val vT = RenderTransforms.viewTransformLookAt(origin, x.copy(y = 0), -Vector3D.unitY)
+      val d = x.toVector.norm
+      vT(x).y shouldBe -2.0
+      vT(y).y shouldBe -1.0
+    }
+
+    it("moves the camera and looks back") {
+      val vT = RenderTransforms.viewTransformLookAt(x, origin, Vector3D.unitY)
+      val d = x.toVector.norm
+      isClose(vT(origin), Point(0.0, 0.0, -d)) shouldBe true
+      isClose(vT(x), origin) shouldBe true
+    }
+  }
+
+  describe("window transform") {
+
+    def within(a: Double, b: Double, eps: Double) = math.abs(a-b) < eps
+    def pointWithin(a: Point[_3D], b: Point[_3D], eps: Double) = within(a.x, b.x, eps) && within(a.y, b.y, eps) && within(a.z, b.z, eps)
+
+    it("is inverted correctly") {
+
+      def transformationRoundTripConsistent = {
+        val trf = WindowBoxTransform(100, 100, 10, 10, 60, 70)
+        val itrf = InverseWindowBoxTransform(100, 100, 10, 10, 60, 70)
+
+        val points = IndexedSeq(Point(-1, -1, -1), Point(0.2, 0.4, -1), Point(0.11, 0.21, -1))
+        def testPoint(pt: Point[_3D]) = {
+          pointWithin(pt, itrf(trf(pt)), 1e-10)
+        }
+        val result = testPoint _
+        points.forall(result)
+      }
+
+      transformationRoundTripConsistent shouldBe true
+    }
+
+    it("results in a correct rendering") {
+
+      def renderedImageSameAsExtractedBox() = {
+        val param = RenderParameter.defaultSquare
+        val mesh = randomGridMesh(100, 100, 0.25)
+        val rendering =  {
+          val buffer = ZBuffer(param.imageSize.width, param.imageSize.height, RGBA.BlackTransparent)
+          TriangleRenderer.renderMesh(mesh.shape, param.pointShader, PixelShaders.PropertyShader(mesh.color), buffer)
+          buffer.toImage
+        }
+        //define box
+        val (x, y) = (350, 150)
+        val (w, h) = (20, 20)
+        val trfScreen = WindowBoxTransform(param.imageSize.width, param.imageSize.height, w, h, x, y)
+        val renderingBox =  {
+          val buffer = ZBuffer(w, h, RGBA.BlackTransparent)
+          TriangleRenderer.renderMesh(mesh.shape, param.pointShader, trfScreen, PixelShaders.PropertyShader(mesh.color), buffer)
+          buffer.toImage
+        }
+        val groundTruth = PixelImageOperations.subImage(rendering, x, y, w, h)
+
+        import PixelImage.implicits._
+        val diff = PixelImageOperations.imageNorm(groundTruth - renderingBox)
+        diff < 1e-9
+      }
+
+      renderedImageSameAsExtractedBox() shouldBe true
+    }
+  }
+
+}


### PR DESCRIPTION
Code to render meshes with various reflectance models and mainly Spherical Harmonics encoded environment maps. This is required to fit the model to images later and to visualize meshes and create images.

The basic structure is built around `TriangleRenderer` and the classes `PointShader` (geometric transform to image) and `PixelShader` (color/shading/value to put in image). For details refer to our tutorial about Probabilistic fitting which is coming soon.

The renderer includes a parametrization of our most-often used fitting scene with `RenderParameter`.

Includes IO and some tests.

Also resolves #14, resolves #15, resolves #18
