### PR TITLE
RenderParameter files V3.0 can now be read.

### DIFF
--- a/src/main/scala/scalismo/faces/io/RenderParameterIO.scala
+++ b/src/main/scala/scalismo/faces/io/RenderParameterIO.scala
@@ -24,7 +24,7 @@ import scalismo.faces.parameters.RenderParameter
 import scalismo.faces.utils.ResourceManagement
 import spray.json._
 
-import RenderParameterJSONFormat.defaultFormat._
+import RenderParameterJSONFormat.renderParameterFormat
 
 import scala.util.Try
 

--- a/src/test/scala/scalismo/faces/io/ParametersIOTests.scala
+++ b/src/test/scala/scalismo/faces/io/ParametersIOTests.scala
@@ -388,6 +388,19 @@ class ParametersIOTests extends FacesTestSuite {
       v4Param shouldBe targetParam
     }
 
+    it("can read the correct version from the files content") {
+      Seq(
+        "/renderParametersV4.rps",
+        "/renderParametersV3.rps",
+        "/renderParametersV2.rps",
+        "/renderParametersV1.rps"
+      ) foreach { filename =>
+        val param = RenderParameterIO.read(new File(this.getClass.getResource(filename).getPath)).get
+        identical(param,targetParam)
+      }
+    }
+
+
     it("can be written to and read from a file") {
       val f = File.createTempFile("ParameterIOTest", ".rps")
       f.deleteOnExit()


### PR DESCRIPTION
Reading of RenderParameter files V3.0 in RenderParameterIO.
Writing to still to current version (4.0).

Resolves #30 