### PR TITLE
Update to scalismo-0.15-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,14 +8,10 @@ scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 resolvers += Resolver.jcenterRepo
 
 libraryDependencies  ++= Seq(
-    "ch.unibas.cs.gravis" %% "scalismo" % "0.14.0",
-    "ch.unibas.cs.gravis" % "scalismo-native-all" % "3.0.0",
+    "ch.unibas.cs.gravis" %% "scalismo" % "0.15.0-RC1",
+    "ch.unibas.cs.gravis" % "scalismo-native-all" % "4.0.0",
     "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 )
-
-// hack to resolve issues with 3.0.+ dependency of scalismo-0.14.0
-// should be fixed by setting to explicit version number
-dependencyOverrides += "ch.unibas.cs.gravis" % "scalismo-native-stub" % "3.0.0"
 
 // Git versioning
 enablePlugins(GitVersioning, GitBranchPrompt)

--- a/src/main/scala/scalismo/faces/image/pyramid/GaussPyramid.scala
+++ b/src/main/scala/scalismo/faces/image/pyramid/GaussPyramid.scala
@@ -49,7 +49,7 @@ class GaussPyramid[A: ClassTag](val image: PixelImage[A], val reduce: ImageFilte
   override val level: Seq[PixelImage[A]] = {
     def makeReducedImages(image: PixelImage[A], levels: Int): Seq[PixelImage[A]] = {
       if (levels == 0) Seq(image)
-      else image +: makeReducedImages(reduce(image), levels - 1)
+      else image +: makeReducedImages(reduce.filter(image), levels - 1)
     }
 
     makeReducedImages(image, maxReductions)

--- a/src/main/scala/scalismo/faces/image/pyramid/LaplacePyramid.scala
+++ b/src/main/scala/scalismo/faces/image/pyramid/LaplacePyramid.scala
@@ -37,13 +37,13 @@ class LaplacePyramid[A: ClassTag](val imagePyramid: ImagePyramid[A], val expand:
 
   override val level: Seq[PixelImage[A]] = {
     val images = imagePyramid.level
-    images.init.zip(images.tail).map(p => p._1 - expand(p._2)) :+ images.last
+    images.init.zip(images.tail).map(p => p._1 - expand.filter(p._2)) :+ images.last
   }
 
   /**
     * Reconstructs the original image using the expand function and the addition of images based on the passed ColorSpaceOperations ops.
     */
-  def reconstruct: PixelImage[A] = level.init.foldRight(level.last)((diff, combined) => expand(combined) + diff)
+  def reconstruct: PixelImage[A] = level.init.foldRight(level.last)((diff, combined) => expand.filter(combined) + diff)
 }
 
 object LaplacePyramid {

--- a/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatLegacy.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatLegacy.scala
@@ -33,7 +33,7 @@ trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
     override def write(vec: Vector[_1D]): JsValue = JsArray(JsNumber(vec.x))
 
     override def read(json: JsValue): Vector[_1D] = json match {
-      case JsArray(List(JsNumber(x))) => Vector(x.toDouble)
+      case JsArray(Seq(JsNumber(x))) => Vector(x.toDouble)
       case _ => deserializationError("Expected Vector[_1D], got:" + json)
     }
   }
@@ -42,7 +42,7 @@ trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
     override def write(vec: Vector[_2D]): JsValue = JsArray(JsNumber(vec.x), JsNumber(vec.y))
 
     override def read(json: JsValue): Vector[_2D] = json match {
-      case JsArray(List(JsNumber(x), JsNumber(y))) => Vector(x.toDouble, y.toDouble)
+      case JsArray(Seq(JsNumber(x), JsNumber(y))) => Vector(x.toDouble, y.toDouble)
       case _ => deserializationError("Expected Vector[_2D], got:" + json)
     }
   }
@@ -51,7 +51,7 @@ trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
     override def write(vec: Vector[_3D]): JsValue = JsArray(JsNumber(vec.x), JsNumber(vec.y), JsNumber(vec.z))
 
     override def read(json: JsValue): Vector[_3D] = json match {
-      case JsArray(List(JsNumber(x), JsNumber(y), JsNumber(z))) => Vector(x.toDouble, y.toDouble, z.toDouble)
+      case JsArray(Seq(JsNumber(x), JsNumber(y), JsNumber(z))) => Vector(x.toDouble, y.toDouble, z.toDouble)
       case _ => deserializationError("Expected Vector[_3D], got:" + json)
     }
   }
@@ -60,7 +60,7 @@ trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
     override def write(col: RGB): JsValue = JsArray(JsNumber(col.r), JsNumber(col.g), JsNumber(col.b))
 
     override def read(json: JsValue): RGB = json match {
-      case JsArray(List(JsNumber(r), JsNumber(g), JsNumber(b))) => RGB(r.toDouble, g.toDouble, b.toDouble)
+      case JsArray(Seq(JsNumber(r), JsNumber(g), JsNumber(b))) => RGB(r.toDouble, g.toDouble, b.toDouble)
       case _ => deserializationError(s"Expected RGB, got: $json")
     }
   }
