### PR TITLE
Fixed inconsistent handling of log values in detection maps

### DIFF
--- a/src/main/scala/scalismo/faces/landmarks/LandmarkDetectionMap.scala
+++ b/src/main/scala/scalismo/faces/landmarks/LandmarkDetectionMap.scala
@@ -17,4 +17,14 @@ package scalismo.faces.landmarks
 
 import scalismo.faces.image.PixelImage
 
-case class LandmarkDetectionMap(tag: String, values: PixelImage[Double])
+/** LandmarkDetectionMap contains certainty of detecting a landmark at an image location (log certainty!) */
+case class LandmarkDetectionMap(tag: String, logValues: PixelImage[Double]) {
+
+  /** correct detection certainty to respect false positive and false negative rates */
+  def correctCertaintyForErrorRates(falsePositiveRate: Double, falseNegativeRate: Double): LandmarkDetectionMap = {
+    copy(logValues =
+      logValues.map{ logCertainty =>
+        math.log(math.exp(logCertainty) * (1.0 - falsePositiveRate - falseNegativeRate) + falseNegativeRate)
+      })
+  }
+}

--- a/src/main/scala/scalismo/faces/landmarks/LandmarkDetectionMap.scala
+++ b/src/main/scala/scalismo/faces/landmarks/LandmarkDetectionMap.scala
@@ -18,7 +18,7 @@ package scalismo.faces.landmarks
 import scalismo.faces.image.PixelImage
 
 /** LandmarkDetectionMap contains certainty of detecting a landmark at an image location (log certainty!) */
