### PR TITLE
Added Poisson solvers

### DIFF
--- a/src/main/scala/scalismo/faces/numerics/ArnoldiSymmetricEigenSolver.scala
+++ b/src/main/scala/scalismo/faces/numerics/ArnoldiSymmetricEigenSolver.scala
@@ -1,0 +1,173 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import com.github.fommil.netlib.ARPACK
+import org.netlib.util.{doubleW, intW}
+
+object ArnoldiSymmetricEigenSolver {
+
+  /** Used in symmetricEigs() to distinguish which k eigenvalues should be calculated first. */
+  object EigenvaluesFirst extends Enumeration {
+    type EigenvaluesFirst = Value
+    val Largest, Smallest, LargestMagnitude, SmallestMagnitude, HalfFromEachEnd = Value
+  }
+
+  /**
+    * Compute the leading k eigenvalues and eigenvectors on a symmetric square matrix using ARPACK.
+    * The caller needs to ensure that the input matrix is real symmetric. This function requires
+    * memory for `n*(4*k+4)` doubles.
+    *
+    * @param mul a function that multiplies the symmetric matrix with a DenseVector.
+    * @param n dimension of the square matrix (maximum Int.MaxValue).
+    * @param k number of leading eigenvalues required, 0 < k < n.
+    * @param eigenValuesFirst which k eigenvalues should be calculated first.
+    * @param tol tolerance of the eigs computation.
+    * @param maxIterations the maximum number of Arnoldi update iterations.
+    * @return a dense vector of eigenvalues in descending order and a dense matrix of eigenvectors
+    *         (columns of the matrix).
+    * @note The number of computed eigenvalues might be smaller than k when some Ritz values do not
+    *       satisfy the convergence criterion specified by tol (see ARPACK Users Guide, Chapter 4.6
+    *       for more details). The maximum number of Arnoldi update iterations is set to 300 in this
+    *       function.
+    */
+  def symmetricEigs(mul: DenseVector[Double] => DenseVector[Double],
+                    n: Int,
+                    k: Int,
+                    eigenValuesFirst: EigenvaluesFirst.Value,
+                    tol: Double,
+                    maxIterations: Int): (DenseVector[Double], DenseMatrix[Double]) = {
+    // TODO: remove this function and use eigs in breeze when switching breeze version
+    require(n > k, s"Number of required eigenvalues $k must be smaller than matrix dimension $n")
+
+    val arpack = ARPACK.getInstance()
+
+    // tolerance used in stopping criterion
+    val tolW = new doubleW(tol)
+    // number of desired eigenvalues, 0 < nev < n
+    val nev = new intW(k)
+    // nev Lanczos vectors are generated in the first iteration
+    // ncv-nev Lanczos vectors are generated in each subsequent iteration
+    // ncv must be smaller than n
+    val ncv = math.min(2 * k, n)
+
+    // "I" for standard eigenvalue problem, "G" for generalized eigenvalue problem
+    val bmat = "I"
+
+    /*'LA' - compute the NEV largest (algebraic) eigenvalues.
+      'SA' - compute the NEV smallest (algebraic) eigenvalues.
+      'LM' - compute the NEV largest (in magnitude) eigenvalues.
+      'SM' - compute the NEV smallest (in magnitude) eigenvalues.
+      'BE' - compute NEV eigenvalues, half from each end of the
+             spectrum.  When NEV is odd, compute one more from the
+             high end than from the low end.*/
+    val which = eigenValuesFirst match  {
+      case EigenvaluesFirst.Largest => "LA"
+      case EigenvaluesFirst.Smallest => "SA"
+      case EigenvaluesFirst.LargestMagnitude => "LM"
+      case EigenvaluesFirst.SmallestMagnitude => "SM"
+      case EigenvaluesFirst.HalfFromEachEnd => "BE"
+    }
+    var iparam = new Array[Int](11)
+    // use exact shift in each iteration
+    iparam(0) = 1
+    // maximum number of Arnoldi update iterations, or the actual number of iterations on output
+    iparam(2) = maxIterations
+    // Mode 1: A*x = lambda*x, A symmetric
+    iparam(6) = 1
+
+    require(n * ncv.toLong <= Integer.MAX_VALUE && ncv * (ncv.toLong + 8) <= Integer.MAX_VALUE,
+      s"k = $k and/or n = $n are too large to compute an eigendecomposition")
+
+    var ido = new intW(0)
+    var info = new intW(0)
+    var resid = new Array[Double](n)
+    var v = new Array[Double](n * ncv)
+    var workd = new Array[Double](n * 3)
+    var workl = new Array[Double](ncv * (ncv + 8))
+    var ipntr = new Array[Int](11)
+
+    // call ARPACK's reverse communication, first iteration with ido = 0
+    arpack.dsaupd(ido, bmat, n, which, nev.`val`, tolW, resid, ncv, v, n, iparam, ipntr, workd,
+      workl, workl.length, info)
+
+    val w = DenseVector(workd)
+
+    // ido = 99 : done flag in reverse communication
+    while (ido.`val` != 99) {
+      if (ido.`val` != -1 && ido.`val` != 1) {
+        throw new IllegalStateException("ARPACK returns ido = " + ido.`val` +
+          " This flag is not compatible with Mode 1: A*x = lambda*x, A symmetric.")
+      }
+      // multiply working vector with the matrix
+      val inputOffset = ipntr(0) - 1
+      val outputOffset = ipntr(1) - 1
+      val x = w.slice(inputOffset, inputOffset + n)
+      val y = w.slice(outputOffset, outputOffset + n)
+      y := mul(x)
+      // call ARPACK's reverse communication
+      arpack.dsaupd(ido, bmat, n, which, nev.`val`, tolW, resid, ncv, v, n, iparam, ipntr,
+        workd, workl, workl.length, info)
+    }
+
+    if (info.`val` != 0) {
+      info.`val` match {
+        case 1 => throw new IllegalStateException("ARPACK returns non-zero info = " + info.`val` +
+          " Maximum number of iterations taken. (Refer ARPACK user guide for details)")
+        case 3 => throw new IllegalStateException("ARPACK returns non-zero info = " + info.`val` +
+          " No shifts could be applied. Try to increase NCV. " +
+          "(Refer ARPACK user guide for details)")
+        case _ => throw new IllegalStateException("ARPACK returns non-zero info = " + info.`val` +
+          " Please refer ARPACK user guide for error message.")
+      }
+    }
+
+    val d = new Array[Double](nev.`val`)
+    val select = new Array[Boolean](ncv)
+    // copy the Ritz vectors
+    val z = java.util.Arrays.copyOfRange(v, 0, nev.`val` * n)
+
+    // call ARPACK's post-processing for eigenvectors
+    arpack.dseupd(true, "A", select, d, z, n, 0.0, bmat, n, which, nev, tol, resid, ncv, v, n,
+      iparam, ipntr, workd, workl, workl.length, info)
+
+    // number of computed eigenvalues, might be smaller than k
+    val computed = iparam(4)
+
+    val eigenPairs = java.util.Arrays.copyOfRange(d, 0, computed).zipWithIndex.map { r =>
+      (r._1, java.util.Arrays.copyOfRange(z, r._2 * n, r._2 * n + n))
+    }
+
+    // sort the eigen-pairs in descending order
+    val sortedEigenPairs = eigenPairs.sortBy(- _._1)
+
+    // copy eigenvectors in descending order of eigenvalues
+    val sortedU = DenseMatrix.zeros[Double](n, computed)
+    sortedEigenPairs.zipWithIndex.foreach { r =>
+      val b = r._2 * n
+      var i = 0
+      while (i < n) {
+        sortedU.data(b + i) = r._1._2(i)
+        i += 1
+      }
+    }
+
+    (DenseVector(sortedEigenPairs.map(_._1)), sortedU)
+  }
+}

--- a/src/main/scala/scalismo/faces/numerics/ConjugateGradient.scala
+++ b/src/main/scala/scalismo/faces/numerics/ConjugateGradient.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{CSCMatrix, DenseVector, norm}
+
+/** Conjugate Gradient solver for sparse, large linear system */
+object ConjugateGradient {
+
+  /** solve system A*x = b, for a sparse matrix A using the Conjugate Gradient algorithm
+    * uses initial guess of zero */
+  def solveSparse(A: CSCMatrix[Double], b: DenseVector[Double], tolerance: Double = 1e-10): DenseVector[Double] = {
+    // without initial guess: zero
+    val initial = DenseVector.zeros[Double](b.length)
+    solveSparse(A, b, initial, tolerance, 2 * b.length)
+  }
+
+  /** solve system A*x = b, for a sparse matrix A using the Conjugate Gradient algorithm */
+  def solveSparse(A: CSCMatrix[Double], b: DenseVector[Double], xInit: DenseVector[Double], tolerance: Double, maxIter: Int): DenseVector[Double] = {
+    require(A.cols == b.length, "matrix and vector dimensions disagree")
+    // prepare
+    val initial = initialState(A, b, xInit)
+    val solver = cgIterator(A, b, initial).take(maxIter).dropWhile(state => norm(state.r) > tolerance).take(1)
+    val solution = if (solver.hasNext) solver.next else initial
+    solution.x
+  }
+
+  /** create an initial CG step (use for cgIterator) */
+  def initialState(A: CSCMatrix[Double], b: DenseVector[Double], x: DenseVector[Double]): CGState = {
+    require(A.cols == b.length, "matrix and vector dimensions disagree")
+    val r = b - A * x
+    val p = r.copy
+    CGState(x, r, p)
+  }
+
+  /** create an iterator of Conjugate Gradient steps */
+  def cgIterator(A: CSCMatrix[Double], b: DenseVector[Double], initial: CGState): Iterator[CGState] = {
+    Iterator.iterate(initial)(cgIteration(A, b, _))
+  }
+
+  /** a single Fletcher-Reeves Conjugate Gradient iteration (matrix A should not change between iterations) */
+  def cgIteration(A: CSCMatrix[Double], b: DenseVector[Double], state: CGState): CGState = {
+    val Ap: DenseVector[Double] = A * state.p
+    val rsq: Double = state.r.t * state.r
+    // alpha: step length
+    val alpha: Double = rsq / (state.p.t * Ap)
+    // update solution
+    val x: DenseVector[Double] = state.x + alpha * state.p
+    val r: DenseVector[Double] = state.r - alpha * Ap
+    // conjugate direction update
+    val beta: Double = (r.t * r) / rsq
+    val p: DenseVector[Double] = r + beta * state.p
+    CGState(x, r, p)
+  }
+
+  /** CG algorithm state (use for iterative interface) */
+  case class CGState(x: DenseVector[Double], r: DenseVector[Double], p: DenseVector[Double])
+}
+

--- a/src/main/scala/scalismo/faces/numerics/DenseCholesky.scala
+++ b/src/main/scala/scalismo/faces/numerics/DenseCholesky.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+
+/** Cholesky decomposition */
+object DenseCholesky {
+  /** perform a dense Cholesky factorization of matrix A, can only deal with 10k+ elements */
+  def apply(A: DenseMatrix[Double]): DenseMatrix[Double] = cholesky(A)
+
+  /** perform a dense Cholesky factorization of matrix A, can only deal with 10k+ elements */
+  def cholesky(A: DenseMatrix[Double], tolerance: Double = 1e-15): DenseMatrix[Double] = {
+    // assume A is positive definite and symmetric
+    require(A.rows == A.cols, "A needs to be symmetric, at least quadratic")
+    if (A.rows == 0) {
+      return A
+    }
+    val n = A.rows
+    // start with empty factor
+    val L = DenseMatrix.zeros[Double](A.rows, A.cols)
+    // column 0
+    val S = A(::, 0)
+    if (S(0) < -tolerance) throw new Exception(s"Cholesky factorization only works with positive definite matrices, negative value encountered: ${S(0)}")
+    val d = math.sqrt(S(0))
+    L(0, 0) = d
+    L(1 until n, 0) := S(1 to -1) / d
+    // column j: 1 until n-1 (w/o first and last)
+    var j = 1
+    while (j < n - 1) {
+      val Lr = L(j until n, 0 until j)
+      val L1 = Lr(0, 0 until j).t
+      val S = A(j until n, j) - Lr * L1
+      val d = math.sqrt(S(0))
+      L(j, j) = d
+      L(j + 1 until n, j) := S(1 to -1) / d
+      j += 1
+    }
+    // last entry
+    val Lr = L(n - 1, ::)
+    L(n - 1, n - 1) = math.sqrt(A(n - 1, n - 1) - Lr * Lr.t)
+    // finished, factor is filled
+    L
+  }
+
+  /** solve the linear system Ax = b for positive definite and symmetric matrix A using a Cholesky decomposition */
+  def solve(A: DenseMatrix[Double], b: DenseVector[Double]): DenseVector[Double] = {
+    val L = cholesky(A)
+    substitutionSolver(L, b)
+  }
+
+  /**
+   * solves LL.t * x = b, for L dense lower triangular matrix,
+   *
+   * @param choleskyFactor Cholesky factor of A
+   */
+  def substitutionSolver(choleskyFactor: DenseMatrix[Double], b: DenseVector[Double]): DenseVector[Double] = {
+    require(choleskyFactor.rows == b.length, "dimensions disagree")
+    require(choleskyFactor.rows == choleskyFactor.cols, "L must be square")
+
+    val L = choleskyFactor
+    val n = L.rows
+
+    // solve L Lt x = b
+    // 1) solve Ly = b
+    val y = DenseVector.zeros[Double](n)
+    // for each row substitute
+    var row = 0
+    while (row < n) {
+      // previous elements
+      val sum = L(row, 0 until row) * y(0 until row)
+      // divide by diagonal element
+      y(row) = (b(row) - sum) / L(row, row)
+      row += 1
+    }
+
+    // 2) solve Lt x = y
+    val x = DenseVector.zeros[Double](n)
+    row = n - 1 // bwd substitution from right to left
+    while (row >= 0) {
+      // previous elements
+      val sum = L.t(row, row + 1 until n) * x(row + 1 until n)
+      // divie by diagonal element
+      x(row) = (y(row) - sum) / L(row, row)
+      row -= 1
+    }
+    // x contains result
+    x
+  }
+}

