### PR TITLE
IO using specified format

### DIFF
--- a/src/main/scala/scalismo/faces/io/GravisArrayIO.scala
+++ b/src/main/scala/scalismo/faces/io/GravisArrayIO.scala
@@ -123,7 +123,7 @@ object GravisArrayIO {
 
     override def parse(string: String): Float = string.toFloat
 
-    override def toString(data: Float): String = f"$data%.10f"
+    override def toString(data: Float): String = "%.10g".formatLocal(java.util.Locale.US, data)
   }
 
   /** read and write Double in gravis-compatible format */
@@ -132,7 +132,7 @@ object GravisArrayIO {
 
     override def parse(string: String): Double = string.toDouble
 
-    override def toString(data: Double): String = f"$data%.20f"
+    override def toString(data: Double): String = "%.20g".formatLocal(java.util.Locale.US, data)
   }
 
   /** read and write Tuple3 (Int, Int, Int) in gravis-compatible format */
@@ -156,7 +156,7 @@ object GravisArrayIO {
       RGB(values(0), values(1), values(2))
     }
 
-    override def toString(data: RGB): String = f"(${data.r}%.20f, ${data.g}%.20f, ${data.b}%.20f)"
+    override def toString(data: RGB): String = "%.20g, %20g, %20g".formatLocal(java.util.Locale.US, data.r, data.g, data.b)
   }
 
   /** read and write RGBA in gravis-compatible format */
@@ -168,7 +168,7 @@ object GravisArrayIO {
       RGBA(values(0), values(1), values(2), values(3))
     }
 
-    override def toString(data: RGBA): String = f"(${data.r}%.20f, ${data.g}%.20f, ${data.b}%.20f, ${data.a}%.20f)"
+    override def toString(data: RGBA): String = "%.20g, %20g, %20g, %20g".formatLocal(java.util.Locale.US, data.r, data.g, data.b, data.a)
   }
 
 }

--- a/src/main/scala/scalismo/faces/io/GravisArrayIO.scala
+++ b/src/main/scala/scalismo/faces/io/GravisArrayIO.scala
@@ -123,7 +123,7 @@ object GravisArrayIO {
 
     override def parse(string: String): Float = string.toFloat
 
-    override def toString(data: Float): String = "%.10g".formatLocal(java.util.Locale.US, data)
+    override def toString(data: Float): String = "%.10f".formatLocal(java.util.Locale.US, data)
   }
 
   /** read and write Double in gravis-compatible format */
@@ -132,7 +132,7 @@ object GravisArrayIO {
 
     override def parse(string: String): Double = string.toDouble
 
-    override def toString(data: Double): String = "%.20g".formatLocal(java.util.Locale.US, data)
+    override def toString(data: Double): String = "%.20f".formatLocal(java.util.Locale.US, data)
   }
 
   /** read and write Tuple3 (Int, Int, Int) in gravis-compatible format */
@@ -156,7 +156,7 @@ object GravisArrayIO {
       RGB(values(0), values(1), values(2))
     }
 
-    override def toString(data: RGB): String = "%.20g, %20g, %20g".formatLocal(java.util.Locale.US, data.r, data.g, data.b)
+    override def toString(data: RGB): String = Seq( data.r, data.g, data.b).map(v => "%.20f".formatLocal(java.util.Locale.US,v)).mkString(", ")
   }
 
   /** read and write RGBA in gravis-compatible format */
@@ -168,7 +168,7 @@ object GravisArrayIO {
       RGBA(values(0), values(1), values(2), values(3))
     }
 
-    override def toString(data: RGBA): String = "%.20g, %20g, %20g, %20g".formatLocal(java.util.Locale.US, data.r, data.g, data.b, data.a)
+    override def toString(data: RGBA): String = Seq( data.r, data.g, data.b, data.a).map(v => "%.20f".formatLocal(java.util.Locale.US,v)).mkString(", ")
   }
 
 }

