### PR TITLE
resolves #70 - fix HSV RGB conversion and added tests

### DIFF
--- a/src/main/scala/scalismo/faces/color/HSV.scala
+++ b/src/main/scala/scalismo/faces/color/HSV.scala
@@ -16,12 +16,12 @@
 
 package scalismo.faces.color
 
-/** HSV color value (Hue, Saturation, Value) */
+/** HSV color value with Hue in [0.0,2*Pi), Saturation in [0.0,1.0] and Value in [0.0,1.0] */
 case class HSV(hue: Double, saturation: Double, value: Double) {
 
-  /** convert to RGB value.*/
+  /** convert to RGB value. May throw or result in undefined behaviour if values outside of ranges.*/
   def toRGB: RGB = {
-    val hs = hue / (math.Pi / 3.0) + math.Pi
+    val hs = hue / (math.Pi / 3.0)
     val h: Int = hs.toInt
     val f: Double = hs - h
     val p: Double = value * (1.0 - saturation)
@@ -35,7 +35,7 @@ case class HSV(hue: Double, saturation: Double, value: Double) {
       case 4 => RGB(t, p, value)
       case 5 => RGB(value, p, q)
       case 6 => RGB(value, t, p)
-      case _ => throw new RuntimeException("Invalid hue value in conversion.")
+      case _ => throw new RuntimeException(s"Invalid hue value (${h}) in conversion of color ${this}.")
     }
   }
 }
@@ -55,7 +55,7 @@ object HSV {
     }
     val s = if (maxCh > 0.0) (maxCh - minCh) / maxCh else 0.0
     val v = maxCh
-    HSV(h, s, v)
+    HSV( if(h<0) h+2.0*math.Pi else h, s, v)
   }
 
   /** ColorBlender for HSV colors */

--- a/src/test/scala/scalismo/faces/color/HSVTests.scala
+++ b/src/test/scala/scalismo/faces/color/HSVTests.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.faces.color
+
+import scalismo.faces.FacesTestSuite
+import scalismo.utils.Random
+
+class HSVTests extends FacesTestSuite {
+
+  implicit val rng = Random(1024l)
+
+  def rndCol = RGB(rng.scalaRandom.nextDouble(),rng.scalaRandom.nextDouble(),rng.scalaRandom.nextDouble())
+
+  def between(v: Double, l: Double, r: Double): Unit = {
+    v should be >= l
+    v should be <= r
+  }
+
+  val pi = math.Pi
+
+  val pairedWithRGB = Seq(
+    (RGB.Black,HSV(0,0,0)),
+    (RGB.White,HSV(0,0,1)),
+    (RGB(1.0,0.0,0.0),HSV(0*pi/3.0,1,1)),
+    (RGB(1.0,1.0,0.0),HSV(1*pi/3.0,1,1)),
+    (RGB(0.0,1.0,0.0),HSV(2*pi/3.0,1,1)),
+    (RGB(0.0,1.0,1.0),HSV(3*pi/3.0,1,1)),
+    (RGB(0.0,0.0,1.0),HSV(4*pi/3.0,1,1)),
+    (RGB(1.0,0.0,1.0),HSV(5*pi/3.0,1,1))
+  )
+  val colors = pairedWithRGB.map(_._1) ++ Seq.fill[RGB](100)(rndCol)
+
+  describe("HSV color") {
+
+    it("converted from RGB has values in proper range") {
+      colors.foreach{ color =>
+        val hsv = HSV(color)
+        between(hsv.hue,0.0,2.0*math.Pi)
+        between(hsv.saturation,0.0,1.0)
+        between(hsv.value,0.0,1.0)
+      }
+    }
+
+    it("can be constructed from RGB and converted back to RGB") {
+      colors.foreach{ color =>
+        val hsv = HSV(color)
+        val roundTrip = hsv.toRGB
+        (color - roundTrip).norm should be < 1.0E-8
+      }
+    }
+
+    it("can be constructed from RGB correctly for a few specific values") {
+      pairedWithRGB.foreach{ case (rgb,hsv) =>
+        val hsvConv = HSV(rgb)
+          hsvConv.hue - hsv.hue should be < 1.0E-8
+          hsvConv.value - hsv.value should be < 1.0E-8
+          hsvConv.saturation - hsv.saturation should be < 1.0E-8
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request fixes problemsin the conversion from and to HSV colors. The construction of HSV colors from an RGB as well as the conversion from HSV to RGB  values was wrong. Now the ranges of the h, s, and v values is specified in the comments.

Additionally tests for different applications of the two conversions are added.