--- a/src/main/scala/scalismo/faces/numerics/ImageDomainPoissonSolver.scala
+++ b/src/main/scala/scalismo/faces/numerics/ImageDomainPoissonSolver.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import scalismo.faces.image.{PixelImage, PixelImageOperations}
+
+/** Solve Poisson's equation in an image domain with (arbitrary) Dirichlet boundary conditions */
+trait ImageDomainPoissonSolver[A] {
+  /**
+   * solve Poisson's equation
+   *
+   * @param image initial and boundary values, fixed values of f
+   * @param mask  marks domain where solution is required, (true: fill-in trough equation (with f), false: keep fixed (boundary value))
+   * @param rhs   right-hand side of Poisson equation
+   */
+  def solvePoisson(image: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A]): PixelImage[A]
+
+  /** solve Poisson's equation in bounding box of mask */
+  def apply(image: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A]): PixelImage[A] = solvePoissonInBoundingBox(image, mask, rhs)
+
+  /** solve Poisson's equation in bounding box of mask */
+  def solvePoissonInBoundingBox(image: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A]): PixelImage[A] = {
+    // extract bounding box of mask: do not need to calculate outside the box + boundary
+    val bb: (Int, Int, Int, Int) = PixelImageOperations.boundingBox[Boolean](mask, x => x)
+
+    // grow bounding box by 1 pixel in each direction, includes boundary values
+    val left = math.max(0, bb._1 - 1)
+    val top = math.max(0, bb._2 - 1)
+    val right = math.min(image.width - 1, bb._3 + 1)
+    val bottom = math.min(image.height - 1, bb._4 + 1)
+
+    // restrict problem to bounding box + 1x1 pixels boundary layer
+    val imageBB = PixelImageOperations.subImage(image, left, top, right - left, bottom - top)
+    val maskBB = PixelImageOperations.subImage(mask, left, top, right - left, bottom - top)
+    val rhsBB = PixelImageOperations.subImage(rhs, left, top, right - left, bottom - top)
+
+    // run solver inside bounding box
+    val solutionBB = solvePoisson(imageBB, maskBB, rhsBB)
+
+    // insert solution into full image
+    PixelImageOperations.insetView(image, solutionBB, left, top)
+  }
+}

--- a/src/main/scala/scalismo/faces/numerics/LinearSystemPoissonSolver.scala
+++ b/src/main/scala/scalismo/faces/numerics/LinearSystemPoissonSolver.scala
@@ -1,0 +1,333 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{CSCMatrix, DenseMatrix, DenseVector}
+import breeze.optimize.linear.{ConjugateGradient => BreezeCG}
+import scalismo.faces.common.ComponentRepresentation
+import scalismo.faces.image.{ChannelOperations, PixelImage}
+
+import scala.reflect.ClassTag
+
+/** transform a Poisson equation in the image domain to a linear system (finite differences) */
+abstract class LinearSystemPoissonSolver[A](implicit vec: ComponentRepresentation[A]) extends ImageDomainPoissonSolver[A] {
+  /** find a good linearization order (currently select column major or row major only) */
+  protected def findLinearization(mask: PixelImage[Boolean]): ImageLinearization = {
+    // choose between row and column major: shorter side should be major to avoid long distances
+    val domain = if (mask.width > mask.height) mask.domain.toColumnMajor else mask.domain.toRowMajor
+    val allPoints = domain.points
+    // construct reduction index (only inner points), maps full index to reduced index (or -1 if not available)
+    var index = -1
+    val reducedIndex = allPoints.map {
+      case (x, y) =>
+        if (mask(x, y)) {
+          index += 1
+          index
+        } else
+          -1 // invalid value for outside points
+    }
+    // keep only pixels which are within the variable domain
+    val linearization = allPoints.filter { case (x, y) => mask(x, y) }
+    // provides linearization (ordering of (x, y) pairs) and reduced index for each (x, y) pair
+    ImageLinearization(linearization, (x, y) => reducedIndex(domain.index(x, y)))
+  }
+
+  /** constructs a Laplace matrix, (-Laplace(f) is positive definite) calls addElement for each matrix element */
+  protected def buildNegativeLaplaceMatrix(linearization: ImageLinearization, mask: PixelImage[Boolean], addElement: (Int, Int, Double) => Unit): Unit = {
+    linearization.order.foreach {
+      case (x, y) =>
+        // reduced index, (only in inside points)
+        val rIndex = linearization.reducedIndex(x, y)
+        assert(rIndex != -1, "invalid reduced index, inner point should have one")
+        // all neighbours
+        val nn = getNeighbours4(x, y)
+        // inner neighbours
+        val in = nn.filter { case (nx, ny) => mask(nx, ny) }
+        // reduced indices of inner neighbours
+        val rIndexIN = in.map { case (nx, ny) => linearization.reducedIndex(nx, ny) }
+        assert(!rIndexIN.contains(-1), "inner point neighbours with invalid reduced index")
+        // set matrix entries for point
+        // diagonal value
+        addElement(rIndex, rIndex, nn.size)
+        // forward neighbouring: symmetric, set both entries now
+        rIndexIN.filter(i => i > rIndex).foreach { rIN =>
+          addElement(rIndex, rIN, -1)
+          addElement(rIN, rIndex, -1)
+        }
+    }
+  }
+
+  /** negative of righthand side: actually solves (-Laplace(f)) = -rhs */
+  protected def buildNegativeRHS(linearization: ImageLinearization, image: PixelImage[A], rhs: PixelImage[A], component: Int): DenseVector[Double] = {
+    val n = linearization.order.size
+    val b = DenseVector.zeros[Double](n)
+    linearization.order.foreach {
+      case (x, y) =>
+        // get index
+        val rIndex = linearization.reducedIndex(x, y)
+        // value of rhs
+        val r = vec.component(rhs(x, y), component)
+        // check neighbours: at boundary? add fixed boundary values of neighbours to rhs
+        val nn = getNeighbours4(x, y)
+        val bn = nn.filter { case (nx, ny) => !linearization.isInside(nx, ny) }
+        val boundaryNeighbours = bn.map { case (bx, by) => vec.component(image(bx, by), component) }.sum
+        // construct target vector
+        b(rIndex) = -r + boundaryNeighbours
+    }
+    b
+  }
+
+  /** find 4-neighbourhood */
+  protected def getNeighbours4(x: Int, y: Int): IndexedSeq[(Int, Int)] = {
+    IndexedSeq((x - 1, y), (x + 1, y), (x, y - 1), (x, y + 1))
+  }
+
+  protected def linearizeImage(linearization: ImageLinearization, image: PixelImage[A], component: Int): DenseVector[Double] = {
+    val n = linearization.order.size
+    val b = DenseVector.zeros[Double](n)
+    linearization.order.foreach {
+      case (x, y) =>
+        // get index
+        val rIndex = linearization.reducedIndex(x, y)
+        // value of image
+        b(rIndex) = vec.component(image(x, y), component)
+    }
+    b
+  }
+
+  protected def reconstructImageComponent(solution: DenseVector[Double], linearization: ImageLinearization, image: PixelImage[A], component: Int): PixelImage[Double] = {
+    // reconstruct component image
+    PixelImage(image.width, image.height,
+      (x, y) => {
+        val rIndex = linearization.reducedIndex(x, y)
+        if (rIndex != -1)
+          solution(rIndex)
+        else
+          vec.component(image(x, y), component)
+      })
+  }
+
+  /** provides a linearization (ordering of (x, y) pairs) and reduced index for each (x, y) pair */
+  protected case class ImageLinearization(order: IndexedSeq[(Int, Int)], reducedIndex: (Int, Int) => Int) {
+    val size = order.size
+
+    def isInside(x: Int, y: Int): Boolean = reducedIndex(x, y) != -1
+  }
+
+}
+
+/** solve a Poisson equation in the image domain using a dense linear Cholesky solver (due to the dense matrix only for small systems and a lot of memory) */
+class DenseLinearSystemPoissonSolver[A: ClassTag](implicit vec: ComponentRepresentation[A]) extends LinearSystemPoissonSolver[A] {
+
+  /**
+   * solve the Poisson equation using a dense linear system solver, careful matrix construction of size (w*h)x(w*h)
+   *
+   * @param image initial and boundary values, fixed values of f
+   * @param mask  marks domain where solution is required, (true: fill-in trough equation (with f), false: keep fixed (boundary value))
+   * @param rhs   right-hand side of Poisson equation
+   */
+  override def solvePoisson(image: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A]): PixelImage[A] = {
+    // get a good linearization order
+    val linearization = findLinearization(mask)
+    // system size (only inner points)
+    val n = linearization.size
+
+    // build matrix according to linearization order
+    val M = DenseMatrix.zeros[Double](n, n)
+    buildNegativeLaplaceMatrix(linearization, mask, (i, j, v) => M(i, j) = v)
+
+    // cholesky factorization
+    val L: DenseMatrix[Double] = DenseCholesky(M)
+
+    // solve system for each channel of A (reuses the same factorization)
+    val imageStack = for (c <- 0 until vec.size) yield {
+      // extraction of channel c
+      // construct rhs for system, original rhs and fixed boundary values (only component c)
+      val b = buildNegativeRHS(linearization, image, rhs, c)
+      // solve!
+      val solution: DenseVector[Double] = DenseCholesky.substitutionSolver(L, b)
+      // reconstruct component image
+      reconstructImageComponent(solution, linearization, image, c)
+    }
+    // compose image stack
+    ChannelOperations.composeChannels[A](imageStack)
+  }
+}
+
+/** solve a Poisson equation using a sparse Cholesky decomposition (efficient for small systems, use PCG for larger systems) */
+class SparseCholeskyPoissonSolver[A: ClassTag](permutationStrategy: PermutationStrategy = PermutationStrategy.default)(implicit vec: ComponentRepresentation[A])
+    extends LinearSystemPoissonSolver[A] {
+
+  /**
+   * solve Poisson's equation using a sparse Cholesky decomposition, solves for each component of A independently
+   * performs only a single factorization which can be reused for each component
+   *
+   * @param image initial and boundary values, fixed values of f
+   * @param mask  marks domain where solution is required, (true: fill-in trough equation (with f), false: keep fixed (boundary value))
+   * @param rhs   right-hand side of Poisson equation
+   */
+  override def solvePoisson(image: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A]): PixelImage[A] = {
+    // get a good linearization order
+    val linearization = findLinearization(mask)
+    // system size (only inner points)
+    val n = linearization.size
+
+    // build matrix according to linearization order
+    val matBuilder = new CSCMatrix.Builder[Double](n, n, 5 * n)
+    buildNegativeLaplaceMatrix(linearization, mask, (i, j, v) => matBuilder.add(i, j, v))
+    val M: CSCMatrix[Double] = matBuilder.result()
+
+    // cholesky factorization
+    val L = SparseCholesky.sparseCholesky(M)
+
+    // solve system for each channel of A (reuses the same factorization)
+    val imageStack = for (c <- 0 until vec.size) yield {
+      // extraction of channel c
+      // construct rhs for system, original rhs and fixed boundary values (only component c)
+      val b = buildNegativeRHS(linearization, image, rhs, c)
+      // solve!
+      val solution: DenseVector[Double] = SparseCholesky.substitutionSolver(L, b)
+
+      // reconstruct component image
+      reconstructImageComponent(solution, linearization, image, c)
+    }
+
+    // compose image stack
+    ChannelOperations.composeChannels[A](imageStack)
+  }
+}
+
+/** conjugate gradient solver for a Poisson system, no preconditioning (only for very small systems, prefer Preconditioned CG) */
+class ConjugateGradientPoissonSolver[A: ClassTag](tolerance: Double = 1e-6, maxIterations: Int = Int.MaxValue)(implicit vec: ComponentRepresentation[A]) extends LinearSystemPoissonSolver[A] {
+  /**
+   * solve Poisson's equation
+   *
+   * @param image initial and boundary values, fixed values of f
+   * @param mask  marks domain where solution is required, (true: fill-in trough equation (with f), false: keep fixed (boundary value))
+   * @param rhs   right-hand side of Poisson equation
+   */
+  override def solvePoisson(image: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A]): PixelImage[A] = {
+    // get a good linearization order
+    val linearization = findLinearization(mask)
+    // system size (only inner points)
+    val n = linearization.size
+
+    // build matrix according to linearization order
+    val matBuilder = new CSCMatrix.Builder[Double](n, n, 5 * n)
+    buildNegativeLaplaceMatrix(linearization, mask, (i, j, v) => matBuilder.add(i, j, v))
+    val A: CSCMatrix[Double] = matBuilder.result()
+
+    val maxIter = math.min(maxIterations, 5 * A.cols)
+    // solve system for each channel of A (reuses the same factorization)
+    val imageStack = for (c <- 0 until vec.size) yield {
+      // extraction of channel c
+      // construct rhs for system, original rhs and fixed boundary values (only component c)
+      val b = buildNegativeRHS(linearization, image, rhs, c)
+      // construct initial guess from image
+      val xInitial = linearizeImage(linearization, image, c)
+      // solve!
+      val solution: DenseVector[Double] = ConjugateGradient.solveSparse(A, b, xInitial, tolerance, maxIter)
+      // reconstruct component image
+      reconstructImageComponent(solution, linearization, image, c)
+    }
+    // compose image stack
+    ChannelOperations.composeChannels[A](imageStack)
+  }
+}
+
+/** conjugate gradient solver for a Poisson system, uses incomplete Cholesky preconditioning (considerably faster than CG) */
+class PreconditionedConjugateGradientPoissonSolver[A: ClassTag](tolerance: Double = 1e-6, maxIterations: Int = Int.MaxValue)(implicit vec: ComponentRepresentation[A]) extends LinearSystemPoissonSolver[A] {
+  /**
+   * solve Poisson's equation
+   *
+   * @param image initial and boundary values, fixed values of f
+   * @param mask  marks domain where solution is required, (true: fill-in trough equation (with f), false: keep fixed (boundary value))
+   * @param rhs   right-hand side of Poisson equation
+   */
+  override def solvePoisson(image: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A]): PixelImage[A] = {
+    // get a good linearization order
+    val linearization = findLinearization(mask)
+    // system size (only inner points)
+    val n = linearization.size
+
+    // build matrix according to linearization order
+    val matBuilder = new CSCMatrix.Builder[Double](n, n, 5 * n)
+    buildNegativeLaplaceMatrix(linearization, mask, (i, j, v) => matBuilder.add(i, j, v))
+    val A: CSCMatrix[Double] = matBuilder.result()
+
+    // preconditioner
+    val precond = PreconditionedConjugateGradient.incompleteCholeskyPreconditioner(A)
+
+    val maxIter = math.min(maxIterations, 5 * A.cols)
+    // solve system for each channel of A (reuses the same factorization)
+    val imageStack = for (c <- 0 until vec.size) yield {
+      // extraction of channel c
+      // construct rhs for system, original rhs and fixed boundary values (only component c)
+      val b = buildNegativeRHS(linearization, image, rhs, c)
+      // construct initial guess from image
+      val xInitial = linearizeImage(linearization, image, c)
+      // solve!
+      val solution: DenseVector[Double] = PreconditionedConjugateGradient.solveSparse(A, b, xInitial, precond, tolerance, maxIter)
+      // reconstruct component image
+      reconstructImageComponent(solution, linearization, image, c)
+    }
+    // compose image stack
+    ChannelOperations.composeChannels[A](imageStack)
+  }
+}
+
+/** conjugate gradient solver from breeze (for completeness, do not use, has no preconditioning and is slow, rather use PreconditionedConjugateGradient and maybe ConjugateGradient) */
+class BreezeCGPoissonSolver[A: ClassTag](tolerance: Double = 1e-6, maxIterations: Int = Int.MaxValue)(implicit vec: ComponentRepresentation[A]) extends LinearSystemPoissonSolver[A] {
+  /**
+   * solve Poisson's equation
+   *
+   * @param image initial and boundary values, fixed values of f
+   * @param mask  marks domain where solution is required, (true: fill-in trough equation (with f), false: keep fixed (boundary value))
+   * @param rhs   right-hand side of Poisson equation
+   */
+  override def solvePoisson(image: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A]): PixelImage[A] = {
+    // get a good linearization order
+    val linearization = findLinearization(mask)
+    // system size (only inner points)
+    val n = linearization.size
+
+    val maxIter = math.min(maxIterations, 2 * n)
+
+    // build matrix according to linearization order
+    val matBuilder = new CSCMatrix.Builder[Double](n, n, 5 * n)
+    buildNegativeLaplaceMatrix(linearization, mask, (i, j, v) => matBuilder.add(i, j, v))
+    val A: CSCMatrix[Double] = matBuilder.result()
+
+    // breeze optimizer
+    val cgOpt = new BreezeCG[DenseVector[Double], CSCMatrix[Double]]()
+
+    // solve system for each channel of A (reuses the same factorization)
+    val imageStack = for (c <- 0 until vec.size) yield {
+      // extraction of channel c
+      // construct rhs for system, original rhs and fixed boundary values (only component c)
+      val b = buildNegativeRHS(linearization, image, rhs, c)
+      // construct initial guess from image
+      val xInitial = linearizeImage(linearization, image, c)
+      // solve!
+      val solution: DenseVector[Double] = cgOpt.minimize(b, A, xInitial)
+      // reconstruct component image
+      reconstructImageComponent(solution, linearization, image, c)
+    }
+    // compose image stack
+    ChannelOperations.composeChannels[A](imageStack)
+  }
+}