-case class LandmarkDetectionMap(tag: String, logValues: PixelImage[Double]) {
+case class LandmarkDetectionMap (tag: String, logValues: PixelImage[Double]) {
 
   /** correct detection certainty to respect false positive and false negative rates */
   def correctCertaintyForErrorRates(falsePositiveRate: Double, falseNegativeRate: Double): LandmarkDetectionMap = {
@@ -26,5 +26,13 @@ case class LandmarkDetectionMap(tag: String, logValues: PixelImage[Double]) {
       logValues.map{ logCertainty =>
         math.log(math.exp(logCertainty) * (1.0 - falsePositiveRate - falseNegativeRate) + falseNegativeRate)
       })
+  }
+}
+
+object LandmarkDetectionMap {
+  /** create a LandmarkDetectionMap from certainty detection responses (no logs) */
+  def fromLinearValues(tag: String, detectionCertainty: PixelImage[Double]): LandmarkDetectionMap = {
+    require(detectionCertainty.values.forall{_ >= 0.0}, "positive certainty values")
+    LandmarkDetectionMap(tag, detectionCertainty.map(math.log))
   }
 }

--- a/src/main/scala/scalismo/faces/sampling/face/evaluators/LandmarkMapEvaluator.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/evaluators/LandmarkMapEvaluator.scala
@@ -22,26 +22,28 @@ import scalismo.faces.landmarks.LandmarkDetectionMap
 import scalismo.faces.parameters.RenderParameter
 import scalismo.faces.sampling.face.ParametricLandmarksRenderer
 import scalismo.faces.sampling.face.evaluators.PointEvaluators.IsotropicGaussianPointEvaluator
-import scalismo.geometry.{Point1D, _1D}
+import scalismo.geometry.{Point, Point1D, _1D, _2D}
 import scalismo.sampling.DistributionEvaluator
-import scalismo.sampling.evaluators.ProductEvaluator
+import scalismo.sampling.evaluators.{PairEvaluator, ProductEvaluator}
 
 /**
- * The LandmarkMapEvaluator evaluates landmark positions by a simple look-up in a LandmarkDetectionMap. These
- * maps usually include a noise-model through precomputation.
- */
-case class LandmarkMapEvaluator(
-  detectionMap: LandmarkDetectionMap,
-  renderer: ParametricLandmarksRenderer
-) extends DistributionEvaluator[RenderParameter] {
+  * The LandmarkMapEvaluator evaluates landmark positions by a simple look-up in a LandmarkDetectionMap. These
+  * maps usually include a noise-model through precomputation.
+  *
+  * @param detectionMap detection map of this landmark, contains log certainty of detecting landmark at every location
+  * @param renderer landmarks renderer to calculate landmarks position of current sample
+  */
+case class LandmarkMapEvaluator(detectionMap: LandmarkDetectionMap,
+                                renderer: ParametricLandmarksRenderer)
+  extends DistributionEvaluator[RenderParameter] {
 
   override def logValue(sample: RenderParameter): Double = {
     val landmarkPosition = renderer.renderLandmark(detectionMap.tag, sample).get
     val point = landmarkPosition.point
     val x = point.x.toInt
     val y = point.y.toInt
-    if (detectionMap.values.domain.isDefinedAt(x, y)) {
-      detectionMap.values(x, y)
+    if (detectionMap.logValues.domain.isDefinedAt(x, y)) {
+      detectionMap.logValues(x, y)
     } else {
       Double.NegativeInfinity
     }
@@ -52,38 +54,53 @@ case class LandmarkMapEvaluator(
 object LandmarkMapEvaluator {
 
   /**
-   * Convenience constructor for combining multiple landmark map evaluators in a ProductEvaluator.
-   */
-  def apply(
-    detectionMaps: Seq[LandmarkDetectionMap],
-    renderer: ParametricLandmarksRenderer,
-    stddevNoiseModel: Double,
-    falsePositiveRate: Double,
-    falseNegativeRate: Double
-  ): ProductEvaluator[RenderParameter] = {
+    * Convenience constructor for combining multiple landmark map evaluators in a ProductEvaluator.
+    */
+  def apply(detectionMaps: Seq[LandmarkDetectionMap],
+            renderer: ParametricLandmarksRenderer): ProductEvaluator[RenderParameter] = {
+    val mapEvaluators = detectionMaps.map{map => LandmarkMapEvaluator(map, renderer)}
+    ProductEvaluator(mapEvaluators: _*)
+  }
+
+  /**
+    * Prepare landmarks detection maps with an isotropic Gaussian noise model, combination in a ProductEvaluator (independent landmarks)
+    */
+  def withIsotropicGaussianNoise(detectionMaps: Seq[LandmarkDetectionMap],
+                                 renderer: ParametricLandmarksRenderer,
+                                 stddevNoiseModel: Double): ProductEvaluator[RenderParameter] = {
     val mapEvaluators = detectionMaps.map { detectionMap =>
-      val correctedDetections = correctFalsePositiveAndFalseNegativeRates(detectionMap.values, falseNegativeRate, falseNegativeRate)
-      val correctedDetectionsIncludingNoise = precalculateIsotropicGaussianNoise(correctedDetections, stddevNoiseModel)
-      new LandmarkMapEvaluator(LandmarkDetectionMap(detectionMap.tag, correctedDetectionsIncludingNoise), renderer)
+      // precalculate best combination of detection certainty and landmarks noise model with a maximum convolution
+      val detectionMapWithNoise = GeneralMaxConvolution.separable2D(
+        detectionMap.logValues,
+        IsotropicGaussianPointEvaluator[_1D](stddevNoiseModel).toDistributionEvaluator(Point1D(0))
+      )
+      new LandmarkMapEvaluator(LandmarkDetectionMap(detectionMap.tag, detectionMapWithNoise), renderer)
     }
     ProductEvaluator(mapEvaluators: _*)
   }
 
   /**
-   * Correctes for the false-positive and false-negative rates of the detector in the detection map.
-   */
-  private def correctFalsePositiveAndFalseNegativeRates(in: PixelImage[Double], falsePositiveRate: Double, falseNegativeRate: Double): PixelImage[Double] = {
-    in.map(e => e * (1.0 - (falsePositiveRate + falseNegativeRate)) + falseNegativeRate)
+    * Prepare landmarks detection maps with the specified noise model, combination in a ProductEvaluator (independent landmarks)
+    * WARNING: uses a slow full maximum search internally, use only for exotic noise models
+    * The resulting map evaluator is lazy - it might still work efficiently if you do not have too many evaluations
+    */
+  def withLandmarksLikelihood(detectionMaps: Seq[LandmarkDetectionMap],
+                              renderer: ParametricLandmarksRenderer,
+                              landmarksLikelihood: PairEvaluator[Point[_2D]]): ProductEvaluator[RenderParameter] = {
+    val mapEvaluators = detectionMaps.map { detectionMap =>
+      // cache all computations
+      val detectionMapWithNoise = PixelImage.view(detectionMap.logValues.domain, { (x, y) =>
+        // find best combination (max) of detection certainty and landmarks noise model
+        // WARNING: very inefficient full search
+        val currentPoint = Point(x, y)
+        detectionMap.logValues.values.zipWithIndex.map{ case (value, i) =>
+          val (tx, ty) = detectionMap.logValues.domain.coordsFromIndex(i)
+          value + landmarksLikelihood.logValue(Point(tx, ty), currentPoint)
+        }.max
+      })
+      // the evaluator is lazy, best combinations are only computed where it is evaluated
+      new LandmarkMapEvaluator(LandmarkDetectionMap(detectionMap.tag, detectionMapWithNoise), renderer)
+    }
+    ProductEvaluator(mapEvaluators: _*)
   }
-
-  /**
-   * Precalculates a new map with included isotropic Gaussian noise model.
-   */
-  private def precalculateIsotropicGaussianNoise(detectionMap: PixelImage[Double], stddevNoiseModel: Double) = {
-    GeneralMaxConvolution.separable2D(
-      detectionMap,
-      IsotropicGaussianPointEvaluator[_1D](stddevNoiseModel).toDistributionEvaluator(Point1D(0f))
-    )
-  }
-
 }

--- a/src/test/scala/scalismo/faces/sampling/face/evaluators/LandmarkMapEvaluatorTests.scala
+++ b/src/test/scala/scalismo/faces/sampling/face/evaluators/LandmarkMapEvaluatorTests.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face.evaluators
+
+import scalismo.faces.FacesTestSuite
+import scalismo.faces.image.PixelImage
+import scalismo.faces.landmarks.{LandmarkDetectionMap, TLMSLandmark2D}
+import scalismo.faces.parameters.RenderParameter
+import scalismo.faces.sampling.face.ParametricLandmarksRenderer
+import scalismo.faces.sampling.face.evaluators.PointEvaluators.IsotropicGaussianPointEvaluator
+import scalismo.geometry._
+
+class LandmarkMapEvaluatorTests extends FacesTestSuite {
+
+  private val rawDetectionMap = PixelImage(20, 20, (x, y) => {
+    -0.5 * (Point(x, y) - Point(5, 5)).norm2
+  })
+
+  private val detectionMap = LandmarkDetectionMap("testLM", rawDetectionMap)
+
+  private val initParam = RenderParameter.default
+  private def lmRenderer(point: Point[_2D]) = new ParametricLandmarksRenderer {
+    /** list of all known landmarks */
+    override def allLandmarkIds: IndexedSeq[String] = IndexedSeq("testLM")
+
+    /** check if landmark id is known */
+    override def hasLandmarkId(lmId: String): Boolean = allLandmarkIds.contains(lmId)
+
+    /** render landmark given by lmId */
+    override def renderLandmark(lmId: String, parameter: RenderParameter): Option[TLMSLandmark2D] = {
+      Some(TLMSLandmark2D("testLM", point, visible = true))
+    }
+  }
+
+  describe("A LandmarksDetectionMap") {
+    it("provides direct lookup") {
+      detectionMap.logValues(5, 5) shouldBe 0.0
+    }
+
+    it("can be corrected with error rates of detection") {
+      val fp = 0.05
+      val fn = 0.07
+      val corrected = detectionMap.correctCertaintyForErrorRates(fp, fn)
+      math.exp(corrected.logValues(5, 5)) shouldBe 1.0 - fp
+      math.exp(corrected.logValues(19, 19)) shouldBe 0.0 + fn
+    }
+  }
+
+  describe("A LandmarksMapEvaluator") {
+    val fp = 0.05
+    val fn = 0.07
+    val corrected = detectionMap.correctCertaintyForErrorRates(fp, fn)
+
+    val randomPoints = Seq.fill(5){Point(rnd.scalaRandom.nextInt(rawDetectionMap.width), rnd.scalaRandom.nextInt(rawDetectionMap.height))}
+
+    it("provides a constructor for isotropic Gaussian noise models with proper value on strongest detection") {
+      val lmNoise = IsotropicGaussianPointEvaluator[_2D](5.0).toDistributionEvaluator(Point2D.origin)
+      val lmEval = LandmarkMapEvaluator.withIsotropicGaussianNoise(Seq(corrected), lmRenderer(Point(5, 5)), 5.0)
+      lmEval.logValue(initParam) shouldBe (corrected.logValues(5, 5) + lmNoise.logValue(Point2D.origin))
+    }
+
+    it("with precalculated noise model returns the proper value for a few points") {
+      val lmNoise = IsotropicGaussianPointEvaluator[_2D](2.0)
+
+      def checkPoint(point: Point[_2D]): Unit = {
+        val renderer = lmRenderer(point)
+        val lmEval = LandmarkMapEvaluator.withIsotropicGaussianNoise(Seq(corrected), renderer, 2.0)
+        val explicitValue = { // brute force maximum finder
+          corrected.logValues.mapWithIndex{ (v, x, y) =>
+            v + lmNoise.logValue(Point(x, y), point)
+          }.values.max
+        }
+        lmEval.logValue(initParam) shouldBe explicitValue +- 1e-10
+      }
+
+      // check for 5 random points
+      for (pt <- randomPoints)
+        checkPoint(pt)
+    }
+
+    it("with an explicit noise model returns the proper value for a few points") {
+      val lmNoise = IsotropicGaussianPointEvaluator[_2D](2.0)
+
+      def checkPoint(point: Point[_2D]): Unit = {
+        val renderer = lmRenderer(point)
+        val lmEvalExplicit = LandmarkMapEvaluator.withLandmarksLikelihood(Seq(corrected), renderer, lmNoise)
+        val explicitValue = { // brute force maximum finder
+          corrected.logValues.mapWithIndex{ (v, x, y) =>
+            v + lmNoise.logValue(Point(x, y), point)
+          }.values.max
+        }
+        lmEvalExplicit.logValue(initParam) shouldBe explicitValue +- 1e-10
+      }
+
+      // check for 5 random points
+      for (pt <- randomPoints)
+        checkPoint(pt)
+    }
+  }
+}


### PR DESCRIPTION
`LandmarkMapEvaluator` treated `LandmarkDetectionMap` inconsistently. All updated to log values now.

- Updated name to `logValues`
- Constructors of `LandmarkMapEvaluator` are more consistent now:
    - they all assume log values
    - false positive / negative correction is done separately
- new tests to check noise model landmarks evaluation

WARNING: old code where landmark maps are loaded needs to be adjusted to respect the log assumption!