### PR TITLE
Mesh parametrization

### DIFF
--- a/src/main/scala/scalismo/faces/deluminate/SphericalHarmonicsOptimizer.scala
+++ b/src/main/scala/scalismo/faces/deluminate/SphericalHarmonicsOptimizer.scala
@@ -21,8 +21,9 @@ import scalismo.faces.deluminate.SphericalHarmonicsSolver.IlluminatedPoint
 import scalismo.faces.image.PixelImage
 import scalismo.faces.mesh.VertexColorMesh3D
 import scalismo.faces.parameters.{RenderParameter, SphericalHarmonicsLight}
-import scalismo.faces.render.{ColorTransform, TextureExtraction}
+import scalismo.faces.render.ColorTransform
 import scalismo.faces.sampling.face.ParametricModel
+import scalismo.faces.texture.TextureExtraction
 import scalismo.geometry.{Vector, _3D}
 import scalismo.mesh.{BarycentricCoordinates, MeshSurfaceProperty, TriangleId, TriangleMesh3D}
 import scalismo.utils.Random

--- a/src/main/scala/scalismo/faces/mesh/DiscreteLaplaceBeltrami.scala
+++ b/src/main/scala/scalismo/faces/mesh/DiscreteLaplaceBeltrami.scala
@@ -22,7 +22,8 @@ import scalismo.mesh.{TriangleList, TriangleMesh3D}
 
 /** Construct a discrete Lapalace-Beltrami operators from different types of weights. */
 object DiscreteLaplaceBeltrami {
-  type WeightFunction = (PointId, PointId) => Double
+
+  trait LaplaceBeltramiWeightingFunction extends ((PointId, PointId) => Double)
 
   /**
     * Constructs a Laplace-Beltrami matrix from a given weight function where its rows and columns correspond to the PointIds of the given triangulation.
@@ -31,7 +32,7 @@ object DiscreteLaplaceBeltrami {
     * @param weightFun
     * @return
     */
-  def laplaceBeltramiMatrix(triangulation: TriangleList, weightFun: WeightFunction): CSCMatrix[Double] = {
+  def laplaceBeltramiMatrix(triangulation: TriangleList, weightFun: LaplaceBeltramiWeightingFunction): CSCMatrix[Double] = {
     val n = triangulation.pointIds.length
     val builderW = new CSCMatrix.Builder[Double](n, n)
     for (i <- triangulation.pointIds) {
@@ -65,7 +66,7 @@ object DiscreteLaplaceBeltrami {
     * @param ref : Mesh used to calculate cotangent weights.
     * @return DenseMatrix[Double]
     */
-  def cotangentWeight(ref: TriangleMesh3D): WeightFunction = {
+  def cotangentWeight(ref: TriangleMesh3D): LaplaceBeltramiWeightingFunction = {
 
     /** All three cotangent values of a triangle are stored and added to possibly already existing values.
       * This way both cotan values are added.
@@ -103,7 +104,7 @@ object DiscreteLaplaceBeltrami {
   def unitWeight(i: PointId, j: PointId): Double = 1.0
 
   /** Constructs a weight function which is the heat kernel value k(x1,x2) = exp(- ||x1-x2||^2 / diffusionDistance^2 ) */
-  def heatKernelWeights(ref: TriangleMesh3D, diffusionDistance: Double): WeightFunction = {
+  def heatKernelWeights(ref: TriangleMesh3D, diffusionDistance: Double): LaplaceBeltramiWeightingFunction = {
     (i: PointId, j: PointId) => {
       val dist = (ref.position.atPoint(i) - ref.position.atPoint(j)).norm2
       math.exp(-dist / (diffusionDistance * diffusionDistance))

--- a/src/main/scala/scalismo/faces/numerics/MultiDimensionalScaling.scala
+++ b/src/main/scala/scalismo/faces/numerics/MultiDimensionalScaling.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.numerics
+
+import breeze.linalg.{DenseMatrix, DenseVector, diag}
+import scalismo.common.PointId
+import scalismo.faces.numerics.ArnoldiSymmetricEigenSolver.EigenvaluesFirst
+import scalismo.geometry.{Point, _3D}
+import scalismo.mesh.{SurfacePointProperty, TriangleList}
+
+/** MDS: Preserves predefined distances between points in a lower dimensional manifold in the least-squares sense.
+  * According to: Zigelman, Gil, Ron Kimmel, and Nahum Kiryati. "Texture mapping using surface flattening via multidimensional scaling." */
+
+object MultiDimensionalScaling {
+
+  trait MDSWeightFunction extends ((PointId, PointId)=>Double)
+
+  /** Calculates distance preserving mapping to a lower dimensional space in the least squares sense.
+    * Distance between two points - each represented by an Int - has to be a valid distance measure.
+    *
+    * @param distance function that measures the distance between two points.
+    * @param problemSize number of input points / size of output matrix
+    * @return matrix problemSizexproblemSize
+    */
+  def apply(distance: (Int, Int) => Double, problemSize: Int, numberOfDimensionsToKeep: Int): DenseMatrix[Double] = {
+    val W = DenseMatrix.zeros[Double](problemSize, problemSize)
+    for (i <- 0 until problemSize) {
+      for (j <- 0 until i) {
+        val d = distance(i, j)
+        W(i, j) = d
+        W(j, i) = d
+      }
+    }
+    //"convert" distance to similarity
+    val J = DenseMatrix.eye[Double](problemSize) - (DenseMatrix.ones[Double](problemSize, problemSize) / problemSize.toDouble)
+    val B = (J * W * J) *:* -0.5
+    val C = (0.5 * B + 0.5 * B.t).toDenseMatrix
+
+    val (eigenvalues, eigenvectors) = ArnoldiSymmetricEigenSolver.symmetricEigs(v => C * v, C.cols, numberOfDimensionsToKeep, EigenvaluesFirst.Largest, 1e-10, C.cols * 4)
+    val sortedEigenvalues = eigenvalues.toArray.toIndexedSeq.zipWithIndex.sortBy(l=>l._1).reverse
+    val D: DenseMatrix[Double] = diag(DenseVector(sortedEigenvalues.map(l => math.sqrt(math.abs(l._1))).toArray)).toDenseMatrix
+    eigenvectors(::, sortedEigenvalues.map(_._2)).toDenseMatrix * D
+  }
+
+  /**
+    * Computes a mesh parametrization according to the Multi Dimensional Scaling Scheme.
+    * Distances can be supplied via the vertexDistance function. They are preserved in the resulting space.
+    * @param triangulation
+    * @param vertexDistance
+    * @return
+    */
+  def parametrizationAsProperty(triangulation: TriangleList, vertexDistance: MDSWeightFunction): SurfacePointProperty[Point[_3D]] = {
+    val n = triangulation.pointIds.length
+    def dist(i: Int, j: Int) = vertexDistance(PointId(i), PointId(j))
+    val mds: DenseMatrix[Double] = MultiDimensionalScaling(dist, n, 3)
+    val embedding = IndexedSeq(mds(::, 0),
+      mds(::, 1),
+      mds(::, 2))
+    val embeddedValues = (0 until mds.rows).map(i => Point(embedding(0)(i).toFloat, embedding(1)(i), embedding(2)(i)))
+    SurfacePointProperty(triangulation, embeddedValues)
+  }
+
+}

--- a/src/main/scala/scalismo/faces/sampling/face/proposals/SphericalHarmonicsLightProposals.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/proposals/SphericalHarmonicsLightProposals.scala
@@ -21,10 +21,10 @@ import scalismo.faces.deluminate.SphericalHarmonicsOptimizer
 import scalismo.faces.image.{AccessMode, PixelImage}
 import scalismo.faces.mesh.{MeshSurfaceSampling, VertexColorMesh3D}
 import scalismo.faces.parameters.{RenderParameter, SphericalHarmonicsLight}
-import scalismo.faces.render.TextureExtraction
 import scalismo.faces.sampling.evaluators.LogNormalDistribution
 import scalismo.faces.sampling.face.evaluators.PixelEvaluators.IsotropicGaussianPixelEvaluatorHSV
 import scalismo.faces.sampling.face.{ParametricImageRenderer, ParametricModel}
+import scalismo.faces.texture.TextureExtraction
 import scalismo.geometry.{Vector, _3D}
 import scalismo.mesh._
 import scalismo.sampling.evaluators.{GaussianEvaluator, PairEvaluator}

--- a/src/main/scala/scalismo/faces/texture/MeshParametrization.scala
+++ b/src/main/scala/scalismo/faces/texture/MeshParametrization.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.texture
+
+
+import scalismo.common.PointId
+import scalismo.faces.image.PixelImageDomain
+import scalismo.faces.mesh.DiscreteLaplaceBeltrami.LaplaceBeltramiWeightingFunction
+import scalismo.faces.mesh.{DiscreteLaplaceBeltrami, TextureMappedProperty}
+import scalismo.faces.numerics.ArnoldiSymmetricEigenSolver.EigenvaluesFirst
+import scalismo.faces.numerics.MultiDimensionalScaling.MDSWeightFunction
+import scalismo.faces.numerics.{ArnoldiSymmetricEigenSolver, MultiDimensionalScaling}
+import scalismo.geometry.{Point, _2D, _3D}
+import scalismo.mesh.{SurfacePointProperty, TriangleList, TriangleMesh3D}
+
+
+object MeshParametrization {
+
+  object MDSTextureMapping {
+    /** Computes a texture mapping for a given mesh. Tries to preserve the euclidean distances between the mesh vertices in uv space. */
+    def apply(mesh: TriangleMesh3D, textureDomain: PixelImageDomain): SurfacePointProperty[Point[_2D]] = {
+      def vertexDistance(a: PointId, b: PointId) = (mesh.position.atPoint(a)- mesh.position.atPoint(b)).norm
+      val embedding3d = MultiDimensionalScaling.parametrizationAsProperty(mesh.triangulation, vertexDistance)
+      normalizeUV(embedding3d.mapPoints(p=>Point(p.x, p.y)), textureDomain, mesh.triangulation)
+    }
+
+    /** Computes a texture mapping for a given mesh. Tries to preserve the supplied distances in uv space. */
+    def apply(triangulation: TriangleList, vertexDistance: MDSWeightFunction, textureDomain: PixelImageDomain): SurfacePointProperty[Point[_2D]] = {
+      val embedding3d = MultiDimensionalScaling.parametrizationAsProperty(triangulation, vertexDistance)
+      normalizeUV(embedding3d.mapPoints(p=>Point(p.x, p.y)), textureDomain, triangulation)
+    }
+  }
+
+  object LaplacianEigenmapTextureMapping {
+    /** Computes a laplacian eigenmap texture mapping for a given mesh. */
+    def apply(mesh: TriangleMesh3D, textureDomain: PixelImageDomain): SurfacePointProperty[Point[_2D]] = {
+      val embedding3d = laplacianEigenmap(mesh.triangulation, DiscreteLaplaceBeltrami.cotangentWeight(mesh))
+      normalizeUV(embedding3d.mapPoints(p=>Point(p.x, p.y)), textureDomain, mesh.triangulation)
+    }
+
+    /** Calculates a new mesh parametrisation for a given mesh and a LaplaceBeltramiWeightingFunction.
+      *
+      * @param triangulation
+      * @param vertexWeightFun only needs values for adjacent points.
+      * @param maxIterFactor Increase from default setting of 3 if not enough.
+      *                      Maximum amount of iterations for finding the eigenvectors
+      *                      is numberOfPoints*maxIterFactor.
+      * @return SurfacePointProperty[Point_3D], the parametrisation
+      */
+    def laplacianEigenmap(triangulation: TriangleList, vertexWeightFun: LaplaceBeltramiWeightingFunction, maxIterFactor: Int = 3): SurfacePointProperty[Point[_3D]] = {
+      val C = DiscreteLaplaceBeltrami.laplaceBeltramiMatrix(triangulation, vertexWeightFun)
+      val maxIter = triangulation.pointIds.length * maxIterFactor // this value seems to depend on the problem. Increase maxIterFactor if necessary.
+      val tol = 1e-10
+      val (eigenValues, eigenvectors) = ArnoldiSymmetricEigenSolver.symmetricEigs(v => C * v, C.cols, 4, EigenvaluesFirst.SmallestMagnitude, tol, maxIter)
+      val embedding = IndexedSeq(eigenvectors(::, 1), //the first eigenvector is not used. It is the offset or "ambient" component.
+        eigenvectors(::, 2),
+        eigenvectors(::, 3))
+      val embeddedValues = (0 until C.rows).map(i => Point(embedding(0)(i).toFloat, embedding(1)(i), embedding(2)(i)))
+      SurfacePointProperty(triangulation, embeddedValues)
+    }
+  }
+
+  /** TextureMapping: Normalizes the x and y coordinates of the parametrisation to the u,v coordinate range.
+    *
+    * Can be used to create a TextureMappedProperty.
+    *
+    * @param parametrisation
+    * @param parametrisationDomain
+    * @param triangulation
+    * @return
+    */
+  def normalizeUV(parametrisation: SurfacePointProperty[Point[_2D]], parametrisationDomain: PixelImageDomain, triangulation: TriangleList): SurfacePointProperty[Point[_2D]] = {
+
+    def normalizeParametrisationToUV(embeddedValues: IndexedSeq[Point[_2D]], textureSize: PixelImageDomain): IndexedSeq[Point[_2D]] = {
+      //normalization of coordinates to texture image size [0, w] x [0, h]
+      def getMinMax(values: IndexedSeq[Point[_2D]]) = {
+        val lst = values.map(_.x)
+        val maxx = lst.max
+        val minx = lst.min
+        val lstY = values.map(_.y)
+        val maxy = lstY.max
+        val miny = lstY.min
+        (maxx, minx, maxy, miny)
+      }
+      val (maxx, minx, maxy, miny) = getMinMax(embeddedValues)
+      val max = math.max(maxx, maxy)
+      val min = math.min(minx, miny)
+      val w = textureSize.width
+      val h = textureSize.height
+      embeddedValues.map(p => Point((p.x - min) / (max - min) * w, (p.y - min) / (max - min) * h))
+    }
+
+    val embeddedValues: IndexedSeq[Point[_2D]] = parametrisation.pointData.map(p => Point(p.x, p.y))
+    val normalizedEmbedding = normalizeParametrisationToUV(embeddedValues, parametrisationDomain)
+    val w = parametrisationDomain.width
+    val h = parametrisationDomain.height
+    SurfacePointProperty(triangulation, normalizedEmbedding.map(p => TextureMappedProperty.imageCoordinatesToUV(p, w, h)))
+  }
+}

--- a/src/main/scala/scalismo/faces/texture/TextureExtraction.scala
+++ b/src/main/scala/scalismo/faces/texture/TextureExtraction.scala
@@ -14,11 +14,12 @@
  *  limitations under the License.
  */
 
-package scalismo.faces.render
+package scalismo.faces.texture
 
 import scalismo.faces.color.ColorSpaceOperations
 import scalismo.faces.image.{InterpolatedPixelImage, PixelImage, PixelImageDomain}
 import scalismo.faces.mesh.TextureMappedProperty
+import scalismo.faces.render.{PointShader, TriangleRenderer}
 import scalismo.geometry.{Point, _2D, _3D}
 import scalismo.mesh._
 

--- a/src/test/scala/scalismo/faces/render/TextureExtractionTests.scala
+++ b/src/test/scala/scalismo/faces/render/TextureExtractionTests.scala
@@ -26,6 +26,7 @@ import scalismo.faces.io.PixelImageIO
 import scalismo.faces.mesh.{ColorNormalMesh3D, TextureMappedProperty}
 import scalismo.faces.parameters.{Camera, Pose, RenderParameter}
 import scalismo.faces.render.PixelShaders.PropertyShader
+import scalismo.faces.texture.TextureExtraction
 import scalismo.geometry.Vector
 import scalismo.mesh.{MeshSurfaceProperty, SurfacePointProperty, TriangleMesh3D}
 import scalismo.utils.Random


### PR DESCRIPTION
This PR provides new functionality to create mesh parametrizations.
Mesh parametrizations allow to compute texture mappings (u,v coordinates) for a given mesh that allow to preserve different properties of the mesh in u,v coordinates.

Parametrizations:
* Multi-Dimensional-Scaling. Preserves user supplied vertex distances in uv space in a least squares sense.
* Laplacian Eigenmaps. Local geometry is optimally preserved in a least squares sense.

Additionally, texture related computations such as TextureExtraction and MeshParametrizaiton are now in the new scalismo.faces.texture package.