@@ -69,7 +69,7 @@ trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
     override def write(col: RGBA): JsValue = JsArray(JsNumber(col.r), JsNumber(col.g), JsNumber(col.b), JsNumber(col.a))
 
     override def read(json: JsValue): RGBA = json match {
-      case JsArray(List(JsNumber(r), JsNumber(g), JsNumber(b), JsNumber(a))) => RGBA(r.toDouble, g.toDouble, b.toDouble, a.toDouble)
+      case JsArray(Seq(JsNumber(r), JsNumber(g), JsNumber(b), JsNumber(a))) => RGBA(r.toDouble, g.toDouble, b.toDouble, a.toDouble)
       case _ => deserializationError(s"Expected RGBA, got: $json")
     }
   }
@@ -77,7 +77,7 @@ trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
   implicit val uriFormat: JsonFormat[URI] = new JsonFormat[URI] {
     override def read(json: JsValue): URI = json match {
       case JsString(uri) => new URI(uri)
-      case _ => throw new DeserializationException(s"expected URI, got $json")
+      case _ => throw DeserializationException(s"expected URI, got $json")
     }
 
     override def write(obj: URI): JsValue = JsString(obj.toString)
@@ -173,7 +173,7 @@ trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
 
     override def read(json: JsValue): ImageSize = json match {
       // warning: order of width and height is not as expected!!
-      case JsArray(List(JsNumber(height), JsNumber(width))) => ImageSize(width.toInt, height.toInt)
+      case JsArray(Seq(JsNumber(height), JsNumber(width))) => ImageSize(width.toInt, height.toInt)
       case _ => deserializationError("Expected Image, got:" + json)
     }
   }
@@ -232,7 +232,7 @@ trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
         if (shl.isEmpty)
           shl
         else if (shl.size > 9)
-          throw new DeserializationException("SHL json reader (V1): cannot read more than 2 bands (9 coeffs), there is no conversion from jz to our format")
+          throw DeserializationException("SHL json reader (V1): cannot read more than 2 bands (9 coeffs), there is no conversion from jz to our format")
         else {
           // 1 - 0 coeffs
           val permutation = IndexedSeq(0, 2, 3, 1, 7, 5, 4, 6, 8).take(shl.size)
@@ -274,7 +274,7 @@ trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
       if (fields.contains("version")) {
         val version = fields("version").convertTo[String]
         if (version != "1.0")
-          throw new DeserializationException(s"V1 json reader expects V1.0 json file, got: $version")
+          throw DeserializationException(s"V1 json reader expects V1.0 json file, got: $version")
       }
 
       // parse illumination: SHL overrides directed light

--- a/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatV2.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatV2.scala
@@ -217,7 +217,7 @@ trait RenderParameterJSONFormatV2 extends RenderParameterJSONFormatLegacy {
     override def write(vec: Point[_2D]): JsValue = JsArray(JsNumber(vec.x), JsNumber(vec.y))
 
     override def read(json: JsValue): Point[_2D] = json match {
-      case JsArray(List(JsNumber(x), JsNumber(y))) => Point(x.toDouble, y.toDouble)
+      case JsArray(Seq(JsNumber(x), JsNumber(y))) => Point(x.toDouble, y.toDouble)
       case _ => deserializationError("Expected Point[_2D], got:" + json)
     }
   }

--- a/src/main/scala/scalismo/faces/mesh/DiscreteLaplaceBeltrami.scala
+++ b/src/main/scala/scalismo/faces/mesh/DiscreteLaplaceBeltrami.scala
@@ -94,7 +94,7 @@ object DiscreteLaplaceBeltrami {
         builderCOT.add(tr.ptId3.id, tr.ptId1.id, cotB)
       })
       val COT = builderCOT.result
