### PR TITLE
added error message if landmarks file corrupted

### DIFF
--- a/src/main/scala/scalismo/faces/io/TLMSLandmarksIO.scala
+++ b/src/main/scala/scalismo/faces/io/TLMSLandmarksIO.scala
@@ -36,6 +36,7 @@ object TLMSLandmarksIO {
     val lines = Source.fromInputStream(stream).getLines()
     lines.map { line =>
       val fields = line.split("\\s+").map(_.trim)
+      require(fields.length == 4, "landmark file not in correct format, or empty line at end")
       val name = fields(0)
       val visibility: Boolean = fields(1).toInt > 0
       val x = fields(2).toFloat
@@ -54,6 +55,7 @@ object TLMSLandmarksIO {
     val lines = Source.fromInputStream(stream).getLines()
     lines.map { line =>
       val fields = line.split("\\s+").map(_.trim)
+      require(fields.length == 5, "landmark file not in correct format, or empty line at end")
       val name = fields(0)
       val visibility: Boolean = fields(1).toInt > 0
       val x = fields(2).toFloat

--- a/src/main/scala/scalismo/faces/io/TLMSLandmarksIO.scala
+++ b/src/main/scala/scalismo/faces/io/TLMSLandmarksIO.scala
@@ -33,10 +33,10 @@ object TLMSLandmarksIO {
 
   /** read TLMS 2D format from a stream (format: "id visible x y") */
   def read2DFromStream(stream: InputStream): Try[IndexedSeq[TLMSLandmark2D]] = Try {
-    val lines = Source.fromInputStream(stream).getLines()
+    val lines = Source.fromInputStream(stream).getLines().filter(!_.isEmpty)
     lines.map { line =>
       val fields = line.split("\\s+").map(_.trim)
-      require(fields.length == 4, "landmark file not in correct format, or empty line at end")
+      require(fields.length == 4, "landmark file not in correct format, expects name, visibility (0 or 1), x-coordinate, y-coordinate per line")
       val name = fields(0)
       val visibility: Boolean = fields(1).toInt > 0
       val x = fields(2).toFloat
@@ -52,10 +52,10 @@ object TLMSLandmarksIO {
 
   /** read TLMS 3D format from a stream (format: "id visible x y z") */
   def read3DFromStream(stream: InputStream): Try[IndexedSeq[TLMSLandmark3D]] = Try {
-    val lines = Source.fromInputStream(stream).getLines()
+    val lines = Source.fromInputStream(stream).getLines().filter(!_.isEmpty)
     lines.map { line =>
       val fields = line.split("\\s+").map(_.trim)
-      require(fields.length == 5, "landmark file not in correct format, or empty line at end")
+      require(fields.length == 5, "landmark file not in correct format, expects name, visibility (0 or 1), x-coordinate, y-coordinate, z-coordinate per line")
       val name = fields(0)
       val visibility: Boolean = fields(1).toInt > 0
       val x = fields(2).toFloat


### PR DESCRIPTION
The TLMSLandmarks-Reader crashes when a landmark file is corrupted.
This happened from time to time to me, if a landmarks-file had an empty line at the end.
This fix does not enable the reader to read those corrupted files, but it at least gives a better error message.