--- a/src/main/scala/scalismo/faces/numerics/MultigridPoissonSolver.scala
+++ b/src/main/scala/scalismo/faces/numerics/MultigridPoissonSolver.scala
@@ -1,0 +1,220 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import scalismo.faces.color.ColorSpaceOperations
+import scalismo.faces.image._
+import scalismo.faces.image.filter.{ImageFilter, ResampleFilter}
+import scalismo.faces.utils.LanguageUtilities.iterate
+
+import scala.reflect.ClassTag
+
+/** Multigrid parameters */
+case class MultigridParameters(vCycles: Int,
+                               minSize: Int,
+                               prepareIterations: Int,
+                               solverIterations: Int,
+                               occlusionCorrectionIterations: Int,
+                               correctionIterations: Int)
+
+object MultigridParameters {
+  /** sane default parameters for image inpainting solutions */
+  val default = MultigridParameters(
+    vCycles = 5,
+    minSize = 8,
+    prepareIterations = 10,
+    solverIterations = 10,
+    occlusionCorrectionIterations = 2,
+    correctionIterations = 10)
+}
+
+/** Multigrid algorithm to solve Poisson's equation in the image domain for generic pixel type A (efficient but may not fully converge with complicated boundaries) */
+class GenericMultigridPoissonSolver[A: ClassTag](parameters: MultigridParameters = MultigridParameters.default)(implicit ops: ColorSpaceOperations[A])
+  extends ImageDomainPoissonSolver[A] {
+
+  import ColorSpaceOperations.implicits._
+
+  /** solve the equation: Laplace(f) = rhs, f|fixedMask = boundary, single level relaxations: slow and does not solve "low frequency part"! use solveMultigridPoisson instead */
+  def solveSingleLevelPoisson(f: PixelImage[A],
+                              mask: PixelImage[Boolean],
+                              rhs: PixelImage[A],
+                              iterations: Int,
+                              hx: Double = 1.0,
+                              hy: Double = 1.0,
+                              sor: Double = 1.5): PixelImage[A] = {
+    iterate(f, iterations)(f => redBlackGaussSeidelRelaxation(f, mask, rhs, hx = hx, hy = hy, sor = sor))
+  }
+
+  /**
+    * multigrid solver of the Poisson equation: calculates f s.t. Laplace(f) = rhs, f(!mask) = image
+    *
+    * @param image initial and boundary values, fixed values of f
+    * @param mask  marks domain where solution is required, (true: fill-in trough equation (with f), false: keep fixed (boundary value))
+    * @param rhs   right-hand side of Poisson equation
+    */
+  override def solvePoisson(image: PixelImage[A],
+                            mask: PixelImage[Boolean],
+                            rhs: PixelImage[A]): PixelImage[A] = {
+    require(mask.domain == image.domain, "mask must be defined on whole image")
+    require(rhs.domain == image.domain, "size of rhs must match size of image and mask")
+    // run solver for starting grid with spacing of 1
+    iterate(image, parameters.vCycles)(i =>
+      recursiveMultigridSolver(
+        i,
+        mask,
+        rhs,
+        dx = 1.0,
+        dy = 1.0,
+        parameters
+      ))
+  }
+
+  /** calculate the residual image of the Poisson problem: rhs - Laplace(image) */
+  def residual(f: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A], hx: Double = 1.0, hy: Double = 1.0): PixelImage[A] = {
+    val image = f.withAccessMode(AccessMode.Repeat())
+    val dxSq = hx * hx
+    val dySq = hy * hy
+    PixelImage(f.width, f.height, (x, y) => {
+      if (mask(x, y))
+        rhs(x, y) - (image(x - 1, y) + image(x + 1, y)) / dxSq - (image(x, y - 1) + image(x, y + 1)) / dySq + (2.0 / dxSq + 2.0 / dySq) *: image(x, y)
+      else
+        ops.zero
+    }, f.accessMode)
+  }
+
+  /** perform a single Jacobi relaxation of the Poisson equation: Laplace(f) = rhs */
+  def jacobiRelaxation(f: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A], hx: Double, hy: Double, sor: Double = 1.0): PixelImage[A] = {
+    val image = f.withAccessMode(AccessMode.Repeat())
+    val dxSq = hx * hx
+    val dySq = hy * hy
+    PixelImage(f.width, f.height, (x, y) => {
+      if (mask(x, y))
+        image(x, y) * (1.0 - sor) + ((sor * 0.5) / (dxSq + dySq)) *: (dySq *: (image(x - 1, y) + image(x + 1, y)) + dxSq *: (image(x, y - 1) + image(x, y + 1)) - (dxSq * dySq) *: rhs(x, y))
+      else
+        f(x, y)
+    }, image.accessMode)
+  }
+
+  /**
+    * perform a single red-black Gauss-Seidel relaxation of the Poisson equation: Laplace(f) = rhs
+    * Gauss-Seidel relaxation uses updated values directly in the relaxation calculation, red-black performs two passes where the even and odd are updated separately
+    *
+    * @param sor SOR (successive over-relaxation) constant use 0..1 to slow down, 1..2 to accelerate
+    */
+  def redBlackGaussSeidelRelaxation(f: PixelImage[A], mask: PixelImage[Boolean], rhs: PixelImage[A], hx: Double, hy: Double, sor: Double = 1.0): PixelImage[A] = {
+    val dxSq = hx * hx
+    val dySq = hy * hy
+    val oddFilter = ImageFilter((image: PixelImage[A]) => PixelImage(image.width, image.height, (x, y) => {
+      if ((x + y) % 2 == 1 && mask(x, y))
+        image(x, y) * (1.0 - sor) + ((sor * 0.5) / (dxSq + dySq)) *: (dySq *: (image(x - 1, y) + image(x + 1, y)) + dxSq *: (image(x, y - 1) + image(x, y + 1)) - (dxSq * dySq) *: rhs(x, y))
+      else
+        image(x, y)
+    }, f.accessMode))
+
+    val evenFilter = ImageFilter((image: PixelImage[A]) => PixelImage(image.width, image.height, (x, y) => {
+      if ((x + y) % 2 == 0 && mask(x, y))
+        image(x, y) * (1.0 - sor) + ((sor * 0.5) / (dxSq + dySq)) *: (dySq *: (image(x - 1, y) + image(x + 1, y)) + dxSq *: (image(x, y - 1) + image(x, y + 1)) - (dxSq * dySq) *: rhs(x, y))
+      else
+        image(x, y)
+    }, f.accessMode))
+
+    f.withAccessMode(AccessMode.Repeat()).filter(oddFilter).filter(evenFilter)
+  }
+
+  // recursive MG implementation
+  private def recursiveMultigridSolver(f: PixelImage[A],
+                                       mask: PixelImage[Boolean],
+                                       rhs: PixelImage[A],
+                                       dx: Double,
+                                       dy: Double,
+                                       parameters: MultigridParameters): PixelImage[A] = {
+
+    val width = f.width
+    val height = f.height
+
+    val halfWidth = restrictSize(width)
+    val halfHeight = restrictSize(height)
+
+    //println(f"level: size=$width%3dx$height%3d: dx=$dx, dy=$dy")
+
+    // check size of mask on next coarser level: do we need to visit or solve here?
+    val restrictedMask = restrictMask(mask, halfWidth, halfHeight)
+    val restrictedMaskArea = restrictedMask.map(if (_) 1.0 else 0.0).values.sum
+
+    // check maximal recursion depth, minimal image size must be respected
+    if (width > parameters.minSize && height > parameters.minSize && restrictedMaskArea > 0.25 * parameters.minSize * parameters.minSize) {
+      // a few relaxation steps to get an approximate solution
+      val approximate = solveSingleLevelPoisson(f, mask, rhs, parameters.prepareIterations, hx = dx, hy = dy)
+      // restrict everything to a coarser level
+      // solve on coarser level
+      val residualImage = residual(approximate, mask, rhs, dx, dy)
+
+      val restrictedResidual = restrict(residualImage, halfWidth, halfHeight)
+      val restrictedResidualMasked = PixelImage.fromTemplate(restrictedResidual, (x, y) => if (restrictedMask(x, y)) restrictedResidual(x, y) else ops.zero)
+
+      val lowerLevelCorrection = recursiveMultigridSolver(
+        PixelImage(halfWidth, halfHeight, (x, y) => ops.zero, AccessMode.Repeat()),
+        restrictedMask,
+        restrictedResidualMasked,
+        dx * width.toDouble / halfWidth,
+        dy * height.toDouble / halfHeight,
+        parameters
+      )
+      val correction = prolongate(lowerLevelCorrection, width, height)
+      // apply residual correction
+      val withProlongationCorrection = PixelImage(width, height, (x, y) => {
+        if (mask(x, y)) // enforce boundary values
+          approximate(x, y) + correction(x, y)
+        else
+          f(x, y)
+      }).withAccessMode(f.accessMode)
+      // fix boundary values which are not corrected in the lower level
+      val maskC = prolongate(restrictedMask.map(b => if (b) 1.0 else 0.0), width, height).map(_ > 0.5)
+      val occludedInLower = PixelImage.fromTemplate(mask, (x, y) => mask(x, y) && !maskC(x, y))
+      // relax pixels which are occluded in lower level: adapt only these pixels
+      val occlusionCorrected = solveSingleLevelPoisson(withProlongationCorrection, occludedInLower, rhs, parameters.occlusionCorrectionIterations, hx = dx, hy = dy)
+
+      // fix some remaining high-frequency errors of the restriction/prolongation process
+      solveSingleLevelPoisson(occlusionCorrected, mask, rhs, parameters.correctionIterations, hx = dx, hy = dy)
+    } else {
+      solveSingleLevelPoisson(f, mask, rhs, parameters.solverIterations, hx = dx, hy = dy)
+    }
+
+  }
+
+  private def restrictSize(n: Int): Int = math.round(n / 1.25).toInt
+
+  /** pyramid / multigrid downsampling step: restrict */
+  private def restrict[B: ClassTag](image: PixelImage[B], w: Int, h: Int)(implicit ops: ColorSpaceOperations[B]): PixelImage[B] = {
+    ResampleFilter.resampleImage(image.withAccessMode(AccessMode.Repeat()), w, h, InterpolationKernel.BilinearKernel)
+  }
+
+  /** pyramid / multigrid downsampling step: boundary mask, treat specially: convert to implicit representation which can be interpolated and then convert back */
+  private def restrictMask(mask: PixelImage[Boolean], w: Int, h: Int): PixelImage[Boolean] = {
+    restrict(mask.map(b => if (b) 1.0 else 0.0), w, h).map(m => m > 0.5)
+  }
+
+  /** pyramid / multigrid upsampling: prolongate */
+  private def prolongate[B: ClassTag](image: PixelImage[B], w: Int, h: Int)(implicit ops: ColorSpaceOperations[B]): PixelImage[B] = {
+    ResampleFilter.resampleImage(image.withAccessMode(AccessMode.Repeat()), w, h, InterpolationKernel.BilinearKernel)
+  }
+}
+
+object GenericMultigridPoissonSolver {
+  // we need to generate an instance due to pixel type parameter A
+  def apply[A: ClassTag](implicit ops: ColorSpaceOperations[A]) = new GenericMultigridPoissonSolver[A]()
+}