-      (COT + COT.t) :* 2.0
+      (COT + COT.t) *:* 2.0
     }
     val cot = cotangentWeightMatrix(ref)
     (i: PointId, j: PointId) => cot(i.id, j.id)

--- a/src/main/scala/scalismo/faces/momo/MoMo.scala
+++ b/src/main/scala/scalismo/faces/momo/MoMo.scala
@@ -516,11 +516,12 @@ case class MoMoExpress(override val referenceMesh: TriangleMesh3D,
     require(colorComps >= 0 && colorComps <= color.rank, "illegal number of reduced color components")
     require(expressComps >= 0 && expressComps <= expression.rank, "illegal number of reduced expression components")
 
-    val redShape = PancakeDLRGP(ModelHelpers.truncateDLRGP(shape.gpModel, shapeComps), shape.noiseVariance)
-    val redColor = PancakeDLRGP(ModelHelpers.truncateDLRGP(color.gpModel, colorComps), color.noiseVariance)
-    val redExpress = PancakeDLRGP(ModelHelpers.truncateDLRGP(expression.gpModel, expressComps), expression.noiseVariance)
-
-    MoMoExpress(referenceMesh, redShape, redColor, redExpress, landmarks)
+    MoMoExpress(
+      referenceMesh,
+      shape.truncate(shapeComps),
+      color.truncate(colorComps),
+      expression.truncate(expressComps),
+      landmarks)
   }
 
   // converters to deal with discrete fields
@@ -655,10 +656,11 @@ case class MoMoBasic(override val referenceMesh: TriangleMesh3D,
     require(colorComps >= 0 && colorComps <= color.rank, "illegal number of reduced color components")
 
     // @todo allow reduction with increasing noise to capture removed components
-    val redShape = PancakeDLRGP(ModelHelpers.truncateDLRGP(shape.gpModel, shapeComps), shape.noiseVariance)
-    val redColor = PancakeDLRGP(ModelHelpers.truncateDLRGP(color.gpModel, colorComps), color.noiseVariance)
-
-    MoMoBasic(referenceMesh, redShape, redColor, landmarks)
+    MoMoBasic(
+      referenceMesh,
+      shape.truncate(shapeComps),
+      color.truncate(colorComps),
+      landmarks)
   }
 
   // converters to deal with discrete fields

--- a/src/main/scala/scalismo/faces/momo/ModelHelpers.scala
+++ b/src/main/scala/scalismo/faces/momo/ModelHelpers.scala
@@ -283,13 +283,4 @@ object ModelHelpers {
     }
     X
   }
-
-
-  def truncateDLRGP[A](gp: DiscreteLowRankGaussianProcess[_3D, A], components: Int): DiscreteLowRankGaussianProcess[_3D, A] = {
-    implicit val vectorizer = gp.vectorizer
-    val variance = gp.variance(0 until components)
-    val basis = gp.basisMatrix(::, 0 until components)
-    ModelHelpers.buildFrom(gp.domain, gp.meanVector, variance, basis)
-  }
-
 }

