### PR TITLE
Fixes #89 (broken PLY reader)

### DIFF
--- a/src/main/scala/scalismo/faces/io/ply/PlyReader.scala
+++ b/src/main/scala/scalismo/faces/io/ply/PlyReader.scala
@@ -58,7 +58,7 @@ object PlyReader {
     // as we use buffered readers we need to reset the input stream
     val fis = new FileInputStream(url)
     val bis = new BufferedInputStream(fis)
-    bis.skip(header.map(_.size).sum + header.size)
+    bis.skip(header.map(_.size).sum + header.size*System.getProperty("line.separator").length)
     val values = readData(bis, plyFormat, elementReaders)
     (values, textures)
   }


### PR DESCRIPTION
This PR fixes #89, describing the buggy PLYReader where the new-line representation is assumed to always have a length of 1. This is not true on all OSs.

In addition, the PLYReader does not require a specific punctuation for the floating point numbers in ASCII-files. Instead, it tries first the US (".", points) variant. If it fails reading the content then it tries it with the FRENCH (",", comma) style. Only if both attempts fail the file is not read.