### PR TITLE
Writing TLMS file is OS-Local dependent

### DIFF
--- a/src/main/scala/scalismo/faces/io/TLMSLandmarksIO.scala
+++ b/src/main/scala/scalismo/faces/io/TLMSLandmarksIO.scala
@@ -70,7 +70,7 @@ object TLMSLandmarksIO {
     ResourceManagement.using(new PrintWriter(stream), (wr: PrintWriter) => wr.flush()) { writer =>
       landmarks.foreach{lm =>
         val visible = if (lm.visible) "1" else "0"
-        val line = f"${lm.id}%s $visible%s ${lm.point.x}%.17g ${lm.point.y}%.17g"
+        val line = "%s %s %.17g %.17g".formatLocal(java.util.Locale.US, lm.id, visible, lm.point.x,lm.point.y)
         writer.println(line)
       }
     }
@@ -86,7 +86,8 @@ object TLMSLandmarksIO {
     ResourceManagement.using(new PrintWriter(stream), (wr: PrintWriter) => wr.flush()) { writer =>
       landmarks.foreach { lm =>
         val visible = if (lm.visible) "1" else "0"
-        writer.println(f"${lm.id}%s $visible%s ${lm.point.x}%.17g ${lm.point.y}%.17g ${lm.point.z}%.17g")
+        val line = "%s %s %.17g %.17g %.17g".formatLocal(java.util.Locale.US, lm.id, visible, lm.point.x,lm.point.y,lm.point.z)
+        writer.println(line)
       }
     }
   }


### PR DESCRIPTION
The current way the landmarks are written to a TLMS file depends on the OS language settings. The punctuation that is written in floats and doubles can change from points to commas. However the reader is expecting points. So we need to force a local scheme that ensures points as proposed in this PR.