### PR TITLE
conversion from DenseVector to SphericalHarmonicsLight added

### DIFF
--- a/src/main/scala/scalismo/faces/parameters/Illumination.scala
+++ b/src/main/scala/scalismo/faces/parameters/Illumination.scala
@@ -130,6 +130,12 @@ object SphericalHarmonicsLight {
     ))
   }
 
+  def fromBreezeVector(dv: DenseVector[Double]): SphericalHarmonicsLight = {
+    require(dv.length % 3 == 0, "length of array to build SHLight must be a multiple of 3")
+    val grouped = dv.toArray.grouped(3).map(g => Vector[_3D](g)).toIndexedSeq
+    SphericalHarmonicsLight(grouped)
+  }
+
   /** Finds the principal light direction in the spherical harmonics with respect to light intensity.
     * lightIntensity(n) = \sum_{i=0} Y_i(n) * lambertKernel_i * ( shl_r(i) + shl_g(i) + shl_b(i) ) */
   def directionFromSHLightIntensity(shl: SphericalHarmonicsLight): Option[Vector[_3D]] = {

--- a/src/main/scala/scalismo/faces/parameters/Illumination.scala
+++ b/src/main/scala/scalismo/faces/parameters/Illumination.scala
@@ -53,10 +53,7 @@ object DirectionalLight {
 /** Spherical Harmonics illumination parameters, environment map */
 case class SphericalHarmonicsLight(coefficients: IndexedSeq[Vector[_3D]]) extends Illumination {
   require(coefficients.isEmpty || SphericalHarmonics.totalCoefficients(bands) == coefficients.length, "invalid length of IndexedSeq to build SphericalHarmonicsLight")
-
-  /** number of m values within a band l */
-  def coefficientsInBand(band: Int): Int = 2 * band + 1
-
+  
   val nonEmpty: Boolean = coefficients.nonEmpty
 
   override def shader(worldMesh: ColorNormalMesh3D, eyePosition: Point[_3D]): SphericalHarmonicsLambertShader = shader(worldMesh)

--- a/src/main/scala/scalismo/faces/parameters/Illumination.scala
+++ b/src/main/scala/scalismo/faces/parameters/Illumination.scala
@@ -52,6 +52,11 @@ object DirectionalLight {
 
 /** Spherical Harmonics illumination parameters, environment map */
 case class SphericalHarmonicsLight(coefficients: IndexedSeq[Vector[_3D]]) extends Illumination {
+  require(coefficients.isEmpty || SphericalHarmonics.totalCoefficients(bands) == coefficients.length, "invalid length of IndexedSeq to build SphericalHarmonicsLight")
+
+  /** number of m values within a band l */
+  def coefficientsInBand(band: Int): Int = 2 * band + 1
+
   val nonEmpty: Boolean = coefficients.nonEmpty
 
   override def shader(worldMesh: ColorNormalMesh3D, eyePosition: Point[_3D]): SphericalHarmonicsLambertShader = shader(worldMesh)

--- a/src/main/scala/scalismo/faces/parameters/Illumination.scala
+++ b/src/main/scala/scalismo/faces/parameters/Illumination.scala
@@ -52,8 +52,8 @@ object DirectionalLight {
 
 /** Spherical Harmonics illumination parameters, environment map */
 case class SphericalHarmonicsLight(coefficients: IndexedSeq[Vector[_3D]]) extends Illumination {
-  require(coefficients.isEmpty || SphericalHarmonics.totalCoefficients(bands) == coefficients.length, "invalid length of IndexedSeq to build SphericalHarmonicsLight")
-  
+  require(coefficients.isEmpty || SphericalHarmonics.totalCoefficients(bands) == coefficients.length, "invalid length of coefficients to build SphericalHarmonicsLight")
+
   val nonEmpty: Boolean = coefficients.nonEmpty
 
   override def shader(worldMesh: ColorNormalMesh3D, eyePosition: Point[_3D]): SphericalHarmonicsLambertShader = shader(worldMesh)

--- a/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
+++ b/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
@@ -57,7 +57,7 @@ class SphericalHarmonicsLightTests extends FacesTestSuite {
       val sh = SphericalHarmonicsLight.frontal
       val shB = sh.toBreezeVector
       val shN = SphericalHarmonicsLight.fromBreezeVector(shB)
-      sh.toBreezeVector.toArray should contain theSameElementsInOrderAs  shN.toBreezeVector.toArray
+      sh shouldBe shN
 
       val bV =  DenseVector(Array.fill(27)(rnd.scalaRandom.nextGaussian()))
       val shL = SphericalHarmonicsLight.fromBreezeVector(bV)

--- a/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
+++ b/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
@@ -52,6 +52,18 @@ class SphericalHarmonicsLightTests extends FacesTestSuite {
       band0.coefficients(0) shouldBe sh.coefficients(0)
     }
 
+    it("SH to DenseVector and from DenseVector"){
+      val sh = SphericalHarmonicsLight.frontal
+      val shB = sh.toBreezeVector
+      val shN = SphericalHarmonicsLight.fromBreezeVector(shB)
+      sh.toBreezeVector.toArray should contain theSameElementsInOrderAs  shN.toBreezeVector.toArray
+
+      val bV =  DenseVector(Array.fill(27)(rnd.scalaRandom.nextGaussian()))
+      val shL = SphericalHarmonicsLight.fromBreezeVector(bV)
+      val nV = shL.toBreezeVector
+      bV.toArray should contain theSameElementsInOrderAs nV.toArray
+    }
+
     describe("To recover a principal direction of illumination, SphericalHarmonicsLight") {
       it("extracts consistently the direction from randomly generated directed spherical harmonics.") {
 

--- a/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
+++ b/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
@@ -16,6 +16,7 @@
 
 package scalismo.faces.parameters
 
+import breeze.linalg.DenseVector
 import scalismo.faces.FacesTestSuite
 import scalismo.faces.color.RGB
 import scalismo.geometry.{Vector, Vector3D, _3D}

--- a/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
+++ b/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
@@ -29,7 +29,6 @@ class SphericalHarmonicsLightTests extends FacesTestSuite {
       sh5.bands shouldBe 5
       sh5.coefficients.length shouldBe SphericalHarmonicsLight.coefficientsInBands(5)
     }
-
     it("can be rescaled to more components") {
       val sh = SphericalHarmonicsLight.frontal
       assert(sh.bands == 1)
@@ -63,6 +62,11 @@ class SphericalHarmonicsLightTests extends FacesTestSuite {
       val shL = SphericalHarmonicsLight.fromBreezeVector(bV)
       val nV = shL.toBreezeVector
       bV.toArray should contain theSameElementsInOrderAs nV.toArray
+    }
+
+    it("avoids building of invalid coefficients") {
+      val wrongLength = IndexedSeq.fill(2)(Vector3D.zero)
+      an [IllegalArgumentException] should be thrownBy  SphericalHarmonicsLight(wrongLength)
     }
 
     describe("To recover a principal direction of illumination, SphericalHarmonicsLight") {

--- a/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
+++ b/src/test/scala/scalismo/faces/parameters/SphericalHarmonicsLightTests.scala
@@ -29,6 +29,7 @@ class SphericalHarmonicsLightTests extends FacesTestSuite {
       sh5.bands shouldBe 5
       sh5.coefficients.length shouldBe SphericalHarmonicsLight.coefficientsInBands(5)
     }
+    
     it("can be rescaled to more components") {
       val sh = SphericalHarmonicsLight.frontal
       assert(sh.bands == 1)


### PR DESCRIPTION
Adds a convenience function to build a SphericalHarmonicsLight from a DenseVector.
The other direction already exists.
Added a test if conversion works.