### PR TITLE
Added nescessary proposal and evaluator.

### DIFF
--- a/src/main/scala/scalismo/faces/sampling/evaluators/MaxOfEvaluatorsEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/evaluators/MaxOfEvaluatorsEvaluator.scala
@@ -25,5 +25,4 @@ class MaxOfEvaluatorsEvaluator[A](evaluators: Seq[DistributionEvaluator[A]]) ext
 
 object MaxOfEvaluatorsEvaluator {
   def apply[A](evaluators: DistributionEvaluator[A]*) = new MaxOfEvaluatorsEvaluator[A](evaluators.toSeq)
-  def apply[A](evaluators: Seq[DistributionEvaluator[A]]) = new MaxOfEvaluatorsEvaluator[A](evaluators)
 }

--- a/src/main/scala/scalismo/faces/sampling/evaluators/MaxOfEvaluatorsEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/evaluators/MaxOfEvaluatorsEvaluator.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.faces.sampling.evaluators
+
+import scalismo.sampling.DistributionEvaluator
+
+class MaxOfEvaluatorsEvaluator[A](evaluators: Seq[DistributionEvaluator[A]]) extends DistributionEvaluator[A] {
+  override def logValue(sample: A): Double = {
+    evaluators.iterator.map(e => e.logValue(sample)).max
+  }
+}
+
+object MaxOfEvaluatorsEvaluator {
+  def apply[A](evaluators: DistributionEvaluator[A]*) = new MaxOfEvaluatorsEvaluator[A](evaluators.toSeq)
+  def apply[A](evaluators: Seq[DistributionEvaluator[A]]) = new MaxOfEvaluatorsEvaluator[A](evaluators)
+}

--- a/src/main/scala/scalismo/faces/sampling/proposals/MarkovChainProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/proposals/MarkovChainProposal.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.faces.sampling.proposals
+
+import scalismo.sampling.{ProposalGenerator, SymmetricTransitionRatio}
+import scalismo.utils.Random
+
+
+
+class MarkovChainProposal[A](val chain: Iterator[A], val numSamples : Int) (implicit rnd: Random)
+  extends ProposalGenerator[A] with SymmetricTransitionRatio[A] {
+
+  override def propose(current: A): A = {
+    chain.drop(numSamples-1).next
+  }
+
+}
+
+object MarkovChainProposal {
+  def apply[A](chain: Iterator[A], numSamples: Int) = new MarkovChainProposal[A](chain,numSamples)
+}


### PR DESCRIPTION
Added a proposal and an evaluator:

- The `MarkovChainProposal` allows to use any Markov Chain as proposal for another markov chain. During construction one can specify the number of samples that are drawn for each new proposal.

- The `MaxOfEvaluatorsEvaluator` returns only the maximum of all evaluators and is used to select the best explanation among ceveral ones.