### PR TITLE
Fitting code added

### DIFF
--- a/src/main/scala/scalismo/faces/deluminate/SphericalHarmonicsOptimizer.scala
+++ b/src/main/scala/scalismo/faces/deluminate/SphericalHarmonicsOptimizer.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.deluminate
+
+import scalismo.faces.color.RGBA
+import scalismo.faces.deluminate.SphericalHarmonicsSolver.IlluminatedPoint
+import scalismo.faces.image.PixelImage
+import scalismo.faces.mesh.VertexColorMesh3D
+import scalismo.faces.parameters.{RenderParameter, SphericalHarmonicsLight}
+import scalismo.faces.render.{ColorTransform, TextureExtraction}
+import scalismo.faces.sampling.face.ParametricModel
+import scalismo.geometry.{Vector, _3D}
+import scalismo.mesh.{BarycentricCoordinates, MeshSurfaceProperty, TriangleId, TriangleMesh3D}
+import scalismo.utils.Random
+
+/** wrap Spherical Harmonics illumination solver in parametric rendering framework */
+class SphericalHarmonicsOptimizer(val renderer: ParametricModel,
+                                  val targetImage: PixelImage[RGBA])(implicit val rnd: Random) {
+
+  private def targetAsSurfaceProperty(rps: RenderParameter): MeshSurfaceProperty[Option[RGBA]] = {
+    TextureExtraction.imageAsSurfaceProperty(renderer.instance(rps).shape, rps.pointShader, targetImage)
+  }
+
+  /**
+    * We solve for the environment map given the target radiance, Albedo and Normals.
+    * We go after a subset of surface points only.
+    */
+  def optimize(rps: RenderParameter,
+               surfacePointsSampler: TriangleMesh3D => IndexedSeq[(TriangleId, BarycentricCoordinates)]): SphericalHarmonicsLight = {
+    val mesh: VertexColorMesh3D = renderer.instance(rps)
+    val surfacePoints: IndexedSeq[(TriangleId, BarycentricCoordinates)] = surfacePointsSampler(mesh.shape)
+    optimize(rps,surfacePoints)
+  }
+
+
+  def optimize(rps: RenderParameter,
+               surfacePoints: IndexedSeq[(TriangleId, BarycentricCoordinates)]): SphericalHarmonicsLight = {
+    val mesh: VertexColorMesh3D = renderer.instance(rps)
+    val albedo = mesh.color
+    val normals = mesh.shape.vertexNormals
+
+    // radiance on surface
+    val inverseColorTransform: ColorTransform = rps.colorTransform.transform.invert
+    val imageAsProperty: MeshSurfaceProperty[Option[RGBA]] = targetAsSurfaceProperty(rps)
+
+    // get surface points to evaluate from sampler
+
+
+    //illuminated point set of sample points, note, there are invisible points which are automatically removed (via Option/None)
+    val points: IndexedSeq[IlluminatedPoint] = surfacePoints.flatMap {
+      case (tid, bcc) =>
+        val r = imageAsProperty(tid, bcc).map(imageColor => {
+          // Option because we could sample from invisible point
+          val albedoLocal = albedo(tid, bcc)
+          val normal = rps.pose.transform(normals(tid, bcc)).normalize
+          IlluminatedPoint(normal, inverseColorTransform(imageColor.toRGB), albedoLocal.toRGB)
+        })
+        r
+    }
+    if(points.nonEmpty) { //If the face is outside the face This is cannot be done outside the function, because number of points depends on visibility.
+    val lightField: IndexedSeq[Vector[_3D]] = SphericalHarmonicsSolver.solveSHSystemDeconvolve(points, SphericalHarmonicsLight.lambertKernel)
+      SphericalHarmonicsLight(lightField)
+    }else {
+      rps.environmentMap
+
+    }
+  }
+
+  override def toString = "SphericalHarmonicsOptimizer"
+}
+
+object SphericalHarmonicsOptimizer {
+  def apply(renderer: ParametricModel, targetImage: PixelImage[RGBA])(implicit rnd: Random) = new SphericalHarmonicsOptimizer(renderer, targetImage)
+}