--- a/src/main/scala/scalismo/faces/numerics/Permutation.scala
+++ b/src/main/scala/scalismo/faces/numerics/Permutation.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{CSCMatrix, DenseVector, VectorBuilder}
+
+/** permutation */
+class Permutation(p: Array[Int]) {
+  val length: Int = p.length
+
+  protected val invP: Array[Int] = {
+    val arr = new Array[Int](p.length)
+    var i = 0
+    while (i < p.length) {
+      arr(p(i)) = i
+      i += 1
+    }
+    arr
+  }
+
+  def apply(i: Int): Int = p(i)
+
+  /** apply inverse permutation */
+  def inverse(i: Int): Int = invP(i)
+
+  /** get inverted permutation */
+  def inverted: Permutation = new Permutation(invP) {
+    override val invP: Array[Int] = p
+  }
+
+  def toArray: Array[Int] = p.clone()
+
+  override def toString: String = p.toIndexedSeq.toString
+}
+
+object Permutation {
+  /** create default identity permutation */
+  def identity(n: Int): Permutation = new Permutation(Array.empty[Int]) {
+    override def apply(i: Int): Int = i
+
+    override def inverse(i: Int): Int = i
+
+    override val length: Int = n
+
+    override def inverted = this
+
+    override def toArray: Array[Int] = (0 until n).toArray
+  }
+
+  /** checks whether a permutation is valid */
+  def isValid(p: Array[Int]): Boolean = {
+    val c = new Array[Boolean](p.length)
+    p.forall(i => {
+      val v = c(i)
+      c(i) = true
+      !v
+    })
+  }
+
+  /** reorder a vector, P gives new order */
+  def permuteVector(v: DenseVector[Double], P: Permutation): DenseVector[Double] = {
+    assert(v.length == P.length, "permutation length is wrong")
+    val w = DenseVector.zeros[Double](v.length)
+    var i = 0
+    while (i < w.length) {
+      w(i) = v(P(i))
+      i += 1
+    }
+    w
+  }
+
+  /** symmetrically permutes a matrix: A' = PAP.t, P holds new ordering */
+  def permuteSparseMatrix(A: CSCMatrix[Double], P: Permutation): CSCMatrix[Double] = {
+    // permutation encoding:
+    // build inverse permutation (for row index updates)
+    assert(P.length == A.cols && P.length == A.rows, "permutation has wrong size")
+    // new matrix storage
+    val pData = new Array[Double](A.data.length)
+    val pColPtrs = new Array[Int](A.colPtrs.length)
+    val pRowIndices = new Array[Int](A.rowIndices.length)
+    assert(pRowIndices.length == pData.length, "data must be of the same length as rowIndices")
+    assert(pColPtrs.length == A.cols + 1, "colPtrs must be of size A.cols+1")
+    // column permutation is easy: single traversal of CSCMatrix structure
+    pColPtrs(0) = 0
+    var col = 0
+    while (col < A.cols) {
+      // find old column in new ordering
+      val colInA = P(col)
+      // start and stop in A's data and row indices structure
+      val cStart = A.colPtrs(colInA)
+      val cEnd = A.colPtrs(colInA + 1)
+      val elemInCol = cEnd - cStart
+      // set length of new column
+      val pStart = pColPtrs(col)
+      val pEnd = pStart + elemInCol
+      pColPtrs(col + 1) = pEnd
+      // update row indices
+      val colBuilder = new VectorBuilder[Double](A.rows)
+      var r = 0
+      while (r < elemInCol) {
+        // old row index of element
+        val rowInA = A.rowIndices(cStart + r)
+        // row after permutation
+        val pRow = P.inverse(rowInA)
+        // add element to vector builder at new row position
+        colBuilder.add(pRow, A.data(cStart + r))
+        r += 1
+      }
+      // build column vector
+      val colVec = colBuilder.toSparseVector
+      assert(elemInCol == colVec.activeSize, "column vector has wrong number of elements")
+      System.arraycopy(colVec.index, 0, pRowIndices, pStart, elemInCol)
+      System.arraycopy(colVec.data, 0, pData, pStart, elemInCol)
+      // next column
+      col += 1
+    }
+    // construct CSCMatrix
+    new CSCMatrix[Double](pData, A.rows, A.cols, pColPtrs, pRowIndices)
+  }
+
+}

--- a/src/main/scala/scalismo/faces/numerics/PermutationStrategy.scala
+++ b/src/main/scala/scalismo/faces/numerics/PermutationStrategy.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.CSCMatrix
+
+import scala.collection.mutable
+
+/** permutation strategy for the Sparse Cholesky decomposition */
+sealed trait PermutationStrategy {
+  def findPermutation(A: CSCMatrix[Double]): Permutation
+}
+
+object PermutationStrategy {
+  val default = NoPermutation
+}
+
+/** do not permute matrix entries */
+case object NoPermutation extends PermutationStrategy {
+  override def findPermutation(A: CSCMatrix[Double]): Permutation = Permutation.identity(A.cols)
+}
+
+/** Cuthill-McKee permutation finder */
+case object CuthillMcKee extends PermutationStrategy {
+
+  import CSCMatrixGraph._
+
+  override def findPermutation(A: CSCMatrix[Double]): Permutation = {
+    require(A.cols == A.rows, "matrix is not square")
+    // breadth-first search with minimum degrees visited first
+    val n = A.cols
+    val ordering = new Array[Int](n)
+    val allNodes: Set[Int] = (0 until n).toSet
+    val visited = mutable.Set.empty[Int]
+    val queue = mutable.Queue.empty[Int] // node
+    var done = 0
+    while (done < n) {
+      // clean queue of visited nodes
+      // get next node to visit
+      val node: Int = {
+        if (queue.nonEmpty) {
+          // from queue
+          queue.dequeue()
+        } // as next minimum degree node
+        else {
+          val notVisited = allNodes.diff(visited)
+          notVisited.map(n => (degree(n, A), n)).min._2
+        }
+      }
+      // visit node:
+      visited.add(node)
+      ordering(done) = node
+      done += 1
+      // get all unvisited neighbours
+      val newNodes = neighbours(node, A).toSet.diff(visited).diff(queue.toSet)
+      // add to queue, in order of increasing degree
+      newNodes.toIndexedSeq.sortBy(n => degree(n, A)).foreach(queue.enqueue(_))
+      assert(newNodes.forall(n => !visited.contains(n)), "visited nodes added to queue")
+      assert(queue.forall { n => !visited.contains(n) }, s"visited nodes in queue, done=$done, q=$queue, visited=$visited")
+    }
+    new Permutation(ordering)
+  }
+}
+
+case object ReverseCuthillMcKee extends PermutationStrategy {
+  override def findPermutation(A: CSCMatrix[Double]): Permutation = {
+    val P = CuthillMcKee.findPermutation(A)
+    new Permutation(P.toArray.reverse)
+  }
+}
+
+/** look a t CSCMatrix as a graph (for permutation finders) */
+object CSCMatrixGraph {
+  def degree(n: Int, A: CSCMatrix[Double]): Int = {
+    require(n >= 0 && n < A.cols, "invalid node number")
+    val cStart = A.colPtrs(n)
+    val cEnd = A.colPtrs(n + 1)
+    cEnd - cStart - 1 // remove diagonal entry
+  }
+
+  def neighbours(n: Int, A: CSCMatrix[Double]): Array[Int] = {
+    require(n >= 0 && n < A.cols, "invalid node number")
+    val cStart = A.colPtrs(n)
+    val cEnd = A.colPtrs(n + 1)
+    A.rowIndices.slice(cStart, cEnd)
+  }
+}

