### PR TITLE
Added missing implicits in the functions of GaussianTranslationProposal

### DIFF
--- a/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianTranslationProposal.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/GaussianTranslationProposal.scala
@@ -36,14 +36,14 @@ object GaussianTranslationProposal {
   /**
     * Constructs a translation proposal, which only shifts in the xy-plane and leaves the z-value constant.
     */
-  def apply(sdev: Vector2D) : GaussianTranslationProposal = {
+  def apply(sdev: Vector2D)(implicit rnd: Random) : GaussianTranslationProposal = {
     Gaussian3DTranslationProposalConstantZ(sdev)
   }
 
   /**
     * Constructs a full 3d translation proposal.
     */
-  def apply(sdev: Vector3D) : GaussianTranslationProposal = {
+  def apply(sdev: Vector3D)(implicit rnd: Random) : GaussianTranslationProposal = {
     Gaussian3DTranslationProposal(sdev)
   }
 


### PR DESCRIPTION
Using the functions `GaussianTranslationProposal.apply` did not handle the implicits correctly. Sampling runs were not correctly seeded. This pull request adds the missing implicit so that it is passed correctly to the constructed objects.