--- a/src/main/scala/scalismo/faces/deluminate/SphericalHarmonicsSolver.scala
+++ b/src/main/scala/scalismo/faces/deluminate/SphericalHarmonicsSolver.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.deluminate
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import scalismo.faces.color.RGB
+import scalismo.faces.numerics.SphericalHarmonics
+import scalismo.geometry.{Vector, _3D}
+
+/** provides functionality to solve the linear illumination equations for a given geometry and resulting radiance */
+object SphericalHarmonicsSolver {
+
+  case class IlluminatedPoint(normal: Vector[_3D], radiance: RGB, albedo: RGB)
+
+  /** solve linear illumination equations for an unknown light field L_l: radiance = albedo * sum_l Y_l(normal) * L_l */
+  def solveSHSystem(points: IndexedSeq[IlluminatedPoint],
+    nBands: Int): IndexedSeq[Vector[_3D]] = {
+    // prepare SH basis
+    val nSH = SphericalHarmonics.totalCoefficients(nBands)
+    val kernel = IndexedSeq.fill(nSH)(1.0)
+    solveSHSystemDeconvolve(points, kernel)
+  }
+
+  /**
+   * solve linear illumination equations for an unknown light field L_l, deconvolve a kernel k_l:
+   *  radiance = albedo * sum_l Y_l(normal) * L_l * k_l
+   *  @param points Illuminated points with normal, radiance and albedo
+   *  @param kernel Kernel on SH coefficients, usually Lambert kernel for diffuse reflectance, determines number of SH coefficients returned
+   */
+  def solveSHSystemDeconvolve(points: IndexedSeq[IlluminatedPoint],
+    kernel: IndexedSeq[Double]): IndexedSeq[Vector[_3D]] = {
+    require(points.nonEmpty)
+    // direct access data
+    val radiances = points.map(_.radiance)
+    val normals = points.map(_.normal)
+    val albedi = points.map(_.albedo)
+
+    // prepare SH basis
+    val nSH = kernel.length
+    val shBasis = IndexedSeq.tabulate(nSH)(i => SphericalHarmonics.shBasisFunction(i))
+
+    // build target vector on rhs: b (3*#points x 1), vectorize all colors to r, g, b
+    val b = DenseVector(radiances.toArray.flatMap(r => r.toVector[_3D].toArray))
+
+    // build matrix: (3*#points) x  (3*#lightCoefficients)
+    def matrixBuilder(i: Int, j: Int): Double = {
+      // major indices: point, light coefficient
+      val pointIndex = i / 3
+      val shCoeffIndex = j / 3
+      // minor indices: color index R, G, B
+      val pointColorIndex = i % 3
+      val shColorIndex = j % 3
+      // matrix element: albedo[point, color] * Y[shCoeff](normal[point]) * kernel(shCoeff) * delta(pointColor, shColor)
+      if (pointColorIndex == shColorIndex)
+        albedi(pointIndex).toVector[_3D].toArray(pointColorIndex) * shBasis(shCoeffIndex)(normals(pointIndex)) * kernel(shCoeffIndex)
+      else
+        0.0
+    }
+    val A: DenseMatrix[Double] = DenseMatrix.tabulate(3 * points.length, 3 * nSH)(matrixBuilder)
+    // solve linear system
+    val lightField: DenseVector[Double] = A \ b
+
+    // extract channeled coefficients
+    val shCoeffs: IndexedSeq[Vector[_3D]] = lightField.toArray.grouped(3).map(a => Vector[_3D](a)).toIndexedSeq
+
+    // finished
+    shCoeffs
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/evaluators/CachedDistributionEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/evaluators/CachedDistributionEvaluator.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.evaluators
+
+import scalismo.sampling.DistributionEvaluator
+import scalismo.utils.Memoize
+
+/** cache a distribution evaluator's logValue -- Warning: make sure your evaluator does not depend on any side-effects */
+class CachedDistributionEvaluator[A](evaluator: DistributionEvaluator[A], cacheSize: Int) extends DistributionEvaluator[A] {
+  private val cachedLogValue = Memoize(evaluator.logValue, cacheSize)
+
+  override def logValue(sample: A): Double = cachedLogValue(sample)
+}
+
+object CachedDistributionEvaluator {
+  def apply[A](evaluator: DistributionEvaluator[A], cacheSize: Int) = new CachedDistributionEvaluator[A](evaluator, cacheSize)
+
+  /** implicit pimping */
+  object implicits {
+    implicit class RichEvaluator[A](evaluator: DistributionEvaluator[A]) {
+      def cached(cacheSize: Int): CachedDistributionEvaluator[A] = CachedDistributionEvaluator(evaluator, cacheSize)
+    }
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/evaluators/LogNormalDistribution.scala
+++ b/src/main/scala/scalismo/faces/sampling/evaluators/LogNormalDistribution.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.evaluators
+
+import scalismo.sampling.DistributionEvaluator
+import scalismo.sampling.evaluators.GaussianEvaluator
+
+
+/** log normal distribution */
+case class LogNormalDistribution(logMean: Double, logSdev: Double) extends DistributionEvaluator[Double] {
+  override def logValue(sample: Double): Double = LogNormalDistribution.logDensity(sample, logMean, logSdev)
+}
+
+object LogNormalDistribution {
+  /** log density value for LogNormal distribution */
+  def logDensity(x: Double, logMean: Double, logSdev: Double): Double = {
+    if (x > 0.0)
+      GaussianEvaluator.probability(math.log(x), logMean, logSdev)
+    else
+      Double.NegativeInfinity
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/MoMoRenderer.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/MoMoRenderer.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face
+
+import breeze.linalg.DenseVector
+import scalismo.faces.color.RGBA
+import scalismo.faces.image.PixelImage
+import scalismo.faces.landmarks.TLMSLandmark2D
+import scalismo.faces.mesh.VertexColorMesh3D
+import scalismo.faces.momo.MoMo
+import scalismo.faces.parameters.{ParametricRenderer, RenderParameter}
+import scalismo.geometry.Point
+import scalismo.mesh.MeshSurfaceProperty
+import scalismo.utils.Memoize
+
+/** parametric renderer for a Morphable Model, implements all useful Parameteric*Renderer interfaces */
+class MoMoRenderer(val model: MoMo, val clearColor: RGBA)
+  extends ParametricImageRenderer[RGBA]
+    with ParametricLandmarksRenderer
+    with ParametricMaskRenderer
+    with ParametricMeshRenderer
+    with ParametricModel {
+
+  /** pad a coefficient vector if it is too short, basis with single vector */
+  private def padCoefficients(coefficients: DenseVector[Double], rank: Int): DenseVector[Double] = {
+    require(coefficients.length <= rank, "too many coefficients for model")
+    if (coefficients.length == rank)
+      coefficients
+    else
+      DenseVector(coefficients.toArray ++ Array.fill(rank - coefficients.length)(0.0))
+  }
+
+  /** create an instance of the model, in the original model's object coordinates */
+  override def instance(parameters: RenderParameter): VertexColorMesh3D = {
+    model.instance(parameters.momo.coefficients)
+  }
+
+  /** render the image described by the parameters */
+  override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {
+    val inst = instance(parameters)
+    ParametricRenderer.renderParameterVertexColorMesh(
+      parameters,
+      inst,
+      clearColor)
+  }
+
+  /** render the mesh described by the parameters, draws instance from model and places properly in the world (world coordinates) */
+  override def renderMesh(parameters: RenderParameter): VertexColorMesh3D = {
+    val t = parameters.pose.transform
+    val mesh = instance(parameters)
+    VertexColorMesh3D(
+      mesh.shape.transform(p => t(p)),
+      mesh.color
+    )
+  }
+
+  /** render landmark position in the image */
+  override def renderLandmark(lmId: String, parameter: RenderParameter): Option[TLMSLandmark2D] = {
+    val renderer = parameter.renderTransform
+    for {
+      ptId <- model.landmarkPointId(lmId)
+      lm3d <- Some(model.instanceAtPoint(parameter.momo.coefficients, ptId)._1)
+      lmImage <- Some(renderer(lm3d))
+    } yield TLMSLandmark2D(lmId, Point(lmImage.x, lmImage.y), visible = true)
+  }
+
+  /** checks the availability of a named landmark */
+  override def hasLandmarkId(lmId: String): Boolean = model.landmarkPointId(lmId).isDefined
+
+
+  /** get all available landmarks */
+  override def allLandmarkIds: IndexedSeq[String] = model.landmarks.keySet.toIndexedSeq
+
+
+  /** render a mask defined on the model to image space */
+  override def renderMask(parameters: RenderParameter, mask: MeshSurfaceProperty[Int]): PixelImage[Int] = {
+    val inst = instance(parameters)
+    val maskImage = ParametricRenderer.renderPropertyImage(parameters, inst.shape, mask)
+    maskImage.map(_.getOrElse(0)) // 0 - invalid, outside rendering area
+  }
+
+  /** get a cached version of this renderer */
+  def cached(cacheSize: Int) = new MoMoRenderer(model, clearColor) {
+    private val imageRenderer = Memoize(super.renderImage, cacheSize)
+    private val meshRenderer = Memoize(super.renderMesh, cacheSize)
+    private val maskRenderer = Memoize((super.renderMask _).tupled, cacheSize)
+    private val lmRenderer = Memoize((super.renderLandmark _).tupled, cacheSize * allLandmarkIds.length)
+    private val instancer = Memoize(super.instance, cacheSize)
+
+    override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = imageRenderer(parameters)
+    override def renderLandmark(lmId: String, parameter: RenderParameter): Option[TLMSLandmark2D] = lmRenderer((lmId, parameter))
+    override def renderMesh(parameters: RenderParameter): VertexColorMesh3D = meshRenderer(parameters)
+    override def instance(parameters: RenderParameter): VertexColorMesh3D = instancer(parameters)
+    override def renderMask(parameters: RenderParameter, mask: MeshSurfaceProperty[Int]): PixelImage[Int] = maskRenderer((parameters, mask))
+  }
+}
+
+object MoMoRenderer {
+  def apply(model: MoMo, clearColor: RGBA) = new MoMoRenderer(model, clearColor)
+  def apply(model: MoMo) = new MoMoRenderer(model, RGBA.BlackTransparent)
+}

--- a/src/main/scala/scalismo/faces/sampling/face/ParametricImageRenderer.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ParametricImageRenderer.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face
+
+import scalismo.faces.image.PixelImage
+import scalismo.faces.parameters.RenderParameter
+
+/** image renderer, controlled by RenderParameter, used for fitting */
+trait ParametricImageRenderer[A] {
+  def renderImage(parameters: RenderParameter): PixelImage[A]
+}

--- a/src/main/scala/scalismo/faces/sampling/face/ParametricLandmarksRenderer.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ParametricLandmarksRenderer.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face
+
+import scalismo.faces.landmarks.TLMSLandmark2D
+import scalismo.faces.parameters.RenderParameter
+
+/** landmarks renderer, controlled by RenderParameter, used for fitting */
+trait ParametricLandmarksRenderer {
+  /** render landmark given by lmId */
+  def renderLandmark(lmId: String, parameter: RenderParameter): Option[TLMSLandmark2D]
+
+  /** check if landmark id is known */
+  def hasLandmarkId(lmId: String): Boolean
+
+  /** list of all known landmarks */
+  def allLandmarkIds: IndexedSeq[String]
+}

--- a/src/main/scala/scalismo/faces/sampling/face/ParametricMaskRenderer.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ParametricMaskRenderer.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face
+
+import scalismo.faces.image.PixelImage
+import scalismo.faces.parameters.RenderParameter
+import scalismo.mesh.MeshSurfaceProperty
+
+/** renders masks (integer values) in image space, controlled by RenderParameter, used for fitting */
+trait ParametricMaskRenderer {
+  def renderMask(parameter: RenderParameter, mask: MeshSurfaceProperty[Int]): PixelImage[Int]
+}

--- a/src/main/scala/scalismo/faces/sampling/face/ParametricMeshRenderer.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ParametricMeshRenderer.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face
+
+import scalismo.faces.mesh.VertexColorMesh3D
+import scalismo.faces.parameters.RenderParameter
+
+/** generates a mesh in world coordinates, controlled by RenderParameter, used for fitting */
+trait ParametricMeshRenderer {
+  def renderMesh(parameters: RenderParameter): VertexColorMesh3D
+}

--- a/src/main/scala/scalismo/faces/sampling/face/ParametricModel.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ParametricModel.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face
+
+import scalismo.faces.mesh.VertexColorMesh3D
+import scalismo.faces.parameters.RenderParameter
+
+/** generates a model instance in original model coordinates */
+trait ParametricModel {
+  def instance(parameters: RenderParameter): VertexColorMesh3D
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/CollectiveLikelihoodEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/CollectiveLikelihoodEvaluator.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.color.{RGB, RGBA}
+import scalismo.faces.image.PixelImage
+import scalismo.sampling.DistributionEvaluator
+import scalismo.sampling.evaluators.PairEvaluator
+
+
+/**
+  * Collective Likelihood: models the average squared distance of images as normal
+  * (valid for many pixels, large averages: Central Limit Theorem)
+  * for Details see "Markov Chain Monte Carlo for Automated Face Image Analysis" in IJCV 2016
+  *
+  * @param sigma expected standard deviation between image and target pixels (noise assumption, total RMS distance), sigma^2 = E[d^2]
+  * @param relativeVariance variance of squared differences, in relative units of sigma^4
+  */
+class CollectiveLikelihoodEvaluator(val sigma: Double, val relativeVariance: Double)
+  extends PairEvaluator[PixelImage[RGBA]] {
+  override def logValue(reference: PixelImage[RGBA], sample: PixelImage[RGBA]): Double = {
+    require(sample.domain == reference.domain, "SqCLTEvaluator: images must be comparable! (different sizes)")
+
+    // Image Loop: sum all fg pixels, CLT enforces noise assumption, no bg model needed
+    var sum: Double = 0.0
+    var count: Int = 0
+
+    var x: Int = 0
+    while (x < reference.width) {
+      var y: Int = 0
+      while (y < reference.height) {
+        val refCol: RGB = reference(x, y).toRGB
+        val smp: RGBA = sample(x, y)
+        if (smp.a >  1e-4) {
+          val diff: RGB = refCol - smp.toRGB
+          val normSq: Double = diff.dot(diff)
+          sum += normSq
+          count += 1
+        }
+        y += 1
+      }
+      x += 1
+    }
+    if(count > 0) { //was something rendered on the image?
+      val avg = sum / (sigma * sigma * count)
+      val stdNormVariate: Double = (avg - 1) / Math.sqrt(relativeVariance/count)
+      -0.5 * Math.log(2 * Math.PI) - 0.5 * (stdNormVariate * stdNormVariate)
+    }
+    else Double.NegativeInfinity  // nothing was rendered on the image!
+  }
+
+  override def toString: String = {
+    val builder = new StringBuilder(128)
+    builder ++= "SqCLTEvaluator("
+    builder ++= sigma.toString
+    builder ++= ","
+    builder ++= relativeVariance.toString
+    builder ++= ")"
+    builder.mkString
+  }
+}
+
+object CollectiveLikelihoodEvaluator {
+  def apply(sigma: Double, relativeVariance: Double) = new CollectiveLikelihoodEvaluator(sigma, relativeVariance)
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/FaceBoxEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/FaceBoxEvaluator.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import java.io.{File, InputStream}
+
+import scalismo.faces.parameters.RenderParameter
+import scalismo.faces.sampling.face.ParametricLandmarksRenderer
+import scalismo.geometry.{Point, Vector, _2D}
+import scalismo.sampling.DistributionEvaluator
+
+import scala.io.Source
+import scala.util.Try
+
+
+/**
+  * evaluate face position with respect to a given detection face box (has scale and position)
+  * @param renderer parametric landmarks renderer, needs to know Seq("center.nose.tip", "left.eye.corner_outer", "right.eye.corner_outer", "right.lips.corner", "left.lips.corner")
+  * @param faceBox target face box
+  * @param scaleEvaluator evaluates scale mismatch (as relative factor, 1.0 is a perfect match)
+  * @param positionEvaluator evaluates position mismatch (as offset, Vector(0, 0) is a perfect match) */
+class FaceBoxEvaluator(renderer: ParametricLandmarksRenderer,
+                       faceBox: FaceBox,
+                       scaleEvaluator: DistributionEvaluator[Double],
+                       positionEvaluator: DistributionEvaluator[Vector[_2D]])
+  extends DistributionEvaluator[RenderParameter] {
+
+  // lmIds to estimate face scale
+  val lmIds = Seq("center.nose.tip", "left.eye.corner_outer", "right.eye.corner_outer", "right.lips.corner", "left.lips.corner")
+
+  // render scale and position of face
+  def renderScaleAndCenter(parameter: RenderParameter): (Double, Point[_2D]) = {
+    val renderedLM = lmIds.map{id => id -> renderer.renderLandmark(id, parameter).get}.toMap
+
+    val faceCenter = renderedLM("center.nose.tip").point
+
+    val eyeDistance = (renderedLM("right.eye.corner_outer").point - renderedLM("left.eye.corner_outer").point).norm
+    val rightEyeLipDistance = (renderedLM("right.eye.corner_outer").point - renderedLM("right.lips.corner").point).norm
+    val leftEyeLipDistance = (renderedLM("left.eye.corner_outer").point - renderedLM("left.lips.corner").point).norm
+    val faceScale = math.max(eyeDistance, math.max(rightEyeLipDistance, leftEyeLipDistance))
+
+    (faceScale, faceCenter)
+  }
+
+  // evaluate with respect to target face box, scale and position
+  override def logValue(sample: RenderParameter): Double = {
+    val (faceScale, faceCenter) = renderScaleAndCenter(sample)
+    val scaleValue = scaleEvaluator.logValue(faceScale / faceBox.scale)
+    val positionValue = positionEvaluator.logValue(faceCenter - faceBox.center)
+    scaleValue + positionValue
+  }
+}
+
+/** a face detection candidate */
+case class FaceBox(topLeft: Point[_2D], bottomRight: Point[_2D], certainty: Double) {
+  val size: Vector[_2D] = bottomRight - topLeft
+  val center: Point[_2D] = topLeft + 0.5 *: size
+  val scale: Double = size.norm / 3.0
+}
+
+object FaceBox {
+  def fromYAML(yaml: String): Try[FaceBox] = Try {
+    // read file line by line
+    val lines = Source.fromString(yaml).getLines()
+    // extract position and scale
+    var boxPosition: Option[(Point[_2D], Vector[_2D])] = None
+    var certainty: Option[Double] = None
+    // extraction patterns
+    val boxMatcher = "FaceBox:\\[([0-9.]+),([0-9.]+),([0-9.]+),([0-9.]+)\\]".r
+    val certaintyMatcher = """pFace:([-+]?[0-9]*\.?([0-9]+)?([eE][-+]?[0-9]+)?)""".r
+    // process line after line
+    for (l <- lines) {
+      val trimmed = """ """.r.replaceAllIn(l.trim, "")
+      trimmed match {
+        case boxMatcher(tlx, tly, sx, sy) =>
+          val topLeft = Point(tlx.toDouble, tly.toDouble)
+          val size = Vector(sx.toDouble, sy.toDouble)
+          boxPosition = Some(topLeft, size)
+        case certaintyMatcher(c, _, _) =>
+          certainty = Some(c.toDouble)
+        case li: String => Unit
+      }
+    }
+    // get results
+    val (tl, size) = boxPosition.getOrElse(throw new RuntimeException("no FaceBox found in file"))
+    val cert = certainty.getOrElse(throw new RuntimeException("no certainty found in file"))
+    // assemble face box
+    FaceBox(tl, tl + size, cert)
+  }
+
+  def fromYAMLStream(stream: InputStream): Try[FaceBox] = Try {
+    fromYAML(Source.fromInputStream(stream).mkString).get
+  }
+
+  /** read face box from standard map file format: YAML with "faceBox: [topLeft.x, topLeft.y, bottomRight.x, bottomRight.y]" and "pValue: certainty" */
+  def fromYAMLFile(file: File): Try[FaceBox] = Try {
+    fromYAML(Source.fromFile(file).mkString).get
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/HistogramRGB.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/HistogramRGB.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.color.{RGB, RGBA}
+import scalismo.faces.image.PixelImage
+import scalismo.sampling.DistributionEvaluator
+
+/**
+ * Provides specific implementation of a Histogram for a sequence/image of RGB values
+ * for RGBA images alpha value is used as mask
+ */
+case class HistogramRGB private (counts: Array[Int], binsPerChannel: Int) extends DistributionEvaluator[RGB] {
+  require(binsPerChannel * binsPerChannel * binsPerChannel == counts.length, "bin size does not match length of sequence")
+  private val total: Int = counts.sum
+  private val logNorm = 3 * Math.log(binsPerChannel)
+  private val logTot = Math.log(total)
+  val distributionPrecalc: Array[Double] = counts.map(c => Math.log(c) - logTot + logNorm)
+
+  def frequency(color: RGB): Double = counts(HistogramRGB.RGBtoIndex(color, binsPerChannel)).toDouble / total
+  def distribution(color: RGB): Double = distributionPrecalc(HistogramRGB.RGBtoIndex(color, binsPerChannel))
+  def binSize: Double = 1.0 / binsPerChannel / binsPerChannel / binsPerChannel
+  def hist2String: String = counts.toIndexedSeq.toString
+  override def logValue(color: RGB): Double = distributionPrecalc(HistogramRGB.RGBtoIndex(color, binsPerChannel))
+  override def toString: String = "HistogramRGBEvaluator(" + binsPerChannel + ")"
+
+}
+
+object HistogramRGB {
+  def apply(image: Seq[RGB], binsPerChannel: Int, init: Int = 0 ) = new HistogramRGB(calculateCounts(image, binsPerChannel, init ), binsPerChannel)
+  def fromImageRGB(image: PixelImage[RGB], binsPerChannel: Int, init: Int = 0) = HistogramRGB(image.values.toIndexedSeq, binsPerChannel, init)
+  def fromImageRGBA(image: PixelImage[RGBA], binsPerChannel: Int, init: Int = 0) = HistogramRGB(image.values.filter(p => p.a > 1e-4).map(p => p.toRGB).toIndexedSeq, binsPerChannel, init)
+
+  private def RGBtoIndex(color: RGB, binsPerChannel: Int): Int = {
+    require(color.isInBounds, "color is invalid (not in bounds between 0 and 1)")
+    val rIndex: Int = Math.min(Math.round(color.r * binsPerChannel - 0.5), binsPerChannel - 1).toInt
+    val gIndex: Int = Math.min(Math.round(color.g * binsPerChannel - 0.5), binsPerChannel - 1).toInt
+    val bIndex: Int = Math.min(Math.round(color.b * binsPerChannel - 0.5), binsPerChannel - 1).toInt
+    rIndex * binsPerChannel * binsPerChannel + gIndex * binsPerChannel + bIndex
+  }
+
+  private def calculateCounts(image: Seq[RGB], binsPerChannel: Int, init:Int): Array[Int] = {
+    val counter = Array.fill(binsPerChannel * binsPerChannel * binsPerChannel) { init }
+    image.foreach { p => counter(RGBtoIndex(p, binsPerChannel)) += 1 }
+    counter
+  }
+
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/ImageRendererEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/ImageRendererEvaluator.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.color.RGBA
+import scalismo.faces.image.PixelImage
+import scalismo.faces.parameters.RenderParameter
+import scalismo.faces.sampling.face.ParametricImageRenderer
+import scalismo.sampling.DistributionEvaluator
+
+/** evaluate the rendered image with given image evaluator */
+class ImageRendererEvaluator(val renderer: ParametricImageRenderer[RGBA], val imageEvaluator: DistributionEvaluator[PixelImage[RGBA]])
+    extends DistributionEvaluator[RenderParameter] {
+
+  override def logValue(rps: RenderParameter): Double = {
+    val rendered = renderer.renderImage(rps)
+    imageEvaluator.logValue(rendered)
+  }
+
+  override def toString: String = "ImageRendererEvaluator(" + imageEvaluator.toString + ")"
+}
+
+object ImageRendererEvaluator {
+  def apply(renderer: ParametricImageRenderer[RGBA], imageEvaluator: DistributionEvaluator[PixelImage[RGBA]]) = new ImageRendererEvaluator(renderer, imageEvaluator)
+}
+
+/** evaluate the transformed, rendered image with given image evaluator */
+class MappedImageRendererEvaluator[A](val renderer: ParametricImageRenderer[RGBA], val evaluator: DistributionEvaluator[A], f: RenderParameter => PixelImage[RGBA] => A)
+    extends DistributionEvaluator[RenderParameter] {
+
+  override def logValue(rps: RenderParameter): Double = {
+    val rendered = f(rps)(renderer.renderImage(rps))
+    evaluator.logValue(rendered)
+  }
+
+  override def toString: String = "ImageMappedRendererEvaluator(" + evaluator.toString + ")"
+}
+
+object ImageMappedRendererEvaluator {
+  def apply[A](renderer: ParametricImageRenderer[RGBA], evaluator: DistributionEvaluator[A], f: RenderParameter => PixelImage[RGBA] => A) = new MappedImageRendererEvaluator[A](renderer, evaluator, f)
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/IndependentPixelEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/IndependentPixelEvaluator.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import breeze.linalg.max
+import scalismo.faces.color.{RGB, RGBA}
+import scalismo.faces.image.PixelImage
+import scalismo.faces.sampling.face.evaluators.PixelEvaluators.IsotropicGaussianPixelEvaluator
+import scalismo.sampling.DistributionEvaluator
+import scalismo.sampling.evaluators.{GaussianEvaluator, PairEvaluator}
+
+
+/** evaluate each pixel independently, uses alpha channel to determine between foreground and background */
+class IndependentPixelEvaluator(val pixelEvaluator: PairEvaluator[RGB], val bgEvaluator: DistributionEvaluator[RGB])
+  extends PairEvaluator[PixelImage[RGBA]] {
+  override def logValue(reference: PixelImage[RGBA], sample: PixelImage[RGBA]): Double = {
+    require(sample.domain == reference.domain, "IndependentPixelEvaluator: images must be comparable! (different sizes)")
+
+    // ugly while for better performance, was a nice zip/map/case before :(
+    var sum: Double = 0.0
+    var x: Int = 0
+    var transparencySum = 0.0
+    while (x < reference.width) {
+      var y: Int = 0
+      while (y < reference.height) {
+        val refCol: RGB = reference(x, y).toRGB
+        val smp: RGBA = sample(x, y)
+        val fg: Double = pixelEvaluator.logValue(refCol, smp.toRGB)
+        val bg: Double = bgEvaluator.logValue(refCol)
+        sum += smp.a * (fg - bg)
+        transparencySum += smp.a
+        y += 1
+      }
+      x += 1
+    }
+    if(transparencySum > 0) //was something rendered on the image?
+      sum
+    else Double.NegativeInfinity  // nothing was rendered on the image!
+  }
+
+  override def toString: String = {
+    val builder = new StringBuilder(128)
+    builder ++= "IndependentPixelEvaluator("
+    builder ++= pixelEvaluator.toString
+    builder ++= "/"
+    builder ++= bgEvaluator.toString
+    builder ++= ")"
+    builder.mkString
+  }
+}
+
+object IndependentPixelEvaluator {
+  def apply(pixelEvaluator: PairEvaluator[RGB], bgEvaluator: DistributionEvaluator[RGB]) = new IndependentPixelEvaluator(pixelEvaluator, bgEvaluator)
+
+  /**
+    * construct an independent pixel likelihood of the target image under the image model */
+  def apply(targetImage: PixelImage[RGBA],
+            fgLikelihood: PairEvaluator[RGB],
+            bgLikelihood: DistributionEvaluator[RGB]): DistributionEvaluator[PixelImage[RGBA]] = {
+    IndependentPixelEvaluator(fgLikelihood, bgLikelihood).toDistributionEvaluator(targetImage)
+  }
+
+  /**
+    * construct a likelihood with independent, isotropic Gaussian likelihoods at each pixel (very common case)
+    * */
+  def isotropicGaussian(targetImage: PixelImage[RGBA],
+                        sdev: Double,
+                        bgLikelihood: DistributionEvaluator[RGB]): DistributionEvaluator[PixelImage[RGBA]] = {
+    val pixelEvaluator = IsotropicGaussianPixelEvaluator(sdev)
+    IndependentPixelEvaluator(targetImage, pixelEvaluator, bgLikelihood)
+  }
+
+  /**
+    * construct a likelihood with independent, isotropic Gaussian likelihoods at each pixel with a constant background model
+    *
+    * @param bgSdev background model becomes better for a pixel when its deviation to the rendered image color is larger than this value, measured in standard deviations sdev
+    *
+    */
+  def isotropicGaussianConstantBackground(targetImage: PixelImage[RGBA],
+                                          sdev: Double,
+                                          bgSdev: Double): DistributionEvaluator[PixelImage[RGBA]] = {
+    // standardized foreground evaluator, z transform to a std normal
+    val pixelEvaluator: PairEvaluator[RGB] = new PairEvaluator[RGB] {
+      override def logValue(first: RGB, second: RGB): Double = {
+        val diff = (first - second).norm/sdev
+        GaussianEvaluator.probability(diff, 0.0, 1.0)
+      }
+    }
+    // background likelihood value at required distance in standard deviations
+    val bgValue = GaussianEvaluator.probability(bgSdev, 0.0, 1.0)
+    val bgEval = PixelEvaluators.ConstantPixelEvaluator[RGB](bgValue)
+    IndependentPixelEvaluator(targetImage, pixelEvaluator, bgEval)
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/LandmarkPointEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/LandmarkPointEvaluator.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.landmarks.TLMSLandmark2D
+import scalismo.faces.parameters.RenderParameter
+import scalismo.faces.sampling.face.ParametricLandmarksRenderer
+import scalismo.faces.sampling.face.evaluators.PointEvaluators.IsotropicGaussianPointEvaluator
+import scalismo.geometry.{Point, _2D}
+import scalismo.sampling.DistributionEvaluator
+import scalismo.sampling.evaluators.{PairEvaluator, ProductEvaluator}
+
+/**
+  * likelihood evaluator for a single landmark position
+  * */
+class LandmarkPointEvaluator(targetLandmark: TLMSLandmark2D,
+                             pointEvaluator: PairEvaluator[Point[_2D]],
+                             landmarksRenderer: ParametricLandmarksRenderer)
+  extends DistributionEvaluator[RenderParameter] {
+
+  override def logValue(sample: RenderParameter): Double = {
+    val lmLocation: TLMSLandmark2D = landmarksRenderer.renderLandmark(targetLandmark.id, sample).get
+    pointEvaluator.logValue(lmLocation.point, targetLandmark.point)
+  }
+}
+
+object LandmarkPointEvaluator {
+  /** construct a single landmark evaluator with the provided noise model */
+  def apply(targetLandmark: TLMSLandmark2D,
+            pointEvaluator: PairEvaluator[Point[_2D]],
+            landmarksRenderer: ParametricLandmarksRenderer): LandmarkPointEvaluator = new LandmarkPointEvaluator(targetLandmark, pointEvaluator, landmarksRenderer)
+
+  /** construct many independent landmark evaluators with the same point noise model */
+  def apply(targetLandmarks: Seq[TLMSLandmark2D],
+            pointEvaluator: PairEvaluator[Point[_2D]],
+            landmarksRenderer: ParametricLandmarksRenderer): DistributionEvaluator[RenderParameter] = {
+    val allLMEvals = targetLandmarks.map{lm => LandmarkPointEvaluator(lm, pointEvaluator, landmarksRenderer)}
+    ProductEvaluator(allLMEvals :_*)
+  }
+
+  /**
+    * construction of an isotropic Gaussian likelihood for a single landmark
+    * encapsulates the general PairEvaluator for this explicit, very common case
+    *
+    * @param targetLandmark the observed target landmark, calculates likelihood of this position under rendered model
+    * @param sdev standard deviation of isotropic Gaussian, typically in pixels (TLMS refers to image locations)
+    * @param landmarksRenderer renderer to generate instance */
+  def isotropicGaussian(targetLandmark: TLMSLandmark2D,
+                        sdev: Double,
+                        landmarksRenderer: ParametricLandmarksRenderer): LandmarkPointEvaluator = {
+    val pointEval = IsotropicGaussianPointEvaluator[_2D](sdev)
+    new LandmarkPointEvaluator(targetLandmark, pointEval, landmarksRenderer)
+  }
+
+  /**
+    * construction of an isotropic Gaussian likelihood for a set of landmarks
+    * encapsulates the general PairEvaluator for this explicit, very common case
+    *
+    * @param targetLandmarks all observed target landmarks, calculates likelihood of these positions under rendered model (product, independence assumption)
+    * @param sdev standard deviation of isotropic Gaussian, typically in pixels (TLMS refers to image locations)
+    * @param landmarksRenderer renderer to generate instance */
+  def isotropicGaussian(targetLandmarks: Seq[TLMSLandmark2D],
+                        sdev: Double,
+                        landmarksRenderer: ParametricLandmarksRenderer): DistributionEvaluator[RenderParameter] = {
+    val pointEval = IsotropicGaussianPointEvaluator[_2D](sdev)
+    LandmarkPointEvaluator(targetLandmarks, pointEval, landmarksRenderer)
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/LandmarksInBoxEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/LandmarksInBoxEvaluator.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.landmarks.TLMSLandmark2D
+import scalismo.geometry.{Point, _2D}
+import scalismo.sampling.DistributionEvaluator
+
+/** simple box structure to capture landmark region */
+case class Box(topLeft: Point[_2D], bottomRight: Point[_2D])
+
+/** evaluate position of landmarks with respect to given box
+  * returns 0 if all landmarks are in box, else -infinity */
+class LandmarksInBoxEvaluator(val box: Box) extends DistributionEvaluator[Seq[TLMSLandmark2D]]{
+
+  private def isLandmarkInBox(lm:TLMSLandmark2D):Boolean = {
+    lm.point.x >= box.topLeft.x &&
+      lm.point.x <= box.bottomRight.x &&
+      lm.point.y >= box.topLeft.y &&
+      lm.point.y <= box.bottomRight.y
+  }
+
+  override def logValue(landmarks: Seq[TLMSLandmark2D]):Double = {
+    if (landmarks.forall(isLandmarkInBox))
+      0
+    else
+      Double.NegativeInfinity
+  }
+}
+
+object LandmarksInBoxEvaluator {
+  def apply(box: Box) = new LandmarksInBoxEvaluator(box)
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/LandmarksMapEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/LandmarksMapEvaluator.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.image.PixelImage
+import scalismo.faces.sampling.face.evaluators.PointEvaluators.IsotropicGaussianPointEvaluator
+import scalismo.faces.utils.GeneralMaxConvolution
+import scalismo.geometry.{Point, Point1D, _1D, _2D}
+import scalismo.sampling.DistributionEvaluator
+
+/** evaluate landmark positions in detection maps using a pre-convolved distance model */
+case class LandmarksMapEvaluator(sdevNoiseModel: Double, detectionMap: PixelImage[Double]) extends DistributionEvaluator[Point[_2D]] {
+  private val probMap = GeneralMaxConvolution.separableMaxConvolution(
+    detectionMap,
+    IsotropicGaussianPointEvaluator[_1D](sdevNoiseModel).toDistributionEvaluator(Point1D(0f))
+  )
+
+  override def logValue(sample: Point[_2D]): Double = {
+    val x = sample.x.toInt
+    val y = sample.y.toInt
+    if (probMap.domain.isDefinedAt(x, y)) {
+      probMap(x, y)
+    } else {
+      Double.NegativeInfinity
+    }
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/PixelEvaluators.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/PixelEvaluators.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.color.{HSV, RGB}
+import scalismo.sampling.DistributionEvaluator
+import scalismo.sampling.evaluators.PairEvaluator
+
+import scala.math._
+
+/** collection of various pixel color distributions */
+object PixelEvaluators {
+
+  /** Gaussian color model, isotropic, 3D (RGB) */
+  case class IsotropicGaussianPixelEvaluator(sdev: Double) extends PairEvaluator[RGB] {
+    val normalizer: Double = -3 / 2 * log(2 * Pi) - 3 * log(sdev)
+
+    override def logValue(first: RGB, second: RGB): Double = {
+      val d2 = pow(first.r - second.r, 2) + pow(first.g - second.g, 2) + pow(first.b - second.b, 2)
+      normalizer - 0.5 * d2 / sdev / sdev
+    }
+  }
+
+  /** Gaussian color model, isotropic, 3D (HSV) */
+  case class IsotropicGaussianPixelEvaluatorHSV(sdev: Double) extends PairEvaluator[RGB] {
+    val normalizer: Double = -3/2*log(2*Pi) - 3*log(sdev)
+
+    def apply(first: HSV, second: HSV): Double = {
+      val d2 = min(min(pow((first.hue - second.hue)/2/Pi,2), pow((first.hue-2*Pi-second.hue)/2/Pi,2)), pow((first.hue+2*Pi-second.hue)/2/Pi,2)) + pow(first.saturation - second.saturation, 2) + pow(first.value - second.value, 2)
+      normalizer - 0.5f * d2/sdev/sdev
+    }
+    override def logValue(f: RGB, s: RGB): Double = {
+      val first = HSV(f.toSRGB)
+      val second = HSV(s.toSRGB)
+      apply(first,second)
+    }
+  }
+
+  /** constant value of evalution, useful as a background likelihood */
+  case class ConstantPixelEvaluator[A](value: Double) extends DistributionEvaluator[A] {
+    override def logValue(sample: A): Double = value
+  }
+
+  /** truncated Gaussian color distribution to respect value range of [0, 1] per channel */
+  case class TruncatedGaussianPixelEvaluator(sdev: Double) extends PairEvaluator[RGB] {
+    val variance: Double = sdev * sdev
+    val normalizer: Double = 3.0 * (0.5 * math.log(2.0 * math.Pi) + 0.5 * math.log(variance))
+    def localNormalizer(channel: Double): Double = {
+      math.log(
+        breeze.numerics.erf((1.0 - channel) / math.sqrt(2.0) / sdev) -
+          breeze.numerics.erf(-channel / math.sqrt(2.0) / sdev)
+      )
+    }
+
+    override def logValue(first: RGB, second: RGB): Double = {
+      val diff = first - second
+      val d = diff.dot(diff)
+      val finalNormalizer = 3.0 * math.log(0.5) + first.map(c => localNormalizer(c)).sum
+      (-d / 2.0 * variance) - normalizer - finalNormalizer
+    }
+  }
+
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/PointEvaluators.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/PointEvaluators.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.sampling.DistributionEvaluator
+import scalismo.sampling.evaluators.PairEvaluator
+import scalismo.geometry._
+
+import scala.math._
+
+object PointEvaluators {
+  case class IsotropicGaussianPointEvaluator[D <: Dim](sdev: Double)(implicit ndSpace: NDSpace[D]) extends PairEvaluator[Point[D]] {
+
+    private val d = ndSpace.dimensionality
+    val normalizer: Double = -0.5 * d * log(2 * Pi) - d * log(sdev)
+
+    override def logValue(first: Point[D], second: Point[D]): Double = {
+      val d2 = (second - first).norm2
+      normalizer - 0.5f * d2 / sdev / sdev
+    }
+  }
+
+  case class ConstantPointEvaluator[D <: Dim](value: Double) extends DistributionEvaluator[Point[D]] {
+    override def logValue(sample: Point[D]): Double = value
+  }
+
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/PriorEvaluators.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/PriorEvaluators.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.parameters.RenderParameter
+import scalismo.sampling.DistributionEvaluator
+
+/**
+ * collection of prior distributions
+ */
+object PriorEvaluators {
+
+  /** Gaussian shape prior of statistical/probabilistic model */
+  case class GaussianShapePrior(mean: Double, sdev: Double) extends DistributionEvaluator[RenderParameter] {
+
+    override def logValue(rps: RenderParameter): Double = {
+      val shapeCoeff = rps.momo.shape
+      if (shapeCoeff.isEmpty) {
+        0.0
+      } else {
+        val dDiff = shapeCoeff.foldLeft(0.0) { (z: Double, v: Double) => z + math.pow(v - mean, 2) / sdev / sdev }
+        val dNorm = -0.5 * shapeCoeff.size * math.log(2 * math.Pi) - shapeCoeff.size * math.log(sdev)
+        dNorm - 0.5 * dDiff
+      }
+    }
+
+  }
+
+  /** Gaussian texture prior of statistical/probabilistic model */
+  case class GaussianTexturePrior(mean: Double, sdev: Double) extends DistributionEvaluator[RenderParameter] {
+
+    override def logValue(rps: RenderParameter): Double = {
+      val colorCoeff = rps.momo.color
+      if (colorCoeff.isEmpty) {
+        0.0
+      } else {
+        val dDiff = colorCoeff.foldLeft(0.0) { (z: Double, v: Double) => z + math.pow(v - mean, 2) / sdev / sdev }
+        val dNorm = -0.5 * colorCoeff.size * math.log(2 * math.Pi) - colorCoeff.size * math.log(sdev)
+        dNorm - 0.5 * dDiff
+      }
+    }
+
+  }
+
+  /** Gaussian expression prior of statistical/probabilistic model */
+  case class GaussianExpressionPrior(mean: Double, sdev: Double) extends DistributionEvaluator[RenderParameter] {
+
+    override def logValue(rps: RenderParameter): Double = {
+      val expressCoeff = rps.momo.expression
+      if (expressCoeff.isEmpty) {
+        0.0
+      } else {
+        val dDiff = expressCoeff.foldLeft(0.0) { (z: Double, v: Double) => z + math.pow(v - mean, 2) / sdev / sdev }
+        val dNorm = -0.5 * expressCoeff.size * math.log(2 * math.Pi) - expressCoeff.size * math.log(sdev)
+        dNorm - 0.5 * dDiff
+      }
+    }
+
+  }
+
+}

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/TrimmedIndependentPixelEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/TrimmedIndependentPixelEvaluator.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.color.{RGB, RGBA}
+import scalismo.faces.image.{ImageBuffer, PixelImage, PixelImageDomain}
+import scalismo.sampling.DistributionEvaluator
+import scalismo.sampling.evaluators.PairEvaluator
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * Ignore 1-alpha pixels with small likelihood.
+  * Evaluate only on alpha-fraction with the largest likelihood.
+  *
+  * visualizationCallback: gives you the log likelihood values per pixel. Could be used to visualze the values per pixel.
+  */
+class TrimmedIndependentPixelEvaluator(val pixelEvaluator: PairEvaluator[RGB], val bgEvaluator: DistributionEvaluator[RGB], val alpha: Double, visualizationCallback: Option[PixelImage[Option[Double]] => Unit])
+  extends PairEvaluator[PixelImage[RGBA]] {
+
+  private val alphaClamped = math.min(math.max(0, alpha), 1)
+
+  /** probability/density value for a pair (log value). */
+  def logValue(reference: PixelImage[RGBA], sample: PixelImage[RGBA]): Double = {
+    require(sample.domain == reference.domain, "TrimmedIndependentPixelEvaluator: images must be comparable! (different sizes)")
+    /** Visualisation. */
+    def visualize(values: IndexedSeq[(Double, Int, Int)], domain: PixelImageDomain, callBack: PixelImage[Option[Double]] => Unit): Unit = {
+      val buffer = ImageBuffer.makeConstantBuffer[Option[Double]](domain.width, domain.height, None)
+      values.foreach { case (lh: Double, x: Int, y: Int) => buffer(x, y) = Some(lh) }
+      callBack(buffer.toImage)
+    }
+    var transparencySum = 0.0
+    var values = ArrayBuffer[(Double, Int, Int)]()
+    var x: Int = 0
+    while (x < reference.width) {
+      var y: Int = 0
+      while (y < reference.height) {
+        val smp = sample(x, y)
+        if (smp.a > 1e-4f) {
+          val ref = reference(x, y).toRGB
+          val fg: Double = pixelEvaluator.logValue(ref, smp.toRGB)
+          val bg: Double = bgEvaluator.logValue(ref)
+          val entry = (fg - bg, x, y)
+          values += entry
+        }
+        transparencySum += smp.a
+        y += 1
+      }
+      x += 1
+    }
+    val nCount = math.floor(values.length.toFloat * alphaClamped).toInt
+    if (transparencySum > 0 && nCount > 0) {
+      //was something rendered on the image?
+      val data = values.toIndexedSeq.sortBy { case (d: Double, x: Int, y: Int) => d }
+      var sumTrimmed: Double = 0.0
+      for (i <- 0 until nCount) {
+        sumTrimmed += data(data.size - 1 - i)._1
+      }
+      if (visualizationCallback.isDefined)
+        visualize(data.slice(data.size - 1 - nCount, data.size - 1), reference.domain, visualizationCallback.get)
+      sumTrimmed
+    } else {
+      // nothing was rendered on the image!
+      Double.NegativeInfinity
+    }
+  }
+
+  override def toString: String = {
+    val builder = new StringBuilder(128)
+    builder ++= "TrimmedIndependentPixelEvaluator("
+    builder ++= pixelEvaluator.toString
+    builder ++= "/"
+    builder ++= bgEvaluator.toString
+    builder ++= s"alpha=$alphaClamped"
+    builder ++= ")"
+    builder.mkString
+  }
+}
+
+object TrimmedIndependentPixelEvaluator {
+  def apply(pixelEvaluator: PairEvaluator[RGB], bgEvaluator: DistributionEvaluator[RGB], alpha: Double) = new TrimmedIndependentPixelEvaluator(pixelEvaluator, bgEvaluator, alpha, None)
+
+  def apply(pixelEvaluator: PairEvaluator[RGB], bgEvaluator: DistributionEvaluator[RGB], alpha: Double, visualisationCallback: PixelImage[Option[Double]] => Unit) = new TrimmedIndependentPixelEvaluator(pixelEvaluator, bgEvaluator, alpha, Some(visualisationCallback))
+
+}

--- a/src/main/scala/scalismo/faces/sampling/face/loggers/ImageRenderLogger.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/loggers/ImageRenderLogger.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.loggers
+
+import java.io.File
+
+import scalismo.faces.color.RGBA
+import scalismo.faces.image.PixelImage
+import scalismo.faces.io.PixelImageIO
+import scalismo.faces.landmarks.{LandmarksDrawer, TLMSLandmark2D}
+import scalismo.faces.parameters.RenderParameter
+import scalismo.faces.sampling.face.{ParametricImageRenderer, ParametricLandmarksRenderer}
+import scalismo.sampling.loggers.ChainStateLogger
+
+/** render images for logging */
+class ImageRenderLogger(renderer: ParametricImageRenderer[RGBA],
+                        path: File,
+                        fileNamePrefix: String) extends ChainStateLogger[RenderParameter] {
+  private var counter = 0
+
+  override def logState(sample: RenderParameter): Unit = {
+    dumpImage(sample)
+    counter += 1
+  }
+
+  private def dumpImage(sample: RenderParameter) = {
+    val image = renderer.renderImage(sample)
+    PixelImageIO.write(image, new File(path, f"$fileNamePrefix$counter%08d.png")).get
+  }
+
+  /** draw each sample in front of a background */
+  def withBackground(background: PixelImage[RGBA]): ImageRenderLogger = {
+    val overlayRenderer = new ParametricImageRenderer[RGBA] {
+      override def renderImage(sample: RenderParameter): PixelImage[RGBA] = {
+        val image = renderer.renderImage(sample.fitToImageSize(background.width, background.height))
+        PixelImage(image.domain, (x, y) => background(x, y).toRGB.blend(image(x, y))).map(_.toRGBA)
+      }
+    }
+    ImageRenderLogger(overlayRenderer, path, fileNamePrefix)
+  }
+
+  /** draw landmarks into each image */
+  def withLandmarks(landmarks: Set[String],
+                    lmRenderer: ParametricLandmarksRenderer,
+                    color: RGBA,
+                    size: Int): ImageRenderLogger = {
+
+    val lmImageRenderer = new ParametricImageRenderer[RGBA] {
+      override def renderImage(sample: RenderParameter): PixelImage[RGBA] = {
+        val image = renderer.renderImage(sample)
+        val renderedLM: Map[String, Option[TLMSLandmark2D]] = (for(lm <- landmarks) yield lm -> lmRenderer.renderLandmark(lm, sample)).toMap
+        val lms: IndexedSeq[TLMSLandmark2D] = renderedLM.flatMap(_._2).toIndexedSeq
+        LandmarksDrawer.drawLandmarks(image, lms, color, size)
+      }
+    }
+    ImageRenderLogger(lmImageRenderer, path, fileNamePrefix)
+  }
+}
+
+object ImageRenderLogger {
+  def apply(renderer: ParametricImageRenderer[RGBA], path: File, fileNamePrefix: String) = new ImageRenderLogger(renderer, path, fileNamePrefix)
+}
+
+/** render images for logging, with segmentation mask */
+class LabeledImageRenderLogger(renderer: ParametricImageRenderer[RGBA],
+                               path: File,
+                               fileNamePrefix: String) extends ChainStateLogger[(RenderParameter, PixelImage[Int])] {
+  private var counter = 0
+
+  override def logState(sample: (RenderParameter, PixelImage[Int])): Unit = {
+    dumpImage(sample._1)
+    dumpMask(sample._2)
+    counter += 1
+  }
+
+  private def dumpImage(sample: RenderParameter) = {
+    val image = renderer.renderImage(sample)
+    PixelImageIO.write(image, new File(path, f"$fileNamePrefix$counter%08d.png")).get
+  }
+  private def dumpMask(sample: PixelImage[Int]) = {
+    val image = sample.map(f=>RGBA(f))
+    PixelImageIO.write(image, new File(path, f"$fileNamePrefix$counter%08d_mask.png")).get
+  }
+
+  def withBackground(background: PixelImage[RGBA]): LabeledImageRenderLogger = {
+    val overlayRenderer = new ParametricImageRenderer[RGBA] {
+      override def renderImage(sample: RenderParameter): PixelImage[RGBA] = {
+        val image = renderer.renderImage(sample.fitToImageSize(background.width, background.height))
+        PixelImage(image.domain, (x, y) => background(x, y).toRGB.blend(image(x, y))).map(_.toRGBA)
+      }
+    }
+    LabeledImageRenderLogger(overlayRenderer, path, fileNamePrefix)
+  }
+}
+
+object LabeledImageRenderLogger {
+  def apply(renderer: ParametricImageRenderer[RGBA], path: File, fileNamePrefix: String) = new LabeledImageRenderLogger(renderer, path, fileNamePrefix)
+}

--- a/src/main/scala/scalismo/faces/sampling/face/loggers/LMMapsARLogger.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/loggers/LMMapsARLogger.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.loggers
+
+import scalismo.faces.color.RGBA
+import scalismo.faces.image.{ImageBuffer, PixelImage}
+import scalismo.faces.parameters.RenderParameter
+import scalismo.faces.sampling.face.ParametricLandmarksRenderer
+import scalismo.sampling.loggers.{AcceptRejectLogger, ChainStateLogger}
+import scalismo.sampling.{DistributionEvaluator, ProposalGenerator}
+
+/** render landmarks positions into image for logging, AcceptReject version */
+case class LMMapsARLogger(landmarks: Set[String],
+    renderer: ParametricLandmarksRenderer,
+    target: PixelImage[RGBA]) extends AcceptRejectLogger[RenderParameter] {
+  val outMaps: Map[String, ImageBuffer[Double]] = landmarks.map(l => l -> ImageBuffer.makeInitializedBuffer[Double](target.domain.width, target.domain.height)(0f)).toMap
+  private var incs: Long = 0
+
+  override def accept(current: RenderParameter, sample: RenderParameter, generator: ProposalGenerator[RenderParameter], evaluator: DistributionEvaluator[RenderParameter]): Unit = {
+    landmarks.foreach { lm =>
+      val pos = renderer.renderLandmark(lm, sample).get
+      val x = pos.point.x.toInt
+      val y = pos.point.y.toInt
+      val m = outMaps(lm)
+      if (m.domain.isDefinedAt(x, y)) {
+        incs = incs + 1
+        m.update(x, y, m(x, y) + 1)
+      }
+    }
+  }
+
+  override def reject(current: RenderParameter, sample: RenderParameter, generator: ProposalGenerator[RenderParameter], evaluator: DistributionEvaluator[RenderParameter]): Unit = {
+    landmarks.foreach { lm =>
+      val pos = renderer.renderLandmark(lm, current).get
+      val x = pos.point.x.toInt
+      val y = pos.point.y.toInt
+      val m = outMaps(lm)
+      if (m.domain.isDefinedAt(x, y)) {
+        incs = incs + 1
+        m.update(x, y, m(x, y) + 1)
+      }
+    }
+  }
+
+}
+
+/** render landmarks positions into image for logging, ChainState version */
+case class LMMapsStateLogger(landmarks: Set[String],
+    renderer: ParametricLandmarksRenderer,
+    target: PixelImage[RGBA]) extends ChainStateLogger[RenderParameter] {
+  val outMaps: Map[String, ImageBuffer[Double]] = landmarks.map(l => l -> ImageBuffer.makeInitializedBuffer[Double](target.domain.width, target.domain.height)(0f)).toMap
+  private var incs: Long = 0
+
+  override def logState(sample: RenderParameter): Unit = {
+    landmarks.foreach { lm =>
+      val pos = renderer.renderLandmark(lm, sample).get
+      val x = pos.point.x.toInt
+      val y = pos.point.y.toInt
+      val m = outMaps(lm)
+      if (m.domain.isDefinedAt(x, y)) {
+        incs = incs + 1
+        m.update(x, y, m(x, y) + 1)
+      }
+    }
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/loggers/ParametersFileBestLogger.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/loggers/ParametersFileBestLogger.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.loggers
+
+import java.io.File
+
+import scalismo.faces.io.RenderParameterIO
+import scalismo.faces.parameters.RenderParameter
+import scalismo.sampling.DistributionEvaluator
+import scalismo.sampling.loggers.{BestSampleLogger, ChainStateLogger}
+
+/** log best parameter file */
+class ParametersFileBestLogger(evaluator: DistributionEvaluator[RenderParameter], fileName: File) extends ChainStateLogger[RenderParameter] {
+  private val bestLogger = BestSampleLogger(evaluator)
+
+  override def logState(sample: RenderParameter): Unit = {
+    bestLogger.logState(sample)
+    dumpToFile()
+  }
+
+  def dumpToFile(): Unit = {
+    val best: Option[RenderParameter] = bestLogger.currentBestSample()
+    best.map { b =>
+      RenderParameterIO.write(b, fileName)
+    }
+  }
+}
+
+object ParametersFileBestLogger {
+  def apply(evaluator: DistributionEvaluator[RenderParameter], fileName: File) = new ParametersFileBestLogger(evaluator, fileName)
+}
+

--- a/src/main/scala/scalismo/faces/sampling/face/loggers/ParametersFileLogger.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/loggers/ParametersFileLogger.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.loggers
+
+import java.io.File
+
+import scalismo.faces.io.RenderParameterIO
+import scalismo.faces.parameters.RenderParameter
+import scalismo.sampling.loggers.AcceptRejectLogger
+import scalismo.sampling.{DistributionEvaluator, ProposalGenerator}
+
+/** log parameter files */
+class ParametersFileLogger(path: File, fileNamePrefix: String) extends AcceptRejectLogger[RenderParameter] {
+  private var counter = 0
+
+  override def accept(current: RenderParameter, sample: RenderParameter, generator: ProposalGenerator[RenderParameter], evaluator: DistributionEvaluator[RenderParameter]): Unit = {
+    RenderParameterIO.write(sample, new File(path, f"$fileNamePrefix$counter%08d.rps"))
+    counter += 1
+  }
+
+  override def reject(current: RenderParameter, sample: RenderParameter, generator: ProposalGenerator[RenderParameter], evaluator: DistributionEvaluator[RenderParameter]): Unit = {
+    counter += 1
+  }
+}
+
+object ParametersFileLogger {
+  def apply(path: File, fileNamePrefix: String) = new ParametersFileLogger(path, fileNamePrefix)
+}
+

--- a/src/main/scala/scalismo/faces/sampling/face/loggers/PrintLogger.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/loggers/PrintLogger.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.loggers
+
+import java.io.PrintStream
+
+import scalismo.sampling.loggers.AcceptRejectLogger
+import scalismo.sampling.{DistributionEvaluator, ProposalGenerator}
+
+/** prints current evaluation result and iteration */
+class PrintLogger[A](output: PrintStream, prefix: String) extends AcceptRejectLogger[A] {
+  private var counter = 0
+  override def accept(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {
+    output.println(s"$counter A ${evaluator.logValue(sample)}")
+    counter += 1
+  }
+  override def reject(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {
+    output.println(s"$counter R ${evaluator.logValue(sample)}")
+    counter += 1
+  }
+
+  def verbose = new VerbosePrintLogger[A](output, prefix)
+}
+
+object PrintLogger{
+  def apply[A](output: PrintStream = Console.out, prefix: String = "") = new PrintLogger[A](output, prefix)
+}
+
+/** prints current evaluation result, iteration number, state, generator and evaluator */
+class VerbosePrintLogger[A](output: PrintStream, prefix: String) extends AcceptRejectLogger[A] {
+  private var counter = 0
+  override def accept(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {
+    output.println(s"$counter A ${evaluator.logValue(sample)} $generator $evaluator")
+    counter += 1
+  }
+  override def reject(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {
+    output.println(s"$counter R ${evaluator.logValue(sample)} $generator $evaluator")
+    counter += 1
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianColorProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianColorProposal.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.proposals
+
+import scalismo.faces.color.RGB
+import scalismo.faces.parameters.ColorTransform
+import scalismo.faces.sampling.evaluators.LogNormalDistribution
+import scalismo.sampling.evaluators.GaussianEvaluator
+import scalismo.sampling.{ProposalGenerator, TransitionProbability}
+import scalismo.utils.Random
+
+/** Random Gaussian Proposal for Color.gain, Color.contrast and Color.offset */
+case class GaussianColorProposal(logSdevGain: RGB, logSdevColorContrast: Double, sdevOffset: RGB)(implicit rnd: Random)
+  extends ProposalGenerator[ColorTransform] with TransitionProbability[ColorTransform] {
+  override def propose(current: ColorTransform): ColorTransform = {
+    val proposedGain = RGB(
+      current.gain.r * math.exp(rnd.scalaRandom.nextGaussian() * logSdevGain.r),
+      current.gain.g * math.exp(rnd.scalaRandom.nextGaussian() * logSdevGain.g),
+      current.gain.b * math.exp(rnd.scalaRandom.nextGaussian() * logSdevGain.b)
+    )
+    current.copy(gain = proposedGain)
+
+    val proposedContrast = current.colorContrast * math.exp(rnd.scalaRandom.nextGaussian() * logSdevColorContrast)
+    current.copy(colorContrast = proposedContrast)
+
+    val proposedOffset = RGB(
+      current.offset.r + rnd.scalaRandom.nextGaussian() * sdevOffset.r,
+      current.offset.g + rnd.scalaRandom.nextGaussian() * sdevOffset.g,
+      current.offset.b + rnd.scalaRandom.nextGaussian() * sdevOffset.b
+    )
+    current.copy(offset = proposedOffset)
+  }
+
+  override def logTransitionProbability(from: ColorTransform, to: ColorTransform): Double = {
+    //gain
+    LogNormalDistribution.logDensity(to.gain.r/from.gain.r, 0.0, logSdevGain.r) +
+      LogNormalDistribution.logDensity(to.gain.g/from.gain.g, 0.0, logSdevGain.g) +
+      LogNormalDistribution.logDensity(to.gain.b/from.gain.b, 0.0, logSdevGain.b) +
+      // contrast
+      LogNormalDistribution.logDensity(to.colorContrast/from.colorContrast, 0.0, logSdevColorContrast) +
+      // offset
+      GaussianEvaluator.probability(to.offset.r, from.offset.r, sdevOffset.r) +
+      GaussianEvaluator.probability(to.offset.g, from.offset.g, sdevOffset.g) +
+      GaussianEvaluator.probability(to.offset.b, from.offset.b, sdevOffset.b)
+  }
+
+  override def toString: String = {
+    s"ColorProposal($logSdevGain,$logSdevColorContrast,$sdevOffset)"
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianDistanceProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianDistanceProposal.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.proposals
+
+import scalismo.faces.parameters.RenderParameter
+import scalismo.geometry.Vector
+import scalismo.sampling.evaluators.GaussianEvaluator
+import scalismo.sampling.{ProposalGenerator, SymmetricTransition}
+import scalismo.utils.Random
+
+/** Gaussian proposal to vary the distance between the face and the camera with an optional scaling compensation
+  * @param sdev standard deviation of Gaussian proposal, typically in mm
+  * @param compensateScaling if true the focal length of the camera is adjusted to compensate for the apparent size change due to the distance change (isolated perspective change) */
+case class GaussianDistanceProposal(sdev: Double, compensateScaling: Boolean)(implicit rnd: Random)
+    extends ProposalGenerator[RenderParameter] with SymmetricTransition[RenderParameter] {
+  override def propose(current: RenderParameter): RenderParameter = {
+    val cameraDistance = current.view.translation.z - current.pose.translation.z
+
+    // limit shift
+    val shift = math.min(cameraDistance - 1.0, rnd.scalaRandom.nextGaussian() * sdev)
+
+    val factor = if (compensateScaling) (cameraDistance - shift) / cameraDistance else 1.0
+    current.copy(
+      pose = current.pose.copy(translation = current.pose.translation + Vector(0.0, 0.0, shift)),
+      camera = current.camera.copy(focalLength = factor * current.camera.focalLength)
+    )
+  }
+
+  /** rate of transition from to (log value) */
+  override def logTransitionProbability(from: RenderParameter, to: RenderParameter): Double = {
+    if (to.copy(pose = from.pose, camera = from.camera) == from) {
+      val diff: Double = to.pose.translation.z - from.pose.translation.z
+      GaussianEvaluator.probability(diff, 0.0, sdev)
+    } else
+      Double.NegativeInfinity
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianMoMoProposals.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianMoMoProposals.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.proposals
+
+import scalismo.faces.parameters.MoMoInstance
+import scalismo.faces.sampling.evaluators.LogNormalDistribution
+import scalismo.sampling.evaluators.GaussianEvaluator
+import scalismo.sampling.{ProposalGenerator, SymmetricTransition, TransitionProbability}
+import scalismo.utils.Random
+
+/** Gaussian proposal on a sequence of numbers */
+case class GaussianParameterProposal(sdev: Double)(implicit rnd: Random)
+  extends ProposalGenerator[IndexedSeq[Double]] with SymmetricTransition[IndexedSeq[Double]] {
+  override def propose(current: IndexedSeq[Double]): IndexedSeq[Double] = {
+    require(current.nonEmpty, "cannot propose change on empty vector")
+    current.map{ v => v + sdev * rnd.scalaRandom.nextGaussian()}
+  }
+
+  override def logTransitionProbability(from: IndexedSeq[Double], to: IndexedSeq[Double]): Double = {
+    require(from.nonEmpty, "cannot calculate transition on empty vector")
+    require(from.length == to.length, "IndexedSeqs must be of same length")
+    to.toIterator.zip(from.toIterator).map{case (t, f) => GaussianEvaluator.probability(t, f, sdev)}.sum
+  }
+}
+
+/** LogNormal proposal on a sequence of numbers, scaling */
+case class LogNormalScalingParameterProposal(logSdev: Double)(implicit rnd: Random)
+  extends ProposalGenerator[IndexedSeq[Double]] with TransitionProbability[IndexedSeq[Double]] {
+
+  private def normSq(vec: IndexedSeq[Double]): Double = vec.toIterator.map{v => v * v}.sum
+  private def dot(a: IndexedSeq[Double], b: IndexedSeq[Double]): Double = a.toIterator.zip(b.toIterator).map{case(u, v) => u * v}.sum
+
+  override def propose(current: IndexedSeq[Double]): IndexedSeq[Double] = {
+    require(current.nonEmpty, "cannot propose change on empty vector")
+    val factor = math.exp(rnd.scalaRandom.nextGaussian() * logSdev)
+    current.map{c => c * factor}
+  }
+
+  override def logTransitionProbability(from: IndexedSeq[Double], to: IndexedSeq[Double]): Double = {
+    require(from.nonEmpty, "cannot calculate transition on empty vector")
+    require(from.length == to.length, "shape coefficients should have the same length")
+    val normSqFrom = normSq(from)
+    val normSqTo = normSq(to)
+    if(normSqFrom < 1e-14 || normSqTo < 1e-14 || (math.abs(dot(from, to)) / math.sqrt(normSqTo * normSqFrom) - 1.0) < 1e-5) //proposal can only scale vectors
+      Double.NegativeInfinity
+    else {
+      val factor = math.sqrt(normSqTo / normSqFrom)
+      LogNormalDistribution.logDensity(factor, 0.0, logSdev)
+    }
+  }
+}
+
+/** proposal to vary the shape parameters of a face with an isotropic Gaussian perturbation
+  * independent on each component, same standard deviation
+  * @param sdev standard deviation of proposal
+  * */
+case class GaussianMoMoShapeProposal(sdev: Double)(implicit rnd: Random)
+  extends ProposalGenerator[MoMoInstance] with SymmetricTransition[MoMoInstance] {
+
+  private val generator = GaussianParameterProposal(sdev)
+
+  override def propose(current: MoMoInstance): MoMoInstance = current.copy(
+    shape = generator.propose(current.shape)
+  )
+
+  override def logTransitionProbability(from: MoMoInstance, to: MoMoInstance): Double = {
+    require(from.shape.length == to.shape.length, "shape coefficients should have the same length")
+    generator.logTransitionProbability(from.shape, to.shape)
+  }
+}
+
+/** proposal to vary the color parameters of a face with an isotropic Gaussian perturbation
+  * @param sdev standard deviation of the proposal
+  */
+case class GaussianMoMoColorProposal(sdev: Double)(implicit rnd: Random)
+  extends ProposalGenerator[MoMoInstance] with SymmetricTransition[MoMoInstance] {
+
+  private val generator = GaussianParameterProposal(sdev)
+
+  override def propose(current: MoMoInstance): MoMoInstance = current.copy(
+    color = generator.propose(current.color)
+  )
+
+  override def logTransitionProbability(from: MoMoInstance, to: MoMoInstance): Double = {
+    require(from.color.length == to.color.length, "color coefficients should have the same length")
+    generator.logTransitionProbability(from.color, to.color)
+  }
+}
+
+/** proposal to vary the expression parameters of a face with an isotropic Gaussian perturbation
+  * independent on each component, same standard deviation
+  * @param sdev standard deviation of proposal
+  * */
+case class GaussianMoMoExpressionProposal(sdev: Double)(implicit rnd: Random)
+  extends ProposalGenerator[MoMoInstance] with SymmetricTransition[MoMoInstance] {
+
+  private val generator = GaussianParameterProposal(sdev)
+
+  override def propose(current: MoMoInstance): MoMoInstance = current.copy(
+    expression = generator.propose(current.expression)
+  )
+
+  override def logTransitionProbability(from: MoMoInstance, to: MoMoInstance): Double = {
+    require(from.expression.length == to.expression.length, "expression paramaters must match in length")
+    generator.logTransitionProbability(from.expression, to.expression)
+  }
+}
+
+/** proposal to vary the distance of the shape to the mean (caricature, length of parameter vector)
+  * @param logSdev log of the expected scaling factor
+  * */
+case class GaussianMoMoShapeCaricatureProposal(logSdev: Double)(implicit rnd: Random)
+  extends ProposalGenerator[MoMoInstance] with TransitionProbability[MoMoInstance] {
+
+  private val generator = LogNormalScalingParameterProposal(logSdev)
+
+  override def propose(current: MoMoInstance): MoMoInstance = current.copy(
+    shape = generator.propose(current.shape)
+  )
+
+  override def logTransitionProbability(from: MoMoInstance, to: MoMoInstance): Double = {
+    require(from.shape.length == to.shape.length, "shape coefficients should have the same length")
+    generator.logTransitionProbability(from.shape, to.shape)
+  }
+}
+
+/** proposal to vary the distance of the color to the mean (caricature, length of parameter vector)
+  * @param logSdev log of the expected scaling factor
+  * */
+case class GaussianMoMoColorCaricatureProposal(logSdev: Double)(implicit rnd: Random)
+  extends ProposalGenerator[MoMoInstance] with TransitionProbability[MoMoInstance] {
+
+  private def generator = LogNormalScalingParameterProposal(logSdev)
+
+  override def propose(current: MoMoInstance): MoMoInstance = current.copy(
+    color = generator.propose(current.color)
+  )
+
+  override def logTransitionProbability(from: MoMoInstance, to: MoMoInstance): Double = {
+    require(from.color.length == to.color.length, "color coefficients should have the same length")
+    generator.logTransitionProbability(from.color, to.color)
+  }
+}
+
+/** proposal to vary the distance of the expression to the mean (caricature, length of parameter vector)
+  * @param logSdev log of the expected scaling factor
+  * */
+case class GaussianMoMoExpressionCaricatureProposal(logSdev: Double)(implicit rnd: Random)
+  extends ProposalGenerator[MoMoInstance] with TransitionProbability[MoMoInstance] {
+
+  private def generator = LogNormalScalingParameterProposal(logSdev)
+
+  override def propose(current: MoMoInstance): MoMoInstance = current.copy(
+    expression = generator.propose(current.expression)
+  )
+
+  override def logTransitionProbability(from: MoMoInstance, to: MoMoInstance): Double = {
+    require(from.expression.length == to.expression.length, "color coefficients should have the same length")
+    generator.logTransitionProbability(from.expression, to.expression)
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianRotationProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianRotationProposal.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.proposals
+
+import scalismo.faces.parameters.Pose
+import scalismo.faces.render.Rotation3D
+import scalismo.geometry.{Vector, _3D}
+import scalismo.sampling.evaluators.GaussianEvaluator
+import scalismo.sampling.{ProposalGenerator, SymmetricTransition}
+import scalismo.utils.Random
+
+/** rotation with a random angle (Gaussian) angle around a given axis */
+case class GaussianRotationProposal(axis: Vector[_3D], sdev: Double)(implicit rnd: Random)
+    extends ProposalGenerator[Pose] with SymmetricTransition[Pose] {
+
+  private val normAxis: Vector[_3D] = axis.normalize
+
+  override def propose(current: Pose): Pose = {
+    val angle = rnd.scalaRandom.nextGaussian() * sdev
+    val rotation = Rotation3D(angle, normAxis)
+    val (pitch, yaw, roll) = Rotation3D.decomposeRotationXYZ(rotation)
+    current.copy(
+      yaw = current.yaw + yaw,
+      pitch = current.pitch + pitch,
+      roll = current.roll + roll
+    )
+  }
+
+  /** rate of transition from to (log value) */
+  override def logTransitionProbability(from: Pose, to: Pose): Double = {
+    // this proposal only changes rotation angles
+    if (to.copy(yaw = from.yaw, pitch = from.pitch, roll = from.roll) != from)
+      Double.NegativeInfinity
+    else {
+      val dp = to.pitch - from.pitch
+      val dy = to.yaw - from.yaw
+      val dr = to.roll - from.roll
+      val rot = Rotation3D.fromEulerXYZ(dp, dy, dr)
+      if (math.abs(rot.phi) > 1e-5 && (rot.axis dot axis) < 1.0 - 1e-4)
+        Double.NegativeInfinity // wrong axis
+      else {
+        GaussianEvaluator.probability(rot.phi, 0.0, sdev)
+      }
+    }
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianScalingProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianScalingProposal.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.proposals
+
+import scalismo.faces.parameters.Camera
+import scalismo.faces.sampling.evaluators.LogNormalDistribution
+import scalismo.sampling.{ProposalGenerator, TransitionProbability}
+import scalismo.utils.Random
+
+/** proposal to change the scaling of the image through the focal length of the camera
+  * @param logSdev log of factor of typical variation, 0.0 is no variation */
+case class GaussianScalingProposal(logSdev: Double)(implicit rnd: Random)
+    extends ProposalGenerator[Camera] with TransitionProbability[Camera] {
+
+  override def propose(current: Camera): Camera = {
+    val f = math.exp(rnd.scalaRandom.nextGaussian() * logSdev)
+    current.copy(focalLength = current.focalLength * f)
+  }
+
+  override def logTransitionProbability(from: Camera, to: Camera): Double = {
+    if (to.copy(focalLength = from.focalLength) == from) {
+      LogNormalDistribution.logDensity(to.focalLength/from.focalLength, 0.0, logSdev)
+    } else
+      Double.NegativeInfinity
+  }
+
+  override def toString: String = s"GaussianScalingProposal($logSdev)"
+}

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianTranslationProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianTranslationProposal.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.proposals
+
+import scalismo.faces.parameters.Pose
+import scalismo.geometry._
+import scalismo.sampling.evaluators.GaussianEvaluator
+import scalismo.sampling.{ProposalGenerator, SymmetricTransition}
+import scalismo.utils.Random
+
+
+/**
+  * Trait for translation proposals.
+  */
+trait GaussianTranslationProposal extends ProposalGenerator[Pose] with SymmetricTransition[Pose]
+
+/**
+  * Gaussian translation proposal for changing a Pose.
+  */
+object GaussianTranslationProposal {
+
+  /**
+    * Constructs a translation proposal, which only shifts in the xy-plane and leaves the z-value constant.
+    */
+  def apply(sdev: Vector2D) : GaussianTranslationProposal = {
+    Gaussian3DTranslationProposalConstantZ(sdev)
+  }
+
+  /**
+    * Constructs a full 3d translation proposal.
+    */
+  def apply(sdev: Vector3D) : GaussianTranslationProposal = {
+    Gaussian3DTranslationProposal(sdev)
+  }
+
+}
+
+/**
+  * Random translation proposal in 3D which is parallel to the xy plane.
+  * The z-value, i.e. the  distance to the camera is constant.
+  */
+private[proposals] case class Gaussian3DTranslationProposalConstantZ(sdev: Vector[_2D])(implicit rnd: Random)
+    extends GaussianTranslationProposal {
+  override def propose(current: Pose): Pose = current.copy(
+    translation = Vector(
+      current.translation.x + rnd.scalaRandom.nextGaussian() * sdev.x,
+      current.translation.y + rnd.scalaRandom.nextGaussian() * sdev.y,
+      current.translation.z)
+  )
+
+  /** rate of transition from to (log value) */
+  override def logTransitionProbability(from: Pose, to: Pose): Double = {
+    if (to.copy(translation = from.translation) != from)
+      Double.NegativeInfinity
+    else {
+      val diff = to.translation - from.translation
+      val px = GaussianEvaluator.probability(diff.x, 0, sdev.x)
+      val py = GaussianEvaluator.probability(diff.y, 0, sdev.y)
+      px + py
+    }
+  }
+}
+
+/**
+  * Full random translation proposal in 3D.
+  */
+private[proposals] case class Gaussian3DTranslationProposal(sdev: Vector[_3D])(implicit rnd: Random)
+  extends GaussianTranslationProposal {
+  override def propose(current: Pose): Pose = current.copy(
+    translation = Vector(
+      current.translation.x + rnd.scalaRandom.nextGaussian() * sdev.x,
+      current.translation.y + rnd.scalaRandom.nextGaussian() * sdev.y,
+      current.translation.z + rnd.scalaRandom.nextGaussian() * sdev.z)
+  )
+
+  /** rate of transition from to (log value) */
+  override def logTransitionProbability(from: Pose, to: Pose): Double = {
+    if (to.copy(translation = from.translation) != from)
+      Double.NegativeInfinity
+    else {
+      val diff = to.translation - from.translation
+      val px = GaussianEvaluator.probability(diff.x, 0, sdev.x)
+      val py = GaussianEvaluator.probability(diff.y, 0, sdev.y)
+      val pz = GaussianEvaluator.probability(diff.z, 0, sdev.z)
+      px + py + pz
+    }
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/ParameterProposals.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/ParameterProposals.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.proposals
+
+import scalismo.faces.parameters._
+import scalismo.sampling._
+
+/** methods to convert between proposals on partial parameters and full parameter proposals */
+object ParameterProposals {
+  /** implicit conversions for promoting partial BetterRenderParameters to full BetterRenderParameter proposals, just use "proposalGenerator.toParameterProposal" */
+  object implicits {
+    import scala.languageFeature.implicitConversions
+
+    /** implicit wrapper class for partial parameter proposals */
+    implicit class NakedPartialParameterProposal[A](proposal: ProposalGenerator[A])(implicit converter: PartialToFullParameterConverter[A]) {
+      def toParameterProposal: ProposalGenerator[RenderParameter] = new ProposalGenerator[RenderParameter] {
+        override def propose(current: RenderParameter): RenderParameter = {
+          val prop = proposal.propose(converter.partialParameter(current))
+          converter.fullParameter(prop, current)
+        }
+
+        override def toString: String = proposal.toString
+      }
+    }
+
+    /** implicit wrapper class for partial parameter proposals */
+    implicit class PartialParameterProposal[A](proposal: ProposalGenerator[A] with TransitionProbability[A])(implicit converter: PartialToFullParameterConverter[A]) {
+      def toParameterProposal: ProposalGenerator[RenderParameter] with TransitionProbability[RenderParameter] = new ProposalGenerator[RenderParameter] with TransitionProbability[RenderParameter] {
+        override def propose(current: RenderParameter): RenderParameter = {
+          val prop = proposal.propose(converter.partialParameter(current))
+          converter.fullParameter(prop, current)
+        }
+
+        override def logTransitionProbability(from: RenderParameter, to: RenderParameter): Double = proposal.logTransitionProbability(converter.partialParameter(from), converter.partialParameter(to))
+
+        override def toString: String = proposal.toString
+      }
+    }
+
+    /** implicit wrapper class for symmetric partial parameter proposals */
+    implicit class PartialSymmetricParameterProposal[A](proposal: ProposalGenerator[A] with SymmetricTransitionRatio[A])(implicit converter: PartialToFullParameterConverter[A]) {
+      def toParameterProposal: ProposalGenerator[RenderParameter] with SymmetricTransitionRatio[RenderParameter] = new ProposalGenerator[RenderParameter] with SymmetricTransitionRatio[RenderParameter] {
+        override def propose(current: RenderParameter): RenderParameter = {
+          val prop = proposal.propose(converter.partialParameter(current))
+          converter.fullParameter(prop, current)
+        }
+
+        override def toString: String = proposal.toString
+      }
+    }
+
+    /** implicit wrapper class for symmtric partial parameter proposals with a transition probability */
+    implicit class PartialTransitionSymmetricParameterProposal[A](proposal: ProposalGenerator[A] with SymmetricTransition[A])(implicit converter: PartialToFullParameterConverter[A]) {
+      def toParameterProposal: ProposalGenerator[RenderParameter] with SymmetricTransition[RenderParameter] = new ProposalGenerator[RenderParameter] with SymmetricTransition[RenderParameter] {
+        override def propose(current: RenderParameter): RenderParameter = {
+          val prop = proposal.propose(converter.partialParameter(current))
+          converter.fullParameter(prop, current)
+        }
+
+        override def logTransitionProbability(from: RenderParameter, to: RenderParameter): Double = proposal.logTransitionProbability(converter.partialParameter(from), converter.partialParameter(to))
+
+        override def toString: String = proposal.toString
+      }
+    }
+
+    // all implicits use the same promotion converters
+
+    trait PartialToFullParameterConverter[A] {
+      def fullParameter(partial: A, blueprint: RenderParameter): RenderParameter
+
+      def partialParameter(full: RenderParameter): A
+    }
+
+    implicit object ParameterAsFullParameter extends PartialToFullParameterConverter[RenderParameter] {
+      override def fullParameter(partial: RenderParameter, blueprint: RenderParameter): RenderParameter = partial
+
+      override def partialParameter(full: RenderParameter): RenderParameter = full
+    }
+
+    implicit object PoseAsFullParameter extends PartialToFullParameterConverter[Pose] {
+      override def fullParameter(partial: Pose, blueprint: RenderParameter): RenderParameter = blueprint.copy(pose = partial)
+
+      override def partialParameter(full: RenderParameter): Pose = full.pose
+    }
+
+    implicit object CameraAsFullParameter extends PartialToFullParameterConverter[Camera] {
+      override def fullParameter(partial: Camera, blueprint: RenderParameter): RenderParameter = blueprint.copy(camera = partial)
+
+      override def partialParameter(full: RenderParameter): Camera = full.camera
+    }
+
+    implicit object ColorAsFullParameter extends PartialToFullParameterConverter[ColorTransform] {
+      override def fullParameter(partial: ColorTransform, blueprint: RenderParameter): RenderParameter = blueprint.copy(colorTransform = partial)
+
+      override def partialParameter(full: RenderParameter): ColorTransform = full.colorTransform
+    }
+
+    implicit object MoMoInstanceAsFullParameter extends PartialToFullParameterConverter[MoMoInstance] {
+      override def fullParameter(partial: MoMoInstance, blueprint: RenderParameter): RenderParameter = {
+        val modelPart = blueprint.momo.copy(
+          shape = partial.shape,
+          color = partial.color,
+          expression = partial.expression
+        )
+        blueprint.copy(momo = modelPart)
+      }
+      override def partialParameter(full: RenderParameter): MoMoInstance = full.momo
+    }
+
+    implicit object SphericalHarmonicsLightAsFullParameter extends PartialToFullParameterConverter[SphericalHarmonicsLight] {
+      override def fullParameter(partial: SphericalHarmonicsLight, blueprint: RenderParameter): RenderParameter = blueprint.withEnvironmentMap(partial)
+
+      override def partialParameter(full: RenderParameter): SphericalHarmonicsLight = full.environmentMap
+    }
+  }
+}

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/SegmentationMasterProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/SegmentationMasterProposal.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.proposals
+
+import scalismo.faces.image.PixelImage
+import scalismo.faces.parameters.RenderParameter
+import scalismo.sampling.{ProposalGenerator, UnitTransition}
+import scalismo.utils.Random
+
+/**
+  * Combined Proposal for Segmentation and Parameters
+  * Proposes either new mask or new Parameterset
+  */
+class SegmentationMasterProposal(paramProposal: ProposalGenerator[RenderParameter], maskProposal: ProposalGenerator[(RenderParameter,PixelImage[Int])], paramProposalProb: Double)
+                                (implicit random: Random)
+  extends ProposalGenerator[(RenderParameter, PixelImage[Int])]
+    with UnitTransition[(RenderParameter, PixelImage[Int])]{
+
+  private var gate = false
+  override def propose(current: (RenderParameter, PixelImage[Int])): (RenderParameter, PixelImage[Int]) = {
+    gate = random.scalaRandom.nextDouble() < paramProposalProb
+    if (gate)
+      (paramProposal.propose(current._1), current._2)
+    else
+      maskProposal.propose(current)
+  }
+
+  override def toString: String = {
+    var str = s"MasterProposal("
+    if (gate)
+      str += paramProposal.toString + ")"
+    else
+      str += maskProposal.toString + ")"
+    str
+  }
+}
+
+object SegmentationMasterProposal {
+  def apply(paramProposal: ProposalGenerator[RenderParameter],
+            maskProposal:  ProposalGenerator[(RenderParameter,PixelImage[Int])],
+            paramProposalProb: Double)
+           (implicit random: Random) = new SegmentationMasterProposal(paramProposal, maskProposal, paramProposalProb)
+}
+
+

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/SphericalHarmonicsLightProposals.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/SphericalHarmonicsLightProposals.scala
@@ -1,0 +1,265 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.proposals
+
+import scalismo.faces.deluminate.SphericalHarmonicsOptimizer
+import scalismo.faces.parameters.{RenderParameter, SphericalHarmonicsLight}
+import scalismo.faces.sampling.evaluators.LogNormalDistribution
+import scalismo.geometry.{Vector, _3D}
+import scalismo.mesh.{BarycentricCoordinates, TriangleId, TriangleMesh3D}
+import scalismo.sampling.evaluators.GaussianEvaluator
+import scalismo.sampling.{ProposalGenerator, SymmetricTransition, TransitionProbability}
+import scalismo.utils.Random
+
+import scala.math._
+
+/** illumination proposals */
+object SphericalHarmonicsLightProposals {
+
+  /** vary the light intensity
+    * @param logSdev log of expected variation factor
+    */
+  case class SHLightIntensityProposal(logSdev: Double)(implicit rnd: Random)
+    extends ProposalGenerator[SphericalHarmonicsLight] with TransitionProbability[SphericalHarmonicsLight] {
+
+    override def propose(current: SphericalHarmonicsLight): SphericalHarmonicsLight = {
+      val factor = exp(rnd.scalaRandom.nextGaussian() * logSdev * 0.5)
+      current.copy(coefficients = current.coefficients.map(_ * factor: Vector[_3D]))
+    }
+
+    override def logTransitionProbability(from: SphericalHarmonicsLight, to: SphericalHarmonicsLight): Double = {
+      LogNormalDistribution.logDensity(math.sqrt(to.energy/from.energy), 0.0, logSdev)
+    }
+  }
+
+  /** vary the color distribution of the illumination while keeping the intensity constant */
+  case class SHLightColorProposal(sdev: Double)(implicit rnd: Random)
+    extends ProposalGenerator[SphericalHarmonicsLight] with SymmetricTransition[SphericalHarmonicsLight] {
+
+    override def propose(current: SphericalHarmonicsLight): SphericalHarmonicsLight = {
+      val shift = Vector(
+        rnd.scalaRandom.nextGaussian() * sdev,
+        rnd.scalaRandom.nextGaussian() * sdev,
+        rnd.scalaRandom.nextGaussian() * sdev
+      )
+      val proposal = current.copy(coefficients = current.coefficients.map(v => v + shift))
+      val intensityChange = sqrt(proposal.energy / current.energy)
+      proposal.copy(coefficients = proposal.coefficients.map(v => v / intensityChange: Vector[_3D]))
+    }
+
+    override def logTransitionProbability(from: SphericalHarmonicsLight, to: SphericalHarmonicsLight): Double = {
+      require(from.coefficients.length == to.coefficients.length, "the same number of SH components")
+      val shifts =to.coefficients.zip(from.coefficients).map{case(t, f) => t - f}
+      val allShiftsEqual = shifts.forall(shift => (shift - shifts.head).norm2 < 1e-5)
+      if (math.abs(from.energy - to.energy) < 1e-5 && allShiftsEqual) {
+        val (t, f) = (to.coefficients.head, from.coefficients.head)
+        GaussianEvaluator.probability(t.x, f.x, sdev) +
+          GaussianEvaluator.probability(t.y, f.y, sdev) +
+          GaussianEvaluator.probability(t.z, f.z, sdev)
+      }
+      else
+        Double.NegativeInfinity
+    }
+  }
+
+  /** independent Gaussian perturbation of the SH illumination parameter
+    * @param sdev standard deviation of proposal per component
+    * @param fixIntensity if true the intensity is perserved */
+  case class SHLightPerturbationProposal(sdev: Double, fixIntensity: Boolean)(implicit rnd: Random)
+    extends ProposalGenerator[SphericalHarmonicsLight] with SymmetricTransition[SphericalHarmonicsLight] {
+
+    override def propose(current: SphericalHarmonicsLight): SphericalHarmonicsLight = {
+      val proposal = current.copy(coefficients = current.coefficients.map(v => v + Vector(
+        rnd.scalaRandom.nextGaussian(),
+        rnd.scalaRandom.nextGaussian(),
+        rnd.scalaRandom.nextGaussian()
+      ) * sdev ))
+      val intensityChange = sqrt(proposal.energy / current.energy)
+      if (fixIntensity)
+        proposal.copy(coefficients = proposal.coefficients.map(v => v / intensityChange: Vector[_3D]))
+      else
+        proposal
+    }
+
+    override def logTransitionProbability(from: SphericalHarmonicsLight, to: SphericalHarmonicsLight): Double = {
+      val intChange = math.sqrt(to.energy/from.energy)
+      if (!fixIntensity || intChange < 1e-5)
+        to.coefficients.zip(from.coefficients).map{case(t, f) =>
+          GaussianEvaluator.probability(t.x, f.x, sdev) +
+            GaussianEvaluator.probability(t.y, f.y, sdev) +
+            GaussianEvaluator.probability(t.z, f.z, sdev)
+        }.sum
+      else
+        Double.NegativeInfinity
+
+    }
+  }
+
+  /**
+    * Randomly changes the light intensity of the shl bands according to std of a normal distribution.
+    *
+    * @param logSdev log of expected factor of variation for each component
+    */
+  case class SHLightBandEnergyMixer(logSdev: Double)(implicit rnd: Random)
+    extends ProposalGenerator[SphericalHarmonicsLight] with TransitionProbability[SphericalHarmonicsLight] {
+
+    override def propose(current: SphericalHarmonicsLight): SphericalHarmonicsLight = {
+      if (current.nonEmpty) {
+        val bands = sqrt(current.coefficients.size).floor.toInt
+        require(bands * bands - current.coefficients.size == 0, "SHLightBandEnergyMixer: number of bands unknown")
+        val coeff: Array[Vector[_3D]] = current.coefficients.toArray
+        for (b <- 1 to bands) {
+          val factor = math.exp(rnd.scalaRandom.nextGaussian() * logSdev)
+          for (i <- (b - 1) * (b - 1) until b * b) {
+            coeff(i) = coeff(i) * factor
+          }
+        }
+        SphericalHarmonicsLight(coeff.toIndexedSeq)
+      } else {
+        current
+      }
+    }
+
+    override def logTransitionProbability(from: SphericalHarmonicsLight, to: SphericalHarmonicsLight): Double = {
+      val toVec = to.coefficients
+      val fromVec = from.coefficients
+      if (toVec.size != fromVec.size)
+        Double.NegativeInfinity
+      else if (toVec.isEmpty) {
+        0.0
+      } else {
+        var totProb = 0.0
+        val bands = math.sqrt(toVec.size).toInt
+        require(bands * bands - toVec.size == 0, "unknown number of bands")
+        for (b <- 1 to bands) {
+          var intFrom = 0.0
+          var intTo = 0.0
+          for (i <- (b - 1) * (b - 1) until b * b) {
+            intFrom = intFrom + fromVec(i).dot(fromVec(i))
+            intTo = intTo + toVec(i).dot(toVec(i))
+          }
+          if (intTo > 1e-4 && intFrom > 1e-4) {
+            val logFactor = math.log(intTo / intFrom)
+            totProb = totProb + -0.5 * math.pow(logFactor / logSdev, 2) - 0.5 * math.log(2.0 * math.Pi) - math.log(logSdev)
+          }
+        }
+        totProb
+      }
+    }
+  }
+
+  /**
+    * Draw from a proposalGenerator in a way such that it has the same illumination intensity as a given sample.
+    * We adjust the intensity of a sample drawn from proposalGenerator, so that it has the same intensity as the given proposal.
+    *
+    * @param proposalGenerator underlying proposal generator to use, proposal of it will get a rescaled light
+    */
+  case class SHLightIntensityPreservingProposal(proposalGenerator: ProposalGenerator[SphericalHarmonicsLight] with TransitionProbability[SphericalHarmonicsLight])(implicit rnd: Random)
+    extends ProposalGenerator[SphericalHarmonicsLight] with TransitionProbability[SphericalHarmonicsLight] {
+
+    /**
+      * Scale "to" according fromIntensity/toIntensity
+      * Calculate intensity of to.
+      * Calculate intensity of from.
+      */
+    def scaleSample(from: SphericalHarmonicsLight, to: SphericalHarmonicsLight): SphericalHarmonicsLight = {
+      val toVec = to.coefficients
+      val fromVec = from.coefficients
+      val intTo = toVec.foldLeft(0.0)((acc, v) => acc + v.dot(v))
+      val intFrom = fromVec.foldLeft(0.0)((acc, v) => acc + v.dot(v))
+      val factor = math.sqrt(intFrom / intTo)
+      val adjustedTo = SphericalHarmonicsLight(toVec.map(v => v * factor))
+      adjustedTo
+    }
+
+    /**
+      * Scale the new sample by the factor currentIntensity/newSampleIntensity.
+      */
+    override def propose(current: SphericalHarmonicsLight): SphericalHarmonicsLight = {
+      val newSample = proposalGenerator.propose(current)
+      scaleSample(current, newSample)
+    }
+
+    /** rate of transition from to */
+    override def logTransitionProbability(from: SphericalHarmonicsLight, to: SphericalHarmonicsLight): Double = {
+      if (to.coefficients.size != from.coefficients.size)
+        Double.NegativeInfinity
+      else if (to.coefficients.isEmpty) {
+        0.0
+      } else {
+        val adjustedTo = scaleSample(from, to)
+        proposalGenerator.logTransitionProbability(from, adjustedTo)
+      }
+    }
+  }
+
+  /**
+    * Perturbs the shl coefficients, without changing the color.
+    */
+  case class SHLightSpatialPerturbation(sdev: Double)(implicit rnd: Random)
+    extends ProposalGenerator[SphericalHarmonicsLight] with TransitionProbability[SphericalHarmonicsLight] {
+    val monochromaticityThreshold = 1e-3
+    /**
+      * Add random normal monochromatic values to current.
+      */
+    override def propose(current: SphericalHarmonicsLight): SphericalHarmonicsLight = {
+      SphericalHarmonicsLight(current.coefficients.map(v => {
+        val value = rnd.scalaRandom.nextGaussian() * sdev
+        v + Vector(value, value, value) //monochrome: add the same to every channel
+      }))
+    }
+
+    /**
+      * Checks if the change between from and to was due to this proposal generator.
+      * In the case of non-monochromatic changes we yield -inf.
+      * In the case of monochromatic change we return the probability.
+      * The probability depends only on the amount of the chromatic change.
+      */
+    override def logTransitionProbability(from: SphericalHarmonicsLight, to: SphericalHarmonicsLight): Double = {
+      if (to.coefficients.size != from.coefficients.size)
+        Double.NegativeInfinity
+      else if (to.coefficients.isEmpty) {
+        0.0
+      } else {
+        val toVec = to.coefficients
+        val fromVec = from.coefficients
+        var totProb = 0.0
+        for (i <- toVec.indices) {
+          val diff = toVec(i) - fromVec(i)
+          if (math.abs(diff.x - diff.y) + math.abs(diff.y - diff.z) < monochromaticityThreshold) { //if monochromatic change, then we could take any channel, we choose the first one.
+            totProb += 3.0 * (-0.5 * math.pow(diff.x / sdev, 2) - 0.5 * math.log(2.0 * math.Pi) - math.log(sdev))
+          } else {
+            return Double.NegativeInfinity //if non monochromatic change
+          }
+        }
+        totProb
+      }
+    }
+  }
+
+  /** use the linear solver to find the best illumination parameters */
+  case class SHLightSolverProposal(sphericalHarmonicsOptimizer: SphericalHarmonicsOptimizer,
+                                   samplingFunction: TriangleMesh3D => IndexedSeq[(TriangleId, BarycentricCoordinates)])(implicit rnd: Random)
+    extends ProposalGenerator[RenderParameter] with TransitionProbability[RenderParameter] {
+    override def propose(current: RenderParameter): RenderParameter = current.copy(
+      environmentMap = sphericalHarmonicsOptimizer.optimize(current, samplingFunction)
+    )
+    override def logTransitionProbability(from: RenderParameter, to: RenderParameter): Double = 0.0
+
+    override def toString = s"SHLightSolverProposal($sphericalHarmonicsOptimizer)"
+  }
+}

--- a/src/main/scala/scalismo/faces/utils/GeneralMaxConvolution.scala
+++ b/src/main/scala/scalismo/faces/utils/GeneralMaxConvolution.scala
@@ -1,0 +1,72 @@
+package scalismo.faces.utils
+
+import scalismo.faces.image.PixelImage
+import scalismo.geometry.{Point, Point1D, _1D}
+import scalismo.sampling.DistributionEvaluator
+
+/** perform general max/min convolutions, such as distance transforms etc. */
+object GeneralMaxConvolution {
+
+  /** calculate a separable max convolution efficiently */
+  def separableMaxConvolution(pixelImage: PixelImage[Double], eval: DistributionEvaluator[Point[_1D]]): PixelImage[Double] = {
+    val tmp = pixelImage.toBuffer
+
+    for (col <- 0 until tmp.domain.height) {
+      val row = pixelImage.row(col)
+
+      val tRow = full1DMaxConvolution(row.toArray, eval)
+      for (x <- 0 until tmp.domain.width) {
+        tmp(x, col) = tRow(x)
+      }
+    }
+
+    val tImg = tmp.toImage
+
+    for (row <- 0 until tmp.domain.width) {
+      val col = tImg.col(row)
+      val tCol = full1DMaxConvolution(col.toArray, eval)
+      for (y <- 0 until tmp.domain.height) {
+        tmp(row, y) = tCol(y)
+      }
+    }
+
+    tmp.toImage
+  }
+
+  /** calculate 1D convolution */
+  def full1DMaxConvolution(data: Array[Double], eval: DistributionEvaluator[Point[_1D]]): Array[Double] = {
+
+    var maximumsPosition = 0
+    var tmp = data.clone().toBuffer
+
+    // keep this line if the local position is often the best one
+    tmp.transform(t => t + eval.logValue(Point1D(0f)))
+
+    // forward pass
+    for (i <- data.indices) {
+      var mPos = i
+      for (lag <- maximumsPosition until i) {
+        val t = data(lag) + eval.logValue(Point1D(i - lag))
+        if (tmp(i) < t) {
+          tmp(i) = t
+          mPos = lag
+        }
+      }
+      maximumsPosition = mPos
+    }
+
+    // backward pass
+    for (i <- maximumsPosition to 0 by -1) {
+      var mPos = i
+      for (lag <- maximumsPosition until i by -1) {
+        val t = data(lag) + eval.logValue(Point1D(i - lag))
+        if (tmp(i) < t) {
+          tmp(i) = t
+          mPos = lag
+        }
+      }
+      maximumsPosition = mPos
+    }
+    tmp.toArray
+  }
+}

--- a/src/test/scala/scalismo/faces/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/faces/io/MeshIOTests.scala
@@ -180,13 +180,13 @@ class MeshIOTests extends FacesTestSuite {
 
       it("with ply format") {
         val f = File.createTempFile("scalismo-faces-test-meshio", ".ply")
-        //f.deleteOnExit()
+        f.deleteOnExit()
         testWriteReadCycleWithTexture(rndMesh, f)
       }
 
       it("with msh format") {
         val f = File.createTempFile("scalismo-faces-test-meshio", ".msh.gz")
-        //f.deleteOnExit()
+        f.deleteOnExit()
         testWriteReadCycleWithTexture(rndMesh, f)
       }
     }

--- a/src/test/scala/scalismo/faces/sampling/evaluators/CachedDistributionEvaluatorTest.scala
+++ b/src/test/scala/scalismo/faces/sampling/evaluators/CachedDistributionEvaluatorTest.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.evaluators
+
+import scalismo.faces.FacesTestSuite
+import scalismo.sampling.DistributionEvaluator
+
+class CachedDistributionEvaluatorTest extends FacesTestSuite {
+
+  private val underlyingEval: DistributionEvaluator[Double] = new DistributionEvaluator[Double] {
+    override def logValue(sample: Double): Double = -sample
+  }
+
+  describe("CachedDistributionEvaluatorTest") {
+
+    it("should yield the underlying evaluator's logValue") {
+      val cachedEval = CachedDistributionEvaluator(underlyingEval, 1)
+      cachedEval.logValue(-5.2) shouldBe underlyingEval.logValue(-5.2)
+    }
+
+    it("should cache the underlying evaluator's logValue and not execute a side-effect a second time") {
+      var sideEffectCounter = 0
+      val evalWithSideEffect: DistributionEvaluator[Double] = new DistributionEvaluator[Double] {
+        override def logValue(sample: Double): Double = {
+          sideEffectCounter += 1
+          -sample
+        }
+      }
+
+      val cachedEval = CachedDistributionEvaluator(evalWithSideEffect, 2)
+
+      def shouldBeCached(value: Double): Unit = {
+        sideEffectCounter = 0
+        cachedEval.logValue(value) shouldBe evalWithSideEffect.logValue(value)
+        sideEffectCounter shouldBe 1 // only 1 from underlying
+      }
+
+      def shouldNotBeCached(value: Double): Unit = {
+        sideEffectCounter = 0
+        cachedEval.logValue(value) shouldBe evalWithSideEffect.logValue(value)
+        sideEffectCounter shouldBe 2 // 2 calls: cached and underlying
+      }
+
+      // tests
+      shouldNotBeCached(1.0)
+      shouldBeCached(1.0)
+    }
+
+    it("should keep its cache at the specified size limit") {
+      var sideEffectCounter = 0
+      val evalWithSideEffect: DistributionEvaluator[Double] = new DistributionEvaluator[Double] {
+        override def logValue(sample: Double): Double = {
+          sideEffectCounter += 1
+          -sample
+        }
+      }
+
+      val cachedEval = CachedDistributionEvaluator(evalWithSideEffect, 2)
+
+
+      def shouldBeCached(value: Double): Unit = {
+        sideEffectCounter = 0
+        cachedEval.logValue(value) shouldBe evalWithSideEffect.logValue(value)
+        sideEffectCounter shouldBe 1 // only 1 from underlying
+      }
+
+      def shouldNotBeCached(value: Double): Unit = {
+        sideEffectCounter = 0
+        cachedEval.logValue(value) shouldBe evalWithSideEffect.logValue(value)
+        sideEffectCounter shouldBe 2 // 2 calls: cached and underlying
+      }
+      // first value
+      shouldNotBeCached(1.0)
+      shouldBeCached(1.0)
+      // second value: first and second in cache
+      shouldNotBeCached(2.0)
+      shouldBeCached(2.0)
+      shouldBeCached(1.0)
+      // third value: second and third in cache, first removed
+      shouldNotBeCached(3.0)
+      shouldBeCached(3.0)
+      shouldBeCached(2.0)
+      shouldNotBeCached(1.0)
+    }
+
+    it("can be constructed using implicit notation") {
+      import CachedDistributionEvaluator.implicits._
+      underlyingEval.cached(2) shouldBe a [CachedDistributionEvaluator[_]]
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/sampling/evaluators/EvaluatorTests.scala
+++ b/src/test/scala/scalismo/faces/sampling/evaluators/EvaluatorTests.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.evaluators
+
+import scalismo.faces.FacesTestSuite
+import scalismo.sampling.evaluators.GaussianEvaluator
+
+class EvaluatorTests extends FacesTestSuite {
+
+  describe("The LogNormalDistribution") {
+    it("returns the same density value as a Gaussian of the log") {
+      val x = 0.5 + math.abs(rnd.scalaRandom.nextGaussian())
+      val dlogN = LogNormalDistribution.logDensity(x, 0.0, 1.0)
+      val dGauss = GaussianEvaluator.probability(math.log(x), 0.0, 1.0)
+      dlogN shouldBe dGauss +- 1e-5
+    }
+
+    it("returns the same value if evaluated as a factor around 1.0 or as value around the mean (mean can be shifted)") {
+      val dLogM = LogNormalDistribution.logDensity(2.0, math.log(1.5), math.log(1.5))
+      val dLogZ = LogNormalDistribution.logDensity(2.0/1.5, 0.0, math.log(1.5))
+      dLogM shouldBe dLogZ +- 1e-5
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/sampling/face/PointEvaluatorTests.scala
+++ b/src/test/scala/scalismo/faces/sampling/face/PointEvaluatorTests.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face
+
+import scalismo.faces.FacesTestSuite
+import scalismo.faces.sampling.face.evaluators.PointEvaluators.IsotropicGaussianPointEvaluator
+import scalismo.geometry.{Point, _2D}
+
+class PointEvaluatorTests extends FacesTestSuite {
+
+  val origin: Point[_2D] = Point.origin[_2D]
+
+  def randomPoint(distance: Double): Point[_2D] = origin + randomDirection * distance
+
+  describe("PointEvaluators:") {
+
+    it("The isotropic Gaussian evaluator obeys the 2d Gaussian density") {
+      val sigma = 1.5
+      val dist = 2.0
+
+      val eval = IsotropicGaussianPointEvaluator[_2D](sigma)
+      val distEval = eval.toDistributionEvaluator(Point(0.0, 0.0))
+
+      val point = randomPoint(dist * sigma)
+
+      distEval.logValue(point) - math.log(math.Pi * 2) - 2 * math.log(sigma) - 0.5 * dist * dist should be < 1e-4
+    }
+
+  }
+}

--- a/src/test/scala/scalismo/faces/sampling/face/evaluators/FaceBoxEvaluatorTest.scala
+++ b/src/test/scala/scalismo/faces/sampling/face/evaluators/FaceBoxEvaluatorTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.FacesTestSuite
+import scalismo.geometry.{Point, Point2D, Vector}
+
+class FaceBoxEvaluatorTest extends FacesTestSuite {
+
+  val yamlCodeBox =
+    """
+      |%YAML:1.0
+      |FaceBox: [ 66, 111, 355, 355 ]
+      |pFace: 9.6226720524414477e-01
+    """.stripMargin
+
+  describe("A Face box (face detection candidate)") {
+
+    var fb: FaceBox = FaceBox(Point2D.origin, Point2D.origin, 0.0)
+
+    it("is read properly") {
+      fb = FaceBox.fromYAML(yamlCodeBox).get
+      fb.topLeft shouldBe Point(66, 111)
+      fb.size shouldBe Vector(355, 355)
+      fb.certainty shouldBe 0.9623 +- 1e-4
+    }
+
+    it("has the position (center)") {
+      fb.center shouldBe Point(243.5, 288.5)
+      fb.bottomRight shouldBe Point(421, 466)
+    }
+
+    it("has the proper scale") {
+      fb.scale shouldBe 167.348 +- 1e-2
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/utils/GeneralMaxConvolutionTest.scala
+++ b/src/test/scala/scalismo/faces/utils/GeneralMaxConvolutionTest.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.utils
+
+import breeze.numerics.log
+import org.scalactic.Equality
+import scalismo.faces.FacesTestSuite
+import scalismo.faces.image.PixelImage
+import scalismo.faces.sampling.face.evaluators.PointEvaluators.IsotropicGaussianPointEvaluator
+import scalismo.geometry.{Point1D, Point2D, _1D, _2D}
+
+class GeneralMaxConvolutionTest extends FacesTestSuite {
+
+  new Equality[Double] {
+    def areEqual(a: Double, b: Any): Boolean =
+      b match {
+        case p: Double => a === p +- 0.0
+        case _ => false
+      }
+  }
+
+  describe("general max convolution") {
+
+    def fixture = new {
+      val noise = 1
+      val eval = IsotropicGaussianPointEvaluator[_1D](noise).toDistributionEvaluator(Point1D(0f))
+      val eval2d = IsotropicGaussianPointEvaluator[_2D](noise).toDistributionEvaluator(Point2D(0f, 0f))
+      val width = 5
+      val height = 5
+      val image = PixelImage(width, height, (x, y) => {
+        (x + y).toDouble
+      }).map(p => log(p / (width + height - 2) * 0.9 + 0.1))
+      val row = image.row(0)
+    }
+
+    describe("in 1d") {
+      it("should be calculated correctly") {
+        val f = fixture
+        val result = GeneralMaxConvolution.full1DMaxConvolution(f.row.toArray, f.eval)
+
+        def evalForPosition(p: Int) {
+          val values = f.row.toArray.zipWithIndex.map { e => e._1 + f.eval.logValue(Point1D(e._2 - p)) }
+          result(p) shouldEqual values.max
+        }
+
+        for (p <- 0 until f.width) {
+          evalForPosition(p)
+        }
+
+      }
+    }
+
+    describe("in 2d") {
+      it("should be correct using the separable version") {
+        val f = fixture
+        val result = GeneralMaxConvolution.separableMaxConvolution(f.image, f.eval)
+
+        def evalForPosition(p: Int, q: Int) {
+          val values = (0 until f.width).flatMap { x =>
+            (0 until f.height).map { y =>
+              f.image(x, y) + f.eval2d.logValue(Point2D(x - p, y - q))
+            }
+          }
+          result(p, q) shouldEqual values.max
+        }
+
+        for (p <- 0 until f.width; q <- 0 until f.height) {
+          evalForPosition(p, q)
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
I added (transferred) the fitting code with MCMC sampler fitting.

Packages include `scalismo.faces.sampling` and `scalismo.faces.sampling.face` mainly

- Proposal distributions
- DistributionEvaluators as used for model fitting
- Some useful Loggers

Code is mainly transferred, not changed

Resolves #19 