--- a/src/main/scala/scalismo/faces/numerics/PivotedCholesky.scala
+++ b/src/main/scala/scalismo/faces/numerics/PivotedCholesky.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{DenseMatrix, DenseVector, sum}
+import scalismo.numerics.PivotedCholesky.{AbsoluteTolerance, NumberOfEigenfunctions, RelativeTolerance, StoppingCriterion}
+
+import scala.collection.mutable.ArrayBuffer
+
+/** performs a Pivoted Cholesky decomposition */
+object PivotedCholesky {
+  /** get a pivoted Cholesky decomposition of matrix A (calculates strongest components, best for low-rank approximation) */
+  def pivotedCholesky(A: DenseMatrix[Double], stoppingCriterion: StoppingCriterion): DenseMatrix[Double] = {
+    require(A.rows == A.cols, "works only for square matrices")
+    pivotedCholesky((i, j) => A(i, j), A.rows, stoppingCriterion)
+  }
+
+  /** get a pivoted Cholesky decomposition of function K(i,j) (calculates strongest components, best for low-rank approximation) */
+  def pivotedCholesky(K: (Int, Int) => Double, dim: Int, stoppingCriterion: StoppingCriterion): DenseMatrix[Double] = {
+    // assume A is positive definite and symmetric
+    if (dim == 0) {
+      return DenseMatrix.zeros[Double](0, 0)
+    }
+
+    val zeroTolerance = 1e-15
+    val n = dim
+
+    // extract diagonal
+    val D = DenseVector.zeros[Double](n)
+    for(i <- 0 until n) D(i) = K(i,i)
+    def error(col: Int) = sum(D(col until D.length).map(math.abs))
+
+    val (maxCols, errorThreshold) = stoppingCriterion match {
+      case RelativeTolerance(relTol) => (dim, error(0) * relTol)
+      case AbsoluteTolerance(eps) => (dim, eps)
+      case NumberOfEigenfunctions(i) => (math.min(dim, i), zeroTolerance)
+    }
+
+    // start with empty factor and identity permutation
+    val L = new PivotedCholeskyFactor(n, maxCols)
+    val P = Array.tabulate(n)(i => i)
+
+    def swapP(i: Int, j: Int) = {
+      val t = P(i)
+      P(i) = P(j)
+      P(j) = t
+    }
+
+    // column j
+    var col: Int = 0
+    while(col < maxCols && error(col) > errorThreshold) {
+      // find best pivot
+      //      val piv = (col until n).map(i => (i, D(P(i)))).maxBy(_._2)._1
+      // optimized pivot finder
+      var piv = col
+      var max = D(P(col))
+      var i = col + 1
+      while(i < n) {
+        val v = D(P(i))
+        if (v > max) {
+          max = v
+          piv = i
+        }
+        i += 1
+      }
+      // update permutation: swap current column with pivot
+      swapP(piv, col)
+      val pCol = P(col)
+      // println(s"col=$col, error=${error(col)}, pivot=$piv, P(col)=$pCol")
+
+      // calculate Schur complement, appropriately permuted
+      // pivot element: diagonal with -L*L.t correction so far
+      val pivEl = D(pCol)
+      require(pivEl > zeroTolerance, s"Pivoted Cholesky factorization only works for positive semi-definite matrices, value too close to zero d=$pivEl")
+
+      // explicit multiplication: find Schur complement, current column "col"
+      val Lcol = new Array[Double](n)
+      // diagonal element, sqrt and division, ensure numerical robustness wrt very small negatives
+      val diagEl = math.sqrt(math.max(0.0, pivEl))
+      Lcol(pCol) = diagEl
+      // initialize factor column with elements from A
+      for(row <- col + 1 until n) {
+        val pRow = P(row)
+        Lcol(pRow) += K(pRow, pCol)
+      }
+      // for each existing factor (column)
+      var component = 0
+      while(component < col) {
+        // fast access to current factor
+        val Lf = L.col(component)
+        val Lfcol = Lf(pCol)
+        // fill current column for rows from current column + 1 to end
+        var row = col + 1
+        while(row < n) {
+          // find permuted row index
+          val pRow = P(row)
+          // find Schur complement (A - L*L.t)/diagEl
+          // update current column of L: only L*L.t part
+          Lcol(pRow) -= Lfcol * Lf(pRow)
+          // next row
+          row += 1
+        }
+        // next factor
+        component += 1
+      } // new cholesky column complete
+      // update diagonal elements, remove contribution from this vector of the Cholesky factorization
+      // also finalize current L column: division by diagEl is still missing
+      var row = col + 1
+      while(row < n) {
+        val pRow = P(row)
+        val l = Lcol(pRow)/diagEl
+        Lcol(pRow) = l
+        D(pRow) -= l*l
+        row += 1
+      }
+      // completed column: append to L
+      L.addCol(Lcol)
+      // next column
+      col += 1
+    }
+    // convert L data structure to proper matrix
+    L.toDenseMatrix
+  }
+}
+
+/** hold a growing Cholesky factor, allows fast addition of columns, direct random index access */
+private class PivotedCholeskyFactor(d: Int, sizeHint: Int = 100) {
+  val cols = new ArrayBuffer[Array[Double]](sizeHint)
+
+  /** access element at L(i, j) */
+  def apply(row: Int, col: Int): Double = {
+    require(row >= 0 && row < d)
+    require(col >= 0 && col < cols.length)
+    cols(col)(row)
+  }
+
+  /** get column i as DenseVector[Double] */
+  def col(i: Int): Array[Double] = cols(i)
+
+  /** append column to end */
+  def addCol(vec: Array[Double]): Unit = {
+    require(vec.length == d)
+    cols += vec
+  }
+
+  /** convert to DenseMatrix */
+  def toDenseMatrix: DenseMatrix[Double] = {
+    val m = DenseMatrix.zeros[Double](d, cols.size)
+    for(i <- cols.indices) {
+      m(::,i) := DenseVector(cols(i))
+    }
+    m
+  }
+}

--- a/src/main/scala/scalismo/faces/numerics/PreconditionedConjugateGradient.scala
+++ b/src/main/scala/scalismo/faces/numerics/PreconditionedConjugateGradient.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{CSCMatrix, DenseVector, norm}
+
+/** implements the preconditioned conjugate gradient for faster convergence with good preconditioners */
+object PreconditionedConjugateGradient {
+
+  /** solve system A*x = b, with sparse matrix A using the Preconditioned Conjuate Gradient algorithm */
+  def solveSparse(A: CSCMatrix[Double], b: DenseVector[Double], preconditioner: DenseVector[Double] => DenseVector[Double], tolerance: Double = 1e-10): DenseVector[Double] = {
+    val xInit = DenseVector.zeros[Double](b.length)
+    solveSparse(A, b, xInit, preconditioner, tolerance, 2 * b.length)
+  }
+
+  /**
+    * solve sparse linear system with the preconditioned conjugate gradient algorithm
+    *
+    * @param preconditioner solves Mx = b (x = preconditionSolver(b)), more efficient inv(M)*b (where is a crude but accessible approximation to A)
+    */
+  def solveSparse(A: CSCMatrix[Double],
+                  b: DenseVector[Double],
+                  xInit: DenseVector[Double],
+                  preconditioner: DenseVector[Double] => DenseVector[Double],
+                  tolerance: Double,
+                  maxIter: Int): DenseVector[Double] = {
+    require(A.cols == b.length, "matrix and vector dimensions disagree")
+    // prepare
+    // count iterations
+    var i = 0
+    // initial guess
+    val initial = initialState(A, b, xInit, preconditioner)
+    // solving iterator with counter and convergence criteria (maxIter or below tolerance)
+    val solver = pcgIterator(A, b, preconditioner, initial).take(maxIter).dropWhile(state => norm(state.r) > tolerance).take(1)
+    val solution = if (solver.hasNext) solver.next else initial
+    solution.x
+  }
+
+  /** create an initial state with an initial guess */
+  def initialState(A: CSCMatrix[Double], b: DenseVector[Double], x: DenseVector[Double], preconditioner: DenseVector[Double] => DenseVector[Double]): PCGState = {
+    require(A.cols == b.length, "matrix and vector dimensions disagree")
+    val r = b - A * x
+    val z = preconditioner(r)
+    val p = z.copy
+    PCGState(x = x, r = r, p = p, z = z)
+  }
+
+  /** create an iterator of this PCG algorithm */
+  def pcgIterator(A: CSCMatrix[Double], b: DenseVector[Double], preconditioner: DenseVector[Double] => DenseVector[Double], initial: PCGState): Iterator[PCGState] = {
+    Iterator.iterate(initial)(state => pcgIteration(A, b, preconditioner, state))
+  }
+
+  /** a single Fletcher-Reeves Conjugate Gradient iteration (matrix A should not change between iterations) */
+  def pcgIteration(A: CSCMatrix[Double], b: DenseVector[Double], preconditioner: DenseVector[Double] => DenseVector[Double], state: PCGState): PCGState = {
+    val Ap: DenseVector[Double] = A * state.p
+    val rz: Double = state.r.t * state.z
+    // alpha: step length
+    val alpha: Double = rz / (state.p.t * Ap)
+    // update solution
+    val x: DenseVector[Double] = state.x + alpha * state.p
+    val r: DenseVector[Double] = state.r - alpha * Ap
+    val z: DenseVector[Double] = preconditioner(r)
+    // conjugate direction update
+    val beta: Double = (r.t * z) / rz
+    val p: DenseVector[Double] = z + beta * state.p
+    PCGState(x = x, r = r, p = p, z = z)
+  }
+
+  /** solve A*x = b, sparse A, initial guess is zero */
+  def solveSparse(A: CSCMatrix[Double], b: DenseVector[Double]): DenseVector[Double] = {
+    val preconditioner = incompleteCholeskyPreconditioner(A)
+    val xInit = DenseVector.zeros[Double](b.length)
+    solveSparse(A, b, xInit, preconditioner, 1e-10, 2 * b.length)
+  }
+
+  /** use an incomplete Cholesky factorization as preconditioner (factor restricted to sparsity pattern of A, no fill-in) */
+  def incompleteCholeskyPreconditioner(A: CSCMatrix[Double]): DenseVector[Double] => DenseVector[Double] = {
+    val incL = SparseCholesky.incompleteSparseCholesky(A)
+    x => SparseCholesky.substitutionSolver(incL, x)
+  }
+
+  /** holds state of a preconditioned conjugate gradient iteration */
+  case class PCGState(x: DenseVector[Double], r: DenseVector[Double], p: DenseVector[Double], z: DenseVector[Double])
+
+}

--- a/src/main/scala/scalismo/faces/numerics/SparseArray.scala
+++ b/src/main/scala/scalismo/faces/numerics/SparseArray.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import java.util
+
+import breeze.linalg.SparseVector
+
+/** sparse array, prevents boxing */
+private[numerics] class SparseArray(var index: Array[Int], var data: Array[Double], var nnz: Int, val length: Int) {
+  require(nnz <= length, "too many non zeros")
+  require(data.length == index.length, "data and index have different length")
+  require(data.length >= nnz, "data array is too short")
+
+  def activeSize = nnz
+
+  def update(i: Int, v: Double): Unit = {
+    val offset = findOffset(i)
+    if (offset >= 0)
+      data(offset) = v
+    else {
+      val insert = ~offset
+      nnz += 1
+      if (nnz > index.length) reallocate()
+
+      // insert
+      // move right part
+      System.arraycopy(index, insert, index, insert + 1, nnz - insert - 1)
+      System.arraycopy(data, insert, data, insert + 1, nnz - insert - 1)
+      // insert data
+      index(insert) = i
+      data(insert) = v
+    }
+  }
+
+  private def reallocate() = {
+    val newLength = math.max(nnz + 1, index.length * 2)
+    val _index = new Array[Int](newLength)
+    val _data = new Array[Double](newLength)
+    System.arraycopy(index, 0, _index, 0, index.length)
+    System.arraycopy(data, 0, _data, 0, data.length)
+    index = _index
+    data = _data
+  }
+
+  def apply(i: Int): Double = {
+    val offset = findOffset(i)
+    if (offset >= 0)
+      data(offset)
+    else
+      0.0
+  }
+
+  def findOffset(i: Int): Int = util.Arrays.binarySearch(index, 0, nnz, i)
+
+  def toDense: Array[Double] = {
+    val arr = new Array[Double](length)
+    var i = 0
+    while (i < nnz) {
+      val ind = index(i)
+      arr(ind) = data(i)
+      i += 1
+    }
+    arr
+  }
+}
+
+object SparseArray {
+  def apply(vector: SparseVector[Double]): SparseArray = {
+    val nnz = vector.activeSize
+    val index = new Array[Int](nnz)
+    val data = new Array[Double](nnz)
+    System.arraycopy(vector.index, 0, index, 0, nnz)
+    System.arraycopy(vector.data, 0, data, 0, nnz)
+    new SparseArray(index, data, nnz, vector.length)
+  }
+}

