### PR TITLE
randomImage deterministic

### DIFF
--- a/src/test/scala/scalismo/faces/image/ImageOperatorsTest.scala
+++ b/src/test/scala/scalismo/faces/image/ImageOperatorsTest.scala
@@ -27,8 +27,8 @@ class ImageOperatorsTest extends FacesTestSuite {
   val r = 4
 
   describe("A PixelImage[A] for A=RGB") {
-    val i1 = randomImage(w, h)
-    val i2 = randomImage(w, h)
+    val i1 = randomImageRGB(w, h)
+    val i2 = randomImageRGB(w, h)
     val f = PixelImage(w, h, (x, y) => rnd.scalaRandom.nextDouble())
 
     it("supports +") {

--- a/src/test/scala/scalismo/faces/image/MultiChannelImageBufferTests.scala
+++ b/src/test/scala/scalismo/faces/image/MultiChannelImageBufferTests.scala
@@ -33,7 +33,7 @@ class MultiChannelImageBufferTests extends FacesTestSuite {
   val emptyBuffer: MultiChannelImageBuffer = MultiChannelImageBuffer(w, h, d)
   val randomBuffer = MultiChannelImageBuffer(w, h, d, Array.fill(w * h * d)(randomDouble))
 
-  val image: PixelImage[RGB] = randomImage(w, h)
+  val image: PixelImage[RGB] = randomImageRGB(w, h)
 
   describe("A MultiChannelImageBuffer") {
     it("has proper dimensions") {

--- a/src/test/scala/scalismo/faces/image/PixelImageTests.scala
+++ b/src/test/scala/scalismo/faces/image/PixelImageTests.scala
@@ -28,7 +28,7 @@ class PixelImageTests extends FacesTestSuite {
   val fixedImageCM = PixelImage(ColumnMajorImageDomain(2, 3), Array(1f, 2f, 3f, 4f, 5f, 6f))
   val fixedImageRM = PixelImage(RowMajorImageDomain(2, 3), Array(1f, 2f, 3f, 4f, 5f, 6f))
 
-  val rndImage: PixelImage[RGB] = randomImage(w, h)
+  val rndImage: PixelImage[RGB] = randomImageRGB(w, h)
 
   describe("A fixed PixelImage") {
     it("has the proper access pattern inside domain (column major)") {

--- a/src/test/scala/scalismo/faces/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/faces/io/ImageIOTests.scala
@@ -33,7 +33,7 @@ class ImageIOTests extends FacesTestSuite {
   /** reconstruction tolerance, IO is only 8 bit! */
   val tolerance = math.sqrt(4*math.pow(1.0/255.0,2.0)) // 8 bit write/read
 
-  val img = randomImage(37, 67)
+  val img = randomImageRGB(37, 67)
   val imgG = img.map(_.gray)
   val imgA = img.map(RGBA(_))
 

--- a/src/test/scala/scalismo/faces/render/TextureExtractionTests.scala
+++ b/src/test/scala/scalismo/faces/render/TextureExtractionTests.scala
@@ -16,18 +16,23 @@
 
 package scalismo.faces.render
 
+import java.io.File
+
 import scalismo.faces.FacesTestSuite
 import scalismo.faces.color.{RGB, RGBA}
 import scalismo.faces.image.InterpolationKernel.BilinearKernel
 import scalismo.faces.image.PixelImage
+import scalismo.faces.io.PixelImageIO
 import scalismo.faces.mesh.{ColorNormalMesh3D, TextureMappedProperty}
 import scalismo.faces.parameters.{Camera, Pose, RenderParameter}
 import scalismo.faces.render.PixelShaders.PropertyShader
 import scalismo.geometry.Vector
 import scalismo.mesh.{MeshSurfaceProperty, SurfacePointProperty, TriangleMesh3D}
+import scalismo.utils.Random
 
 class TextureExtractionTests extends FacesTestSuite {
   import scalismo.faces.image.PixelImage.implicits._
+  override  implicit val rnd = Random(43)
 
   val w = 100
   val h = 100
@@ -41,7 +46,7 @@ class TextureExtractionTests extends FacesTestSuite {
   val texture: TextureMappedProperty[RGBA] = gridMesh.color.asInstanceOf[TextureMappedProperty[RGBA]]
 
   val texImage: PixelImage[RGBA] = texture.texture
-  val rndTexture: PixelImage[RGBA] = PixelImage(texImage.width / 20, texImage.height / 20, (x, y) => randomRGBA).resample(texImage.width, texImage.height, BilinearKernel)
+  val rndTexture: PixelImage[RGBA] = randomImageRGBA(texImage.width / 20, texImage.height / 20).resample(texImage.width, texImage.height, BilinearKernel)
 
   val rps: RenderParameter = RenderParameter.default.copy(
     camera = Camera.for35mmFilm(focalLength = 100),
@@ -64,7 +69,7 @@ class TextureExtractionTests extends FacesTestSuite {
 
   describe("TextureExtractionTests") {
     // make random image
-    val rndImage: PixelImage[RGBA] = randomImage(rps.imageSize.width / 10, rps.imageSize.height / 10).resample(rps.imageSize.width, rps.imageSize.height).mapLazy(_.toRGBA)
+    val rndImage: PixelImage[RGBA] = randomImageRGBA(rps.imageSize.width / 10, rps.imageSize.height / 10).resample(rps.imageSize.width, rps.imageSize.height)
 
     // imageAsSurfaceProperty
     it("should extract and re-render an image as surface property consistently") {


### PR DESCRIPTION
def randomImageRGB was not deterministic
The non-deterministic behaviour was caused by the buffer of the Pixelimage which uses a parallel map.

replaced some inplace implementations to generate a random image

fixes #42 and fixes #17 