--- a/src/main/scala/scalismo/faces/sampling/evaluators/LogNormalDistribution.scala
+++ b/src/main/scala/scalismo/faces/sampling/evaluators/LogNormalDistribution.scala
@@ -29,7 +29,7 @@ object LogNormalDistribution {
   /** log density value for LogNormal distribution */
   def logDensity(x: Double, logMean: Double, logSdev: Double): Double = {
     if (x > 0.0)
-      GaussianEvaluator.probability(math.log(x), logMean, logSdev)
+      GaussianEvaluator.logDensity(math.log(x), logMean, logSdev)
     else
       Double.NegativeInfinity
   }

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/IndependentPixelEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/IndependentPixelEvaluator.scala
@@ -97,11 +97,11 @@ object IndependentPixelEvaluator {
     val pixelEvaluator: PairEvaluator[RGB] = new PairEvaluator[RGB] {
       override def logValue(first: RGB, second: RGB): Double = {
         val diff = (first - second).norm/sdev
-        GaussianEvaluator.probability(diff, 0.0, 1.0)
+        GaussianEvaluator.logDensity(diff, 0.0, 1.0)
       }
     }
     // background likelihood value at required distance in standard deviations
-    val bgValue = GaussianEvaluator.probability(bgSdev, 0.0, 1.0)
+    val bgValue = GaussianEvaluator.logDensity(bgSdev, 0.0, 1.0)
     val bgEval = PixelEvaluators.ConstantPixelEvaluator[RGB](bgValue)
     IndependentPixelEvaluator(targetImage, pixelEvaluator, bgEval)
   }

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianColorProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianColorProposal.scala
@@ -53,9 +53,9 @@ case class GaussianColorProposal(logSdevGain: RGB, logSdevColorContrast: Double,
       // contrast
       LogNormalDistribution.logDensity(to.colorContrast/from.colorContrast, 0.0, logSdevColorContrast) +
       // offset
-      GaussianEvaluator.probability(to.offset.r, from.offset.r, sdevOffset.r) +
-      GaussianEvaluator.probability(to.offset.g, from.offset.g, sdevOffset.g) +
-      GaussianEvaluator.probability(to.offset.b, from.offset.b, sdevOffset.b)
+      GaussianEvaluator.logDensity(to.offset.r, from.offset.r, sdevOffset.r) +
+      GaussianEvaluator.logDensity(to.offset.g, from.offset.g, sdevOffset.g) +
+      GaussianEvaluator.logDensity(to.offset.b, from.offset.b, sdevOffset.b)
   }
 
   override def toString: String = {

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianDistanceProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianDistanceProposal.scala
@@ -19,14 +19,14 @@ package scalismo.faces.sampling.face.proposals
 import scalismo.faces.parameters.RenderParameter
 import scalismo.geometry.Vector
 import scalismo.sampling.evaluators.GaussianEvaluator
-import scalismo.sampling.{ProposalGenerator, SymmetricTransition}
+import scalismo.sampling.{ProposalGenerator, SymmetricTransitionRatio, TransitionProbability}
 import scalismo.utils.Random
 
 /** Gaussian proposal to vary the distance between the face and the camera with an optional scaling compensation
   * @param sdev standard deviation of Gaussian proposal, typically in mm
   * @param compensateScaling if true the focal length of the camera is adjusted to compensate for the apparent size change due to the distance change (isolated perspective change) */
 case class GaussianDistanceProposal(sdev: Double, compensateScaling: Boolean)(implicit rnd: Random)
-    extends ProposalGenerator[RenderParameter] with SymmetricTransition[RenderParameter] {
+    extends ProposalGenerator[RenderParameter] with SymmetricTransitionRatio[RenderParameter] with TransitionProbability[RenderParameter] {
   override def propose(current: RenderParameter): RenderParameter = {
     val cameraDistance = current.view.translation.z - current.pose.translation.z
 
@@ -44,7 +44,7 @@ case class GaussianDistanceProposal(sdev: Double, compensateScaling: Boolean)(im
   override def logTransitionProbability(from: RenderParameter, to: RenderParameter): Double = {
     if (to.copy(pose = from.pose, camera = from.camera) == from) {
       val diff: Double = to.pose.translation.z - from.pose.translation.z
-      GaussianEvaluator.probability(diff, 0.0, sdev)
+      GaussianEvaluator.logDensity(diff, 0.0, sdev)
     } else
       Double.NegativeInfinity
   }

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianMoMoProposals.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianMoMoProposals.scala
@@ -19,12 +19,12 @@ package scalismo.faces.sampling.face.proposals
 import scalismo.faces.parameters.MoMoInstance
 import scalismo.faces.sampling.evaluators.LogNormalDistribution
 import scalismo.sampling.evaluators.GaussianEvaluator
-import scalismo.sampling.{ProposalGenerator, SymmetricTransition, TransitionProbability}
+import scalismo.sampling.{ProposalGenerator, SymmetricTransitionRatio, TransitionProbability}
 import scalismo.utils.Random
 
 /** Gaussian proposal on a sequence of numbers */
 case class GaussianParameterProposal(sdev: Double)(implicit rnd: Random)
-  extends ProposalGenerator[IndexedSeq[Double]] with SymmetricTransition[IndexedSeq[Double]] {
+  extends ProposalGenerator[IndexedSeq[Double]] with SymmetricTransitionRatio[IndexedSeq[Double]] with TransitionProbability[IndexedSeq[Double]] {
   override def propose(current: IndexedSeq[Double]): IndexedSeq[Double] = {
     require(current.nonEmpty, "cannot propose change on empty vector")
     current.map{ v => v + sdev * rnd.scalaRandom.nextGaussian()}
@@ -33,7 +33,7 @@ case class GaussianParameterProposal(sdev: Double)(implicit rnd: Random)
   override def logTransitionProbability(from: IndexedSeq[Double], to: IndexedSeq[Double]): Double = {
     require(from.nonEmpty, "cannot calculate transition on empty vector")
     require(from.length == to.length, "IndexedSeqs must be of same length")
-    to.toIterator.zip(from.toIterator).map{case (t, f) => GaussianEvaluator.probability(t, f, sdev)}.sum
+    to.toIterator.zip(from.toIterator).map{case (t, f) => GaussianEvaluator.logDensity(t, f, sdev)}.sum
   }
 }
 
@@ -69,7 +69,7 @@ case class LogNormalScalingParameterProposal(logSdev: Double)(implicit rnd: Rand
   * @param sdev standard deviation of proposal
   * */
 case class GaussianMoMoShapeProposal(sdev: Double)(implicit rnd: Random)
-  extends ProposalGenerator[MoMoInstance] with SymmetricTransition[MoMoInstance] {
+  extends ProposalGenerator[MoMoInstance] with SymmetricTransitionRatio[MoMoInstance] with TransitionProbability[MoMoInstance] {
 
   private val generator = GaussianParameterProposal(sdev)
 
@@ -87,7 +87,7 @@ case class GaussianMoMoShapeProposal(sdev: Double)(implicit rnd: Random)
   * @param sdev standard deviation of the proposal
   */
 case class GaussianMoMoColorProposal(sdev: Double)(implicit rnd: Random)
-  extends ProposalGenerator[MoMoInstance] with SymmetricTransition[MoMoInstance] {
+  extends ProposalGenerator[MoMoInstance] with SymmetricTransitionRatio[MoMoInstance] with TransitionProbability[MoMoInstance] {
 
   private val generator = GaussianParameterProposal(sdev)
 
@@ -106,7 +106,7 @@ case class GaussianMoMoColorProposal(sdev: Double)(implicit rnd: Random)
   * @param sdev standard deviation of proposal
   * */
 case class GaussianMoMoExpressionProposal(sdev: Double)(implicit rnd: Random)
-  extends ProposalGenerator[MoMoInstance] with SymmetricTransition[MoMoInstance] {
+  extends ProposalGenerator[MoMoInstance] with SymmetricTransitionRatio[MoMoInstance] with TransitionProbability[MoMoInstance] {
 
   private val generator = GaussianParameterProposal(sdev)
 

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianRotationProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianRotationProposal.scala
@@ -20,12 +20,12 @@ import scalismo.faces.parameters.Pose
 import scalismo.faces.render.Rotation3D
 import scalismo.geometry.{Vector, _3D}
 import scalismo.sampling.evaluators.GaussianEvaluator
-import scalismo.sampling.{ProposalGenerator, SymmetricTransition}
+import scalismo.sampling.{ProposalGenerator, SymmetricTransitionRatio, TransitionProbability}
 import scalismo.utils.Random
 
 /** rotation with a random angle (Gaussian) angle around a given axis */
 case class GaussianRotationProposal(axis: Vector[_3D], sdev: Double)(implicit rnd: Random)
-    extends ProposalGenerator[Pose] with SymmetricTransition[Pose] {
+    extends ProposalGenerator[Pose] with SymmetricTransitionRatio[Pose] with TransitionProbability[Pose] {
 
   private val normAxis: Vector[_3D] = axis.normalize
 
@@ -53,7 +53,7 @@ case class GaussianRotationProposal(axis: Vector[_3D], sdev: Double)(implicit rn
       if (math.abs(rot.phi) > 1e-5 && (rot.axis dot axis) < 1.0 - 1e-4)
         Double.NegativeInfinity // wrong axis
       else {
-        GaussianEvaluator.probability(rot.phi, 0.0, sdev)
+        GaussianEvaluator.logDensity(rot.phi, 0.0, sdev)
       }
     }
   }

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianTranslationProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianTranslationProposal.scala
@@ -18,15 +18,15 @@ package scalismo.faces.sampling.face.proposals
 
 import scalismo.faces.parameters.Pose
 import scalismo.geometry._
+import scalismo.sampling.{ProposalGenerator, SymmetricTransitionRatio, TransitionProbability}
 import scalismo.sampling.evaluators.GaussianEvaluator
-import scalismo.sampling.{ProposalGenerator, SymmetricTransition}
 import scalismo.utils.Random
 
 
 /**
   * Trait for translation proposals.
   */
-trait GaussianTranslationProposal extends ProposalGenerator[Pose] with SymmetricTransition[Pose]
+trait GaussianTranslationProposal extends ProposalGenerator[Pose] with SymmetricTransitionRatio[Pose] with TransitionProbability[Pose]
 
 /**
   * Gaussian translation proposal for changing a Pose.
@@ -68,8 +68,8 @@ private[proposals] case class Gaussian3DTranslationProposalConstantZ(sdev: Vecto
       Double.NegativeInfinity
     else {
       val diff = to.translation - from.translation
-      val px = GaussianEvaluator.probability(diff.x, 0, sdev.x)
-      val py = GaussianEvaluator.probability(diff.y, 0, sdev.y)
+      val px = GaussianEvaluator.logDensity(diff.x, 0, sdev.x)
+      val py = GaussianEvaluator.logDensity(diff.y, 0, sdev.y)
       px + py
     }
   }
@@ -93,9 +93,9 @@ private[proposals] case class Gaussian3DTranslationProposal(sdev: Vector[_3D])(i
       Double.NegativeInfinity
     else {
       val diff = to.translation - from.translation
-      val px = GaussianEvaluator.probability(diff.x, 0, sdev.x)
-      val py = GaussianEvaluator.probability(diff.y, 0, sdev.y)
-      val pz = GaussianEvaluator.probability(diff.z, 0, sdev.z)
+      val px = GaussianEvaluator.logDensity(diff.x, 0, sdev.x)
+      val py = GaussianEvaluator.logDensity(diff.y, 0, sdev.y)
+      val pz = GaussianEvaluator.logDensity(diff.z, 0, sdev.z)
       px + py + pz
     }
   }

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/ParameterProposals.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/ParameterProposals.scala
@@ -64,8 +64,13 @@ object ParameterProposals {
     }
 
     /** implicit wrapper class for symmtric partial parameter proposals with a transition probability */
-    implicit class PartialTransitionSymmetricParameterProposal[A](proposal: ProposalGenerator[A] with SymmetricTransition[A])(implicit converter: PartialToFullParameterConverter[A]) {
-      def toParameterProposal: ProposalGenerator[RenderParameter] with SymmetricTransition[RenderParameter] = new ProposalGenerator[RenderParameter] with SymmetricTransition[RenderParameter] {
+    implicit class PartialTransitionSymmetricParameterProposal[A](proposal: ProposalGenerator[A] with SymmetricTransitionRatio[A] with TransitionProbability[A])(implicit converter: PartialToFullParameterConverter[A]) {
+      def toParameterProposal: ProposalGenerator[RenderParameter] with
+        SymmetricTransitionRatio[RenderParameter] with
+        TransitionProbability[RenderParameter] =
+        new ProposalGenerator[RenderParameter] with
+          SymmetricTransitionRatio[RenderParameter] with
+          TransitionProbability[RenderParameter] {
         override def propose(current: RenderParameter): RenderParameter = {
           val prop = proposal.propose(converter.partialParameter(current))
           converter.fullParameter(prop, current)

--- a/src/test/scala/scalismo/faces/sampling/evaluators/EvaluatorTests.scala
+++ b/src/test/scala/scalismo/faces/sampling/evaluators/EvaluatorTests.scala
@@ -25,7 +25,7 @@ class EvaluatorTests extends FacesTestSuite {
     it("returns the same density value as a Gaussian of the log") {
       val x = 0.5 + math.abs(rnd.scalaRandom.nextGaussian())
       val dlogN = LogNormalDistribution.logDensity(x, 0.0, 1.0)
-      val dGauss = GaussianEvaluator.probability(math.log(x), 0.0, 1.0)
+      val dGauss = GaussianEvaluator.logDensity(math.log(x), 0.0, 1.0)
       dlogN shouldBe dGauss +- 1e-5
     }
 


### PR DESCRIPTION
Scalismo released a first release candidate 0.15.0-RC1. In order to test it, I updated scalismo-faces to use the new version.

- updated to 0.15 (mainly method rename, SymmtricTransition trait removed)
- removed deprecated usage of ImageFilter.apply
- added PancakeDLRGP.truncate -- as in scalismo