--- a/src/main/scala/scalismo/faces/numerics/SparseCholesky.scala
+++ b/src/main/scala/scalismo/faces/numerics/SparseCholesky.scala
@@ -1,0 +1,430 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import java.util
+
+import breeze.linalg._
+import scalismo.faces.image._
+
+/** sparse Cholesky decomposition */
+object SparseCholesky {
+
+  /** calculate sparse Cholesky decompositon, return factor L for A = LL^T ^ */
+  def apply(A: CSCMatrix[Double]): CSCMatrix[Double] = sparseCholesky(A)
+
+  /** solve the linear system Ax = b for a sparse positive definite and symmetric matrix A using a Cholesky decomposition */
+  def solve(A: CSCMatrix[Double], b: DenseVector[Double], fillInReduction: PermutationStrategy = PermutationStrategy.default): DenseVector[Double] = {
+    val P = fillInReduction.findPermutation(A)
+    val pA = Permutation.permuteSparseMatrix(A, P)
+    val L = sparseCholesky(pA)
+    substitutionSolver(L, b, P)
+  }
+
+  /** Cholesky decomposition of a sparse, positive definite and symmetric matrix A */
+  def sparseCholesky(A: CSCMatrix[Double], tolerance: Double = 1e-15): CSCMatrix[Double] = {
+    // assume A is positive definite and symmetric
+    require(A.rows == A.cols, "A needs to be symmetric, at least quadratic")
+    val n = A.rows
+    // start with empty factor
+    val L = new SparseCholeskyFactor(n)
+    // special column accumulator for fast write access and fast conversion to SparseVector
+    val columnBuilder = new SparseAccumulator(n)
+    // bandwidth protection: sparsity is limited by bandwidth in both A and L
+    var bandWidth = 0
+    // column j: 0 until n (no special treatment of first and last col)
+    var j = 0
+    while (j < n) {
+      // initialize sparse accumulator with column of A (below diagonal)
+      columnBuilder.initWithColumn(A, j)
+      bandWidth = min(n - 1, max(bandWidth, columnBuilder.lastIndex)) // last row with non-zero elements in A
+      // traverse row j in L(j, k=0 until j), for each non-zero subtract L(j, k)*L(j until n, k)
+      // use cursors structure to keep track of current row entries in columns
+      // along row j from left to diagonal
+      val Lrow = L.rows(j)
+      if (Lrow != null) {
+        // use sparse rows structure: e active element, next non-zero element
+        var e = 0
+        while (e < Lrow.activeSize) {
+          val k = Lrow.index(e)
+          val l = Lrow.data(e)
+
+          val c = L.cursors(k)
+          val Lcol = L.cols(k)
+          // subtract from acc: columnBuilder -= L(j,k) * L(j:n,k).t
+          // subtract: acting on VectorBuilder, subtract col L(j to n,k)
+          var actEl = math.max(c, 0)
+          while (actEl < Lcol.activeSize) {
+            // subtract element
+            val row = Lcol.index(actEl)
+            if (row <= bandWidth) {
+              // add elements only within bandwidth, outside is zero (cancels with later elements)
+              val data = Lcol.data(actEl)
+              columnBuilder.add(row, -data * l)
+            }
+            // next element to subtract
+            actEl += 1
+          }
+          // move cursor
+          L.cursors(k) += 1
+          // next non-zero col in row
+          e += 1
+        }
+      }
+      // work with SparseVector now, sparsity pattern is stable
+      val S = columnBuilder.toSparseVector
+      // sqrt and division of acc
+      assert(S.activeSize > 0 && S.index(0) == j, "first element is not diagonal entry") // first element on diagonal
+      assert(S.data(0) > -tolerance, s"Cholesky decomposition needs positive definite matrix! Negative value encountered: v=${S.data(0)}")
+      // negative number within numerical tolerance, set to zero to make sqrt work
+      if (S.data(0) < 0.0) S.data(0) = 0.0
+      // sqrt of first element
+      val d = math.sqrt(S.data(0))
+      S.data(0) = d
+      // divide all lower elements by d
+      var i = 1
+      while (i < S.activeSize) {
+        S.data(i) /= d
+        // next active element in S
+        i += 1
+      }
+      // update column value to new accumulator value
+      L.setCol(j, S)
+      // next column
+      j += 1
+    }
+    // finished, factor is filled
+    L.toCSCMatrix
+  }
+
+  /**
+   * solves LL.t * x = b, for L sparse lower triangular matrix,
+   *
+   * @param choleskyFactor Cholesky factor of A
+   */
+  def substitutionSolver(choleskyFactor: CSCMatrix[Double], b: DenseVector[Double]): DenseVector[Double] = {
+    require(choleskyFactor.rows == b.length, "dimensions disagree")
+    require(choleskyFactor.rows == choleskyFactor.cols, "L must be square")
+
+    val y = fwdSubstitution(choleskyFactor, b)
+    bwdSubstitution(choleskyFactor, y)
+  }
+
+  /**
+   * solves PLL.tP.t * x = b, for L sparse lower triangular matrix, P permutation
+   *
+   * @param choleskyFactor Cholesky factor of A
+   */
+  def substitutionSolver(choleskyFactor: CSCMatrix[Double], b: DenseVector[Double], P: Permutation): DenseVector[Double] = {
+    require(choleskyFactor.rows == b.length, "dimensions disagree")
+    require(choleskyFactor.rows == choleskyFactor.cols, "L must be square")
+
+    val pb = Permutation.permuteVector(b, P)
+    val py = fwdSubstitution(choleskyFactor, pb)
+    val px = bwdSubstitution(choleskyFactor, py)
+    Permutation.permuteVector(px, P.inverted)
+  }
+
+  /** solve Lx = b with L lower triangular sparse matrix */
+  private def fwdSubstitution(L: CSCMatrix[Double], b: DenseVector[Double]): DenseVector[Double] = {
+    require(L.cols == b.length, "dimensions disagree")
+    require(L.cols == L.rows, "L should be quadratic")
+    // solve L x = b, L lower triangular
+    // target vector
+    val n = b.length
+    val x: DenseVector[Double] = b.copy
+    // for each column: substitution from top to bottom
+    var col = 0
+    while (col < n) {
+      // extract column slice
+      val colStart = L.colPtrs(col)
+      val colEnd = L.colPtrs(col + 1)
+      // we need at least the diagonal element
+      if (colEnd > colStart && L.rowIndices(colStart) == col) {
+        // calculate first element of column y(col)
+        x(col) /= L.data(colStart)
+        val yc = x(col)
+        // substitute for each nnz index
+        var i = colStart + 1
+        while (i < colEnd) {
+          val d = L.data(i)
+          val row = L.rowIndices(i)
+          x(row) -= d * yc
+          i += 1
+        }
+      } else {
+        throw new Exception("fwd substitution solver: diagonal element is not first in column! L needs to be lower triangular with non-zero diagonal")
+      }
+      col += 1
+    }
+    x
+  }
+
+  /** solve L.t x = b with L lower triangular sparse matrix */
+  private def bwdSubstitution(L: CSCMatrix[Double], b: DenseVector[Double]): DenseVector[Double] = {
+    require(L.cols == b.length, "dimensions disagree")
+    require(L.cols == L.rows, "L should be quadratic")
+    // solve L.t x = b, L lower triangular
+    val n = b.length
+    val x = b.copy
+    var col = n - 1 // bwd substitution from right to left
+    while (col >= 0) {
+      // extract column slice
+      val colStart = L.colPtrs(col)
+      val colEnd = L.colPtrs(col + 1)
+      // we need at least the diagonal element of the column
+      if (colEnd > colStart && L.rowIndices(colStart) == col) {
+        // calculate L(col+1 until n, col) * x(col+1 until n)
+        var sum = 0.0
+        var i = colStart + 1 // w/o diagonal element
+        while (i < colEnd) {
+          sum += L.data(i) * x(L.rowIndices(i))
+          i += 1
+        }
+        // update x(col) and divide by diagonal element
+        x(col) -= sum
+        x(col) /= L.data(colStart)
+      } else {
+        throw new Exception("bwd substitution solver: diagonal element is not first in column! L needs to be lower triangular with non-zero diagonal")
+      }
+      col -= 1
+    }
+    // x contains result
+    x
+  }
+
+  /** calculate the incomplete Cholesky factorization, useful as a preconditioner for CG (only approximate, as sparse as A, fast) */
+  def incompleteSparseCholesky(A: CSCMatrix[Double], tolerance: Double = 1e-15): CSCMatrix[Double] = {
+    // assume A is positive definite and symmetric
+    require(A.rows == A.cols, "A is not square")
+    val n = A.rows
+    // start with empty factor
+    val L = new SparseCholeskyFactor(n)
+    // column j: 0 until n (no special treatment of first and last col)
+    var j = 0
+    while (j < n) {
+      // initialize sparse accumulator with column of A (below diagonal)
+      val currentColumn = extractColumnBelowDiagonal(A, j)
+
+      // traverse row j in L(j, k=0 until j), for each non-zero subtract L(j, k)*L(j until n, k) from currentColumn -- do only where is non-zero ("incomplete")
+      // use cursors structure to keep track of current row entries in columns
+      // along row j from left to diagonal
+      val Lrow = L.rows(j)
+      if (Lrow != null) {
+        // use sparse rows structure: e active element, next non-zero element
+        var e = 0
+        while (e < Lrow.activeSize) {
+          val k = Lrow.index(e)
+          val l = Lrow.data(e)
+          // corresponding column in L
+          val Lcol = L.cols(k)
+          // traverse current column, do operation only for non-zero entries (restrict incomplete to sparsity pattern of A)
+          var colEl = 0
+          while (colEl < currentColumn.activeSize) {
+            val row = currentColumn.index(colEl)
+            // subtract from current column
+            currentColumn.data(colEl) -= Lcol(row) * l
+            // next column element
+            colEl += 1
+          }
+          // next element in row L(j, k=0 until j)
+          e += 1
+        }
+      }
+      // work with SparseVector now, sparsity pattern is stable
+      val S = currentColumn
+      // sqrt and division of acc
+      assert(S.activeSize > 0 && S.index(0) == j, "first element is not diagonal entry") // first element on diagonal
+      assert(S.data(0) > -tolerance, s"(incomplete) Cholesky decomposition needs positive definite matrix! Negative value encountered: v=${S.data(0)}")
+      // negative number within numerical tolerance, set to zero to make sqrt work
+      if (S.data(0) < 0.0) S.data(0) = 0.0
+      // sqrt of first element
+      val d = math.sqrt(S.data(0))
+      S.data(0) = d
+      // divide all lower elements by d
+      var i = 1
+      while (i < S.activeSize) {
+        S.data(i) /= d
+        // next active element in S
+        i += 1
+      }
+      // update column value to new accumulator value
+      L.setCol(j, S)
+      // next column
+      j += 1
+    }
+    // finished, factor is filled
+    L.toCSCMatrix
+  }
+
+  private def extractColumnBelowDiagonal(A: CSCMatrix[Double], col: Int): SparseVector[Double] = {
+    val cStart = A.colPtrs(col)
+    val cEnd = A.colPtrs(col + 1)
+    // find diagonal
+    val diag = util.Arrays.binarySearch(A.rowIndices, cStart, cEnd, col)
+    if (diag < 0) throw new Exception("diagonal not found, is required")
+    val nnz = cEnd - diag
+    val index = new Array[Int](nnz)
+    val data = new Array[Double](nnz)
+    System.arraycopy(A.data, diag, data, 0, nnz)
+    System.arraycopy(A.rowIndices, diag, index, 0, nnz)
+    new SparseVector[Double](index, data, A.rows)
+  }
+
+  /**
+   * structure to build a sparse cholesky factor, efficient columns and rows, ~ CSC & CSR matrix,
+   * internal use only, no safe bookkeeping
+   */
+  private class SparseCholeskyFactor(val length: Int) {
+    val cols = new Array[SparseVector[Double]](length)
+    //val rows = new Array[SparseVector[Double]](length)
+    val rows = new Array[SparseArray](length)
+
+    // active row cursors for faster lookup
+    val cursors: Array[Int] = Array.fill(length)(-1)
+    var nnz = 0
+
+    def activeSize: Int = nnz
+
+    def setCol(col: Int, vector: SparseVector[Double]): Unit = {
+      require(vector.length == length)
+      nnz += vector.activeSize
+      cols(col) = vector
+      cursors(col) = 1 // first element is diagonal, set cursor for next row to next element
+      // update rows ... not optimal
+      // need at least the same row
+      var e = 0
+      while (e < vector.activeSize) {
+        val row = vector.index(e)
+        if (rows(row) != null)
+          rows(row)(col) = vector.data(e)
+        else
+          rows(row) = new SparseArray(Array(col, 0, 0, 0), Array(vector.data(e), 0.0, 0.0, 0.0), 1, length)
+        //rows(row) = new SparseVector[Double](Array(col, 0, 0, 0), Array(vector.data(e), 0.0, 0.0, 0.0), 1, length)
+        // next element
+        e += 1
+      }
+    }
+
+    /** build CSCMatrix structure (copy) */
+    def toCSCMatrix: CSCMatrix[Double] = {
+      val n = nnz
+      val data = new Array[Double](n)
+      val rowIndices = new Array[Int](n)
+      val colPtrs = new Array[Int](length + 1)
+      // fill structure
+      // linear master index
+      var i = 0
+      var col = 0
+      while (col < length) {
+        assert(i < n, "master index got too large")
+        // set column pointer to start
+        colPtrs(col) = i
+        // insert data and rowindex
+        Array.copy(cols(col).data, 0, data, i, cols(col).activeSize)
+        Array.copy(cols(col).index, 0, rowIndices, i, cols(col).activeSize)
+        // advance master index
+        i += cols(col).activeSize
+        // next column
+        col += 1
+      }
+      assert(i == n, "something went wrong with the number of elements")
+      // set sentry: last coloumn pointer outside the array
+      colPtrs(col) = n
+
+      new CSCMatrix[Double](data, length, length, colPtrs, rowIndices)
+    }
+  }
+
+  /** accumulator for cholesky factor creation, handles a sparse column with dense storage for fast access */
+  private class SparseAccumulator(val length: Int) {
+    // full structures for data and exists, fast direct access
+    private val data = new Array[Double](length)
+    private val exists = new Array[Boolean](length)
+    // row index structure for fast conversion to sparse format
+    private var index = new Array[Int](length)
+    private var nnz: Int = 0
+
+    def lastIndex: Int = index(nnz - 1)
+
+    /** create a SparseVector (copy) */
+    def toSparseVector: SparseVector[Double] = {
+      // sort index array (index is unsorted!!)
+      util.Arrays.sort(index, 0, nnz)
+      // create sparse vector by extracting data
+      val dt = new Array[Double](nnz)
+      val in = new Array[Int](nnz)
+      val length = this.length
+      var e = 0
+      while (e < nnz) {
+        val r = index(e) // row
+        dt(e) = data(r)
+        in(e) = r
+        e += 1
+      }
+      new SparseVector[Double](in, dt, length)
+    }
+
+    def add(i: Int, v: Double): Unit = {
+      //require(i >= 0 && i < length, s"row is out of bounds, r=$i")
+      //assert(nnz <= length, "too many nnz elements")
+      if (exists(i)) {
+        data(i) += v
+      } else {
+        data(i) = v
+        exists(i) = true
+        index(nnz) = i
+        nnz += 1
+      }
+    }
+
+    /** copy column of matrix to accumulator, replaces all former data */
+    def initWithColumn(A: CSCMatrix[Double], j: Int): Unit = {
+      clear()
+      // copy over column of A
+      val colStart = A.colPtrs(j)
+      val colEnd = A.colPtrs(j + 1)
+      // find diagonal element
+      val diag = util.Arrays.binarySearch(A.rowIndices, colStart, colEnd, j)
+      if (diag < 0) throw new Exception("cannot extract subdiagonal column elements, no diagonal found")
+      // extract data below diagonal, including diagonal
+      var k = diag
+      while (k < colEnd) {
+        val v = A.data(k)
+        val r = A.rowIndices(k)
+
+        data(r) = v
+        exists(r) = true
+        index(nnz) = r
+        nnz += 1
+        k += 1
+      }
+      assert(nnz == colEnd - diag, "nnz is wrong")
+    }
+
+    def clear(): Unit = {
+      // reset structure
+      var i = 0
+      while (i < nnz) {
+        val r = index(i)
+        exists(r) = false
+        i += 1
+      }
+      nnz = 0
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/numerics/CholeskyTests.scala
+++ b/src/test/scala/scalismo/faces/numerics/CholeskyTests.scala
@@ -1,0 +1,186 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{CSCMatrix, DenseMatrix, DenseVector, norm}
+import scalismo.faces.FacesTestSuite
+
+import scala.collection.mutable
+
+class CholeskyTests extends FacesTestSuite {
+
+  val n = 50
+  val tol = 1e-11
+
+  val A = randomDiagDomBandMatrix(n, 10)
+  val Ad = A.toDense
+  val b = DenseVector.rand[Double](n)
+
+  /** build a random PSD matrix: band matrix, diagonally dominant */
+  def randomDiagDomBandMatrix(n: Int, band: Int): CSCMatrix[Double] = {
+    val builder = new CSCMatrix.Builder[Double](n, n)
+    // generate band
+    for (i <- 0 until n; j <- i + 1 until math.min(n, i + band)) {
+      val e = rnd.scalaRandom.nextDouble()
+      builder.add(i, j, e)
+      builder.add(j, i, e)
+    }
+    // diagonally dominant
+    for (i <- 0 until n) {
+      builder.add(i, i, band)
+    }
+    builder.result()
+  }
+
+  /** build a random PSD matrix: sparse matrix, diagonally dominant */
+  def randomDiagDomMatrix(n: Int, elementsPerColumn: Int): CSCMatrix[Double] = {
+    val builder = new CSCMatrix.Builder[Double](n, n)
+    // generate band
+    for (col <- 0 until n; j <- 0 until elementsPerColumn) {
+      val e = rnd.scalaRandom.nextDouble()
+      val row = rnd.scalaRandom.nextInt(n)
+      builder.add(row, col, e)
+      builder.add(col, row, e)
+    }
+    // diagonally dominant
+    for (i <- 0 until n) {
+      builder.add(i, i, 2 * elementsPerColumn)
+    }
+    builder.result()
+  }
+
+  def randomPermutation(n: Int): Array[Int] = {
+    // load id
+    val p = (0 until n).toArray
+    // swap random elements
+    var i = n - 1
+    while (i > 0) {
+      val other = rnd.scalaRandom.nextInt(i + 1)
+      // swap i and other
+      val t = p(other)
+      p(other) = p(i)
+      p(i) = t
+      i -= 1
+    }
+    p
+  }
+
+  def matNorm(A: DenseMatrix[Double]): Double = norm(A.toDenseVector)
+  def matNorm(A: CSCMatrix[Double]): Double = norm(A.toDenseMatrix.toDenseVector)
+
+  describe("Cholesky (Dense)") {
+    it("decomposes the matrix A properly: A=L*L.t") {
+      val L: DenseMatrix[Double] = DenseCholesky(Ad)
+      val D: DenseMatrix[Double] = Ad - L * L.t
+      matNorm(D) should be < tol
+    }
+
+    it("solves the system Ax=b") {
+      val x = DenseCholesky.solve(Ad, b)
+      norm(b - Ad * x) should be < tol
+    }
+  }
+
+  describe("Sparse Cholesky") {
+    it("decomposes the matrix A properly: A=L*L.t") {
+      val L: CSCMatrix[Double] = SparseCholesky(A)
+      matNorm(A - L * L.t) should be < tol
+    }
+
+    it("solves the system Ax=b") {
+      val x = SparseCholesky.solve(A, b)
+      norm(b - A * x) should be < tol
+    }
+
+    it("can permute a sparse matrix") {
+      val perm = new Permutation(randomPermutation(n))
+      val pA = Permutation.permuteSparseMatrix(A, perm)
+      for (i <- 0 until pA.rows; j <- 0 until pA.cols) {
+        pA(i, j) shouldBe A(perm(i), perm(j))
+      }
+    }
+
+    it("can permute a sparse matrix without effect (id permutation)") {
+      val permId = Permutation.identity(n)
+      val pA = Permutation.permuteSparseMatrix(A, permId)
+      pA shouldBe A
+    }
+
+    it("can solve a permuted system") {
+      val perm = new Permutation(randomPermutation(n))
+      val pA = Permutation.permuteSparseMatrix(A, perm)
+      val L = SparseCholesky(pA)
+      val x = SparseCholesky.substitutionSolver(L, b, perm)
+      norm(b - A * x) should be < tol
+    }
+
+    it("can automatically find a permutation to reduce fill-in") {
+      val P = ReverseCuthillMcKee.findPermutation(A)
+      Permutation.isValid(P.toArray) shouldBe true
+
+      val pA = Permutation.permuteSparseMatrix(A, P)
+
+      val L = SparseCholesky(A)
+      val pL = SparseCholesky(pA)
+
+      pL.activeSize should be <= L.activeSize
+
+      // solution check
+      val x = SparseCholesky.substitutionSolver(L, b)
+      val px = SparseCholesky.substitutionSolver(pL, b, P)
+
+      norm(b - A * x) should be < tol
+      norm(b - A * px) should be < tol
+    }
+
+    it("support the PermutationStrategy interface") {
+      val x = SparseCholesky.solve(A, b, ReverseCuthillMcKee)
+      norm(b - A * x) should be < tol
+    }
+
+  }
+
+  def extractSparsityPattern(A: CSCMatrix[Double]): Set[(Int, Int)] = {
+    val spPattern = mutable.Set.empty[(Int, Int)]
+    for (col <- 0 until A.cols) {
+      val cS = A.colPtrs(col)
+      val cE = A.colPtrs(col + 1)
+      for (e <- cS until cE) {
+        val row = A.rowIndices(e)
+        spPattern.add((row, col))
+      }
+    }
+    spPattern.toSet
+  }
+
+  describe("An incomplete Cholesky decomposition of a random sparse matrix (diagonally dominant)") {
+    val A = randomDiagDomMatrix(n, math.max(2, n / 100))
+    val incL = SparseCholesky.incompleteSparseCholesky(A)
+
+    it("has the same sparsity pattern as A") {
+      val spA: Set[(Int, Int)] = extractSparsityPattern(A)
+      val spL: Set[(Int, Int)] = extractSparsityPattern(incL)
+      // reduce to lower triangular
+      val spALT: Set[(Int, Int)] = spA.filter { case (row, col) => row >= col }
+      spL shouldBe spALT
+    }
+
+    it("is not too different from A") {
+      matNorm(A - incL * incL.t) should be < n * 0.1
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/numerics/ConjugateGradientTests.scala
+++ b/src/test/scala/scalismo/faces/numerics/ConjugateGradientTests.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{CSCMatrix, DenseVector, norm}
+import scalismo.faces.FacesTestSuite
+
+class ConjugateGradientTests extends FacesTestSuite {
+
+  val n = 50
+  val tol = 1e-10
+
+  val A = randomDiagDomBandMatrix(n, 10)
+  val Ad = A.toDense
+  val b = DenseVector.rand[Double](n)
+
+  /** build a random PSD matrix: band matrix, diagonally dominant */
+  def randomDiagDomBandMatrix(n: Int, band: Int): CSCMatrix[Double] = {
+    val builder = new CSCMatrix.Builder[Double](n, n)
+    // generate band
+    for (i <- 0 until n; j <- i + 1 until math.min(n, i + band)) {
+      val e = rnd.scalaRandom.nextDouble()
+      builder.add(i, j, e)
+      builder.add(j, i, e)
+    }
+    // diagonally dominant
+    for (i <- 0 until n) {
+      builder.add(i, i, band)
+    }
+    builder.result()
+  }
+
+  /** build a random PSD matrix: sparse matrix, diagonally dominant */
+  def randomDiagDomMatrix(n: Int, elementsPerColumn: Int): CSCMatrix[Double] = {
+    val builder = new CSCMatrix.Builder[Double](n, n)
+    // generate band
+    for (col <- 0 until n; j <- 0 until elementsPerColumn) {
+      val e = rnd.scalaRandom.nextDouble()
+      val row = rnd.scalaRandom.nextInt(n)
+      builder.add(row, col, e)
+      builder.add(col, row, e)
+    }
+    // diagonally dominant
+    for (i <- 0 until n) {
+      builder.add(i, i, 2 * elementsPerColumn)
+    }
+    builder.result()
+  }
+
+  describe("ConjugateGradient solver") {
+    it("can solve a random sparse linear system to high accuracy") {
+      val x = ConjugateGradient.solveSparse(A, b, tol / 10)
+      norm(b - A * x) should be < tol
+    }
+  }
+
+  describe("PreconditionedConjugateGradient solver") {
+    it("can solve a random sparse linear system to high accuracy with the incomplete Cholesky preconditioner") {
+      val M = PreconditionedConjugateGradient.incompleteCholeskyPreconditioner(A)
+      val x = PreconditionedConjugateGradient.solveSparse(A, b, M, tol / 10)
+      norm(b - A * x) should be < tol
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/numerics/ImageDomainPoissonSolverTests.scala
+++ b/src/test/scala/scalismo/faces/numerics/ImageDomainPoissonSolverTests.scala
@@ -1,0 +1,226 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import scalismo.faces.FacesTestSuite
+import scalismo.faces.color.RGB
+import scalismo.faces.common.ComponentRepresentation
+import scalismo.faces.image.{AccessMode, PixelImage, PixelImageDifferential}
+
+/** tests for Poisson solvers in the image domain (used for inpainting) */
+class ImageDomainPoissonSolverTests extends FacesTestSuite {
+  import PixelImage.implicits._
+
+  // setup problem (small enough to solve within reasonable time and memory)
+  val w = 151
+  val h = 149
+
+  // transfer a zero-gradient into a color gradient, expected behavior: reconstruct color gradient
+  val target: PixelImage[Double] = PixelImage(w, h, (x, y) => y.toDouble / h)
+  val donor: PixelImage[Double] = PixelImage(w, h, (x, y) => 0.0)
+
+  val boxX = 33
+  val boxY = 74
+  val mask = PixelImage(target.domain, (x, y) =>
+    x >= boxX && x < target.width - boxX && y >= boxY && y < target.height - boxY
+  ).withAccessMode(AccessMode.Repeat())
+
+  // initial values: constant black, boundary values are fixed to target
+  val initialWithBoundary = PixelImage(target.domain, (x, y) => if (mask(x, y)) 0.0 else target(x, y)).withAccessMode(AccessMode.Repeat())
+
+  // right-hand-side: laplace of donor (zero actually)
+  val lapDonor = PixelImageDifferential.laplace4NN(donor)
+
+  // optimal solution
+  val optimalSolution = target
+
+  // target values
+  val maxResidual = 1.0e-10
+  val maxReconstructionError = 1.0e-10 * w * h
+
+  // double vectorizer
+  implicit val doubleVectorizer = new ComponentRepresentation[Double] {
+    override def fromArray(arr: Array[Double]): Double = arr(0)
+    override def component(color: Double, index: Int): Double = color.toDouble
+    override def fromComponents(comp: (Int) => Double): Double = comp(0)
+    override val size: Int = 1
+  }
+
+  // multigrid
+
+  // multigrid settings
+  val param = MultigridParameters.default.copy(vCycles = 4)
+
+  describe("The Multigrid Poisson solver for [A], with A=Double") {
+    val solver = new GenericMultigridPoissonSolver[Double](param)
+    val solution = solver.solvePoisson(initialWithBoundary, mask, lapDonor)
+
+    it("should work with expected precision, residual of Poisson equation") {
+      val residual = solver.residual(solution, mask, lapDonor).map(x => x * x).values.sum
+      residual should be < maxResidual
+    }
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff: Double = (target - solution).normSq
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  describe("The Multigrid Poisson solver for [A], with A=RGB") {
+    def toRGB(image: PixelImage[Double]) = image.map(v => RGB(v))
+    val initRGB = toRGB(initialWithBoundary)
+    val lapDonorRGB = toRGB(lapDonor)
+
+    val solver = new GenericMultigridPoissonSolver[RGB](param)
+    val solution = solver.solvePoissonInBoundingBox(initRGB, mask, lapDonorRGB)
+
+    it("should work with expected precision, residual of Poisson equation") {
+      val residual = solver.residual(solution, mask, lapDonorRGB).map(c => c.toVector.norm2).values.sum / 3
+      residual should be < maxResidual
+    }
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff = (target.map(f => RGB(f)) - solution).normSq / 3
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  // Sparse Cholesky
+  describe("The sparse Cholesky Poisson solver for [A], with A=Double") {
+    val solver = new SparseCholeskyPoissonSolver[Double]
+    val solution = solver.solvePoissonInBoundingBox(initialWithBoundary, mask, lapDonor)
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff: Double = (target - solution).normSq
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  describe("The sparse Cholesky Poisson solver for [A], with A=RGB") {
+    def toRGB(image: PixelImage[Double]) = image.map(v => RGB(v))
+    val initRGB = toRGB(initialWithBoundary)
+    val lapDonorRGB = toRGB(lapDonor)
+
+    val solver = new SparseCholeskyPoissonSolver[RGB]
+    val solution = solver.solvePoissonInBoundingBox(initRGB, mask, lapDonorRGB)
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff = (target.map(f => RGB(f)) - solution).normSq / 3
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  // Conjugate Gradient
+  describe("The conjugate gradient Poisson solver for [A], with A=Double") {
+    val solver = new ConjugateGradientPoissonSolver[Double]
+    val solution = solver.solvePoissonInBoundingBox(initialWithBoundary, mask, lapDonor)
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff: Double = (target - solution).normSq
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  describe("The conjugate gradient Poisson solver for [A], with A=RGB") {
+    def toRGB(image: PixelImage[Double]) = image.map(v => RGB(v))
+    val initRGB = toRGB(initialWithBoundary)
+    val lapDonorRGB = toRGB(lapDonor)
+
+    val solver = new ConjugateGradientPoissonSolver[RGB]
+    val solution = solver.solvePoissonInBoundingBox(initRGB, mask, lapDonorRGB)
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff = (target.map(f => RGB(f)) - solution).normSq / 3
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  // Preconditioned Conjugate Gradient
+  describe("The preconditioned conjugate gradient Poisson solver for [A], with A=Double") {
+    val solver = new PreconditionedConjugateGradientPoissonSolver[Double]
+    val solution = solver.solvePoissonInBoundingBox(initialWithBoundary, mask, lapDonor)
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff: Double = (target - solution).normSq
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  describe("The preconditioned conjugate gradient Poisson solver for [A], with A=RGB") {
+    def toRGB(image: PixelImage[Double]) = image.map(v => RGB(v))
+    val initRGB = toRGB(initialWithBoundary)
+    val lapDonorRGB = toRGB(lapDonor)
+
+    val solver = new PreconditionedConjugateGradientPoissonSolver[RGB]
+    val solution = solver.solvePoissonInBoundingBox(initRGB, mask, lapDonorRGB)
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff = (target.map(f => RGB(f)) - solution).normSq / 3
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  // dense Cholesky
+  describe("The dense Cholesky Poisson solver for [A], with A=Double") {
+    val solver = new DenseLinearSystemPoissonSolver[Double]
+    val solution = solver.solvePoissonInBoundingBox(initialWithBoundary, mask, lapDonor)
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff: Double = (target - solution).normSq
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  describe("The dense Cholesky Poisson solver for [A], with A=RGB") {
+    def toRGB(image: PixelImage[Double]) = image.map(v => RGB(v))
+    val initRGB = toRGB(initialWithBoundary)
+    val lapDonorRGB = toRGB(lapDonor)
+
+    val solver = new DenseLinearSystemPoissonSolver[RGB]
+    val solution = solver.solvePoissonInBoundingBox(initRGB, mask, lapDonorRGB)
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff = (target.map(f => RGB(f)) - solution).normSq / 3
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  // Breeze Conjugate Gradient
+  describe("Breeze's conjugate gradient Poisson solver for [A], with A=Double") {
+    val solver = new BreezeCGPoissonSolver[Double]
+    val solution = solver.solvePoissonInBoundingBox(initialWithBoundary, mask, lapDonor)
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff: Double = (target - solution).normSq
+      sqDiff should be < maxReconstructionError
+    }
+  }
+
+  describe("Breeze's conjugate gradient Poisson solver for [A], with A=RGB") {
+    def toRGB(image: PixelImage[Double]) = image.map(v => RGB(v))
+    val initRGB = toRGB(initialWithBoundary)
+    val lapDonorRGB = toRGB(lapDonor)
+
+    val solver = new BreezeCGPoissonSolver[RGB]
+    val solution = solver.solvePoissonInBoundingBox(initRGB, mask, lapDonorRGB)
+
+    it("should work with expected precision, reconstruction error") {
+      val sqDiff = (target.map(f => RGB(f)) - solution).normSq / 3
+      sqDiff should be < maxReconstructionError
+    }
+  }
+}

--- a/src/test/scala/scalismo/faces/numerics/PivotedCholeskyTests.scala
+++ b/src/test/scala/scalismo/faces/numerics/PivotedCholeskyTests.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{CSCMatrix, DenseMatrix, DenseVector, trace}
+import org.scalatest.PrivateMethodTester
+import scalismo.faces.FacesTestSuite
+import scalismo.numerics.PivotedCholesky.{AbsoluteTolerance, NumberOfEigenfunctions, RelativeTolerance}
+
+class PivotedCholeskyTests extends FacesTestSuite with PrivateMethodTester {
+
+  val d = 20
+  val cols = 10
+
+  val gtMatrix = DenseMatrix.fill(d, cols)(rnd.scalaRandom.nextDouble())
+
+  val tol = 1e-11
+
+  describe("PivotedCholeskyFactor data structure:") {
+
+    val fac = new PivotedCholeskyFactor(d, cols/5) // expect 3 reallocations
+
+    it("can be filled with random numbers columns") {
+      for (c <- 0 until cols) {
+        val col: Array[Double] = gtMatrix(::, c).toDenseVector.toArray
+        fac.addCol(col)
+        // actual column should be identical
+        fac.cols(c) shouldBe col
+        // allows random access with proper values
+        for (r <- 0 until d) {
+          fac(r, c) shouldBe col(r)
+        }
+      }
+    }
+
+    it("converts to a DenseMatrix") {
+      val m = fac.toDenseMatrix
+      for (r <- 0 until d; c <- 0 until cols)
+        m(r, c) shouldBe gtMatrix(r, c)
+    }
+
+    it("allows for random access") {
+      for (r <- 0 until 10) {
+        val row = rnd.scalaRandom.nextInt(d)
+        val col = rnd.scalaRandom.nextInt(cols)
+        fac(row, col) shouldBe gtMatrix(row, col)
+      }
+    }
+  }
+
+  /** build a random PSD matrix: band matrix, diagonally dominant */
+  def randomDiagDomBandMatrix(n: Int, band: Int): CSCMatrix[Double] = {
+    val builder = new CSCMatrix.Builder[Double](n, n)
+    // generate band
+    for (i <- 0 until n; j <- i + 1 until math.min(n, i + band)) {
+      val e = rnd.scalaRandom.nextDouble()
+      builder.add(i, j, e)
+      builder.add(j, i, e)
+    }
+    // diagonally dominant
+    for (i <- 0 until n) {
+      builder.add(i, i, band)
+    }
+    builder.result()
+  }
+
+  /** build a random PSD matrix: sparse matrix, diagonally dominant */
+  def randomDiagDomMatrix(n: Int, elementsPerColumn: Int): CSCMatrix[Double] = {
+    val builder = new CSCMatrix.Builder[Double](n, n)
+    // generate band
+    for (col <- 0 until n; j <- 0 until elementsPerColumn) {
+      val e = rnd.scalaRandom.nextDouble()
+      val row = rnd.scalaRandom.nextInt(n)
+      builder.add(row, col, e)
+      builder.add(col, row, e)
+    }
+    // diagonally dominant
+    for (i <- 0 until n) {
+      builder.add(i, i, 2 * elementsPerColumn)
+    }
+    builder.result()
+  }
+
+  describe("Pivoted Cholesky factorization") {
+    // random matrices
+    val A = randomDiagDomBandMatrix(d, 10).toDense
+    val b = DenseVector.rand[Double](d)
+
+    it("it should factorize a random positive definite matrix completely") {
+      val L = PivotedCholesky.pivotedCholesky(A, NumberOfEigenfunctions(A.cols))
+      val Am = L * L.t
+      trace(A - Am) should be < 1e-10
+    }
+
+    it("it stops after reaching required accuracy (relative tolerance)") {
+      val relativeTolerance = 0.25
+      val L = PivotedCholesky.pivotedCholesky(A, RelativeTolerance(relativeTolerance))
+      val Am = L * L.t
+      trace(A - Am) should be <= (relativeTolerance * trace(A))
+      L.cols should be < A.cols
+    }
+
+    it("it stops after reaching required accuracy (absolute tolerance)") {
+      val absoluteTolerance = trace(A) * 0.5
+      val L = PivotedCholesky.pivotedCholesky(A, AbsoluteTolerance(absoluteTolerance))
+      val Am = L * L.t
+      trace(A - Am) should be <= absoluteTolerance
+      L.cols should be < A.cols
+    }
+
+    it("it stops after calculating enough factors") {
+      val numberOfEigenfunctions = NumberOfEigenfunctions(10)
+      val L = PivotedCholesky.pivotedCholesky(A, numberOfEigenfunctions)
+      val Am = L * L.t
+      trace(A - Am) should be <= trace(A)
+      L.cols shouldBe numberOfEigenfunctions.n
+    }
+
+  }
+}
+

--- a/src/test/scala/scalismo/faces/numerics/SparseArrayTests.scala
+++ b/src/test/scala/scalismo/faces/numerics/SparseArrayTests.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import scalismo.faces.FacesTestSuite
+
+class SparseArrayTests extends FacesTestSuite {
+
+  describe("A SparseArray") {
+    val index = Array(0, 1, 5, 6)
+    val data = Array(1.0, 2.0, 3.0, 4.0)
+
+    val a = new SparseArray(index, data, index.length, 10)
+
+    it("supports reading nnz values") {
+      a(0) shouldBe 1.0
+      a(1) shouldBe 2.0
+      a(6) shouldBe 4.0
+    }
+
+    it("support reading of zero values") {
+      a(2) shouldBe 0.0
+      a(9) shouldBe 0.0
+    }
+
+    it("supports writing of existing values") {
+      a(5) = -7.0
+      a(5) shouldBe -7.0
+      a(4) shouldBe 0.0
+      a(6) shouldBe 4.0
+    }
+
+    it("supports writing at the end (w/o affecting its neighbours)") {
+      a(7) = -1.0
+      a(7) shouldBe -1.0
+      a(6) shouldBe 4.0
+      a(8) shouldBe 0.0
+    }
+
+    it("supports writing within") {
+      a(2) = -2.0
+      a(2) shouldBe -2.0
+      a(1) shouldBe 2.0
+      a(3) shouldBe 0.0
+      a(5) shouldBe -7.0
+    }
+
+    it("keeps its index sorted") {
+      var i = 1
+      while (i < a.nnz) {
+        a.index(i) shouldBe >(a.index(i - 1))
+        i += 1
+      }
+    }
+
+    it("can be transformed to a dense array") {
+      val d = a.toDense
+      d.toIndexedSeq shouldBe IndexedSeq(1.0, 2.0, -2.0, 0.0, 0.0, -7.0, 4.0, -1.0, 0.0, 0.0)
+    }
+  }
+
+  describe("A SparseAccumulator") {
+    //@todo
+  }
+}


### PR DESCRIPTION
Methods for solving Poisson's equation. This is required for Poisson image editing and warp field extrapolation.

Poisson equation: find *f* such that

&#916; *f* = *g* on domain &#937;, s.t. *f* = *h* on boundary of &#8706;&#937; (Dirichlet boundary conditions)

The equation is solved within the 2D image domain expressed by a `PixelImage[A]`. The mask defines where the function value is to be found or where it is fixed and known.

There are different solvers available:
- Cholesky solvers: use a Cholesky decomposition to solve the linear system resulting from the equation
- Conjugate Gradient solver: fast for large sparse systems (precondition available, e.g. incomplete Cholesky) 
- Multigrid solver: multi grid approach in image domain, fast but not always with good convergence for complex domain boundaries

Abstractions:
- `ImageDomainPoissonSolver[A]`: trait to solve Poisson's equation in the image domain
- `LinearSystemPoissonSolver`: abstract class to obtain the solution to Poisson's equation as the solution to the corresponding linear system (Discretization on image pixels, Laplace matrix)

Required (generic) numeric algorithms:
- Cholesky decompositions: dense, sparse and pivoted, including different permutation strategies to find good sparsity orderings


- includes tests