--- a/src/main/scala/scalismo/faces/io/ply/Writers.scala
+++ b/src/main/scala/scalismo/faces/io/ply/Writers.scala
@@ -100,13 +100,13 @@ object StringWriter {
 
   implicit object FloatStringWriter extends StringWriter[Float] {
     def write(a: Iterable[Float], osw: OutputStreamWriter): Unit = {
-      osw.write(a.mkString(" "))
+      osw.write(a.map(f => "%.8g".formatLocal(java.util.Locale.US, f)).mkString(" "))
     }
   }
 
   implicit object DoubleStringWriter extends StringWriter[Double] {
     def write(a: Iterable[Double], osw: OutputStreamWriter): Unit = {
-      osw.write(a.mkString(" "))
+      osw.write(a.map(d => "%.17g".formatLocal(java.util.Locale.US, d)).mkString(" "))
     }
   }
 

--- a/src/test/scala/scalismo/faces/io/ArrayIOTest.scala
+++ b/src/test/scala/scalismo/faces/io/ArrayIOTest.scala
@@ -19,8 +19,8 @@ package scalismo.faces.io
 import java.io.File
 
 import scalismo.faces.FacesTestSuite
-import scalismo.faces.color.RGB
-import scalismo.faces.io.GravisArrayIO.GravisTypeIO
+import scalismo.faces.color.{RGB, RGBA}
+import scalismo.faces.io.GravisArrayIO.{GravisTypeIO, RGBAIO}
 
 import scala.reflect.ClassTag
 
@@ -35,8 +35,20 @@ class ArrayIOTest extends FacesTestSuite {
 
   describe("Array IO") {
 
+    def checkSameElementsSameOrder[A](a:Seq[A],b:Seq[A]): Unit = {
+      a.zip(b).zipWithIndex.foreach { case ((x, y), i) =>
+        y match {
+          case RGBA =>
+            if (x != y) println(s"${i}: $x, $y ${y.toString()} ${RGBAIO.parse(y.toString)}")
+          case _ =>
+            if (x != y) println(s"${i}: $x, $y ${y.toString()}")
+        }
+      }
+    }
+
     it("can write and read a random sequence for A=Double") {
       val seq = IndexedSeq.fill(25)(randomDouble)
+      checkSameElementsSameOrder(writeReadSeq(seq),seq)
       writeReadSeq(seq) should contain theSameElementsInOrderAs seq
     }
 
@@ -62,11 +74,13 @@ class ArrayIOTest extends FacesTestSuite {
 
     it("can write and read a random sequence for A=RGB") {
       val seq = IndexedSeq.fill(25)(randomRGB)
+      checkSameElementsSameOrder(writeReadSeq(seq),seq)
       writeReadSeq(seq) should contain theSameElementsInOrderAs seq
     }
 
     it("can write and read a random sequence for A=RGBA") {
       val seq = IndexedSeq.fill(25)(randomRGBA)
+      checkSameElementsSameOrder(writeReadSeq(seq),seq)
       writeReadSeq(seq) should contain theSameElementsInOrderAs seq
     }
 

--- a/src/test/scala/scalismo/faces/io/ArrayIOTest.scala
+++ b/src/test/scala/scalismo/faces/io/ArrayIOTest.scala
@@ -19,8 +19,8 @@ package scalismo.faces.io
 import java.io.File
 
 import scalismo.faces.FacesTestSuite
-import scalismo.faces.color.{RGB, RGBA}
-import scalismo.faces.io.GravisArrayIO.{GravisTypeIO, RGBAIO}
+import scalismo.faces.color.RGB
+import scalismo.faces.io.GravisArrayIO.GravisTypeIO
 
 import scala.reflect.ClassTag
 
@@ -35,20 +35,8 @@ class ArrayIOTest extends FacesTestSuite {
 
   describe("Array IO") {
 
-    def checkSameElementsSameOrder[A](a:Seq[A],b:Seq[A]): Unit = {
-      a.zip(b).zipWithIndex.foreach { case ((x, y), i) =>
-        y match {
-          case RGBA =>
-            if (x != y) println(s"${i}: $x, $y ${y.toString()} ${RGBAIO.parse(y.toString)}")
-          case _ =>
-            if (x != y) println(s"${i}: $x, $y ${y.toString()}")
-        }
-      }
-    }
-
     it("can write and read a random sequence for A=Double") {
       val seq = IndexedSeq.fill(25)(randomDouble)
-      checkSameElementsSameOrder(writeReadSeq(seq),seq)
       writeReadSeq(seq) should contain theSameElementsInOrderAs seq
     }
 
@@ -74,13 +62,11 @@ class ArrayIOTest extends FacesTestSuite {
 
     it("can write and read a random sequence for A=RGB") {
       val seq = IndexedSeq.fill(25)(randomRGB)
-      checkSameElementsSameOrder(writeReadSeq(seq),seq)
       writeReadSeq(seq) should contain theSameElementsInOrderAs seq
     }
 
     it("can write and read a random sequence for A=RGBA") {
       val seq = IndexedSeq.fill(25)(randomRGBA)
-      checkSameElementsSameOrder(writeReadSeq(seq),seq)
       writeReadSeq(seq) should contain theSameElementsInOrderAs seq
     }
 


### PR DESCRIPTION
Some more writers did not set the local format explicitly (see #79) . This is now changed. RenderParametersIO uses json serialization so there we should not have the problem.