### PR TITLE
Draw a random coefficient sample in MoMoInstance

### DIFF
--- a/src/main/scala/scalismo/faces/momo/MoMo.scala
+++ b/src/main/scala/scalismo/faces/momo/MoMo.scala
@@ -90,6 +90,13 @@ trait MoMo {
   def sample()(implicit rnd: Random): VertexColorMesh3D
 
   /**
+    * Draw a set of coefficients from the prior of the statistical model.
+    *
+    * @return a set of coefficients to generate a random sample.
+    */
+  def sampleCoefficients()(implicit rnd: Random): MoMoCoefficients
+
+  /**
     * Returns the same model but with exchanged or added landmarks.
     *
     * @param landmarksMap Map of named landmarks.
@@ -471,6 +478,19 @@ case class MoMoExpress(override val referenceMesh: TriangleMesh3D,
     )
   }
 
+
+  /**
+    * Draw a set of coefficients from the prior of the statistical model.
+    *
+    * @return a set of coefficients to generate a random sample.
+    */
+  override def sampleCoefficients()(implicit rnd: Random): MoMoCoefficients = {
+    MoMoCoefficients(
+      shape.coefficientsDistribution.sample(),
+      color.coefficientsDistribution.sample(),
+      expression.coefficientsDistribution.sample())
+  }
+
   /**
     * Returns the same model but with exchanged or added landmarks.
     *
@@ -611,6 +631,20 @@ case class MoMoBasic(override val referenceMesh: TriangleMesh3D,
       discreteFieldToColor(color.gpModel.sample())
     )
   }
+
+
+  /**
+    * Draw a set of coefficients from the prior of the statistical model.
+    *
+    * @return a set of coefficients to generate a random sample.
+    */
+  override def sampleCoefficients()(implicit rnd: Random): MoMoCoefficients = {
+    MoMoCoefficients(
+      shape.coefficientsDistribution.sample(),
+      color.coefficientsDistribution.sample()
+    )
+  }
+
 
   /**
     * Returns the same model but with exchanged or added landmarks.

--- a/src/main/scala/scalismo/faces/momo/MoMoCoefficients.scala
+++ b/src/main/scala/scalismo/faces/momo/MoMoCoefficients.scala
@@ -17,7 +17,6 @@
 package scalismo.faces.momo
 
 import breeze.linalg.DenseVector
-import scalismo.utils.Random
 
 /** coefficients describing a Morphable Model instance */
 case class MoMoCoefficients(shape: DenseVector[Double],
@@ -48,14 +47,5 @@ object MoMoCoefficients {
       DenseVector.zeros(shapeComponents),
       DenseVector.zeros(colorComponents),
       DenseVector.zeros(expressionComponents))
-  }
-
-  def sample(shapeComponents: Int,
-             colorComponents: Int,
-             expressionComponents: Int)(implicit rnd: Random): MoMoCoefficients = {
-    val fullShapeCoeffs = for (_ <- 0 until shapeComponents) yield rnd.rng.breezeRandBasis.gaussian.draw()
-    val fullColorCoeffs = for (_ <- 0 until colorComponents) yield rnd.rng.breezeRandBasis.gaussian.draw()
-    val fullExpressCoeffs = for (_ <- 0 until expressionComponents) yield rnd.rng.breezeRandBasis.gaussian.draw()
-    MoMoCoefficients(fullShapeCoeffs, fullColorCoeffs, fullExpressCoeffs)
   }
 }

--- a/src/main/scala/scalismo/faces/momo/MoMoCoefficients.scala
+++ b/src/main/scala/scalismo/faces/momo/MoMoCoefficients.scala
@@ -17,6 +17,7 @@
 package scalismo.faces.momo
 
 import breeze.linalg.DenseVector
+import breeze.stats.distributions.Gaussian
 
 /** coefficients describing a Morphable Model instance */
 case class MoMoCoefficients(shape: DenseVector[Double],

--- a/src/main/scala/scalismo/faces/momo/MoMoCoefficients.scala
+++ b/src/main/scala/scalismo/faces/momo/MoMoCoefficients.scala
@@ -17,7 +17,7 @@
 package scalismo.faces.momo
 
 import breeze.linalg.DenseVector
-import breeze.stats.distributions.Gaussian
+import scalismo.utils.Random
 
 /** coefficients describing a Morphable Model instance */
 case class MoMoCoefficients(shape: DenseVector[Double],
@@ -48,5 +48,14 @@ object MoMoCoefficients {
       DenseVector.zeros(shapeComponents),
       DenseVector.zeros(colorComponents),
       DenseVector.zeros(expressionComponents))
+  }
+
+  def sample(shapeComponents: Int,
+             colorComponents: Int,
+             expressionComponents: Int)(implicit rnd: Random): MoMoCoefficients = {
+    val fullShapeCoeffs = for (_ <- 0 until shapeComponents) yield rnd.rng.breezeRandBasis.gaussian.draw()
+    val fullColorCoeffs = for (_ <- 0 until colorComponents) yield rnd.rng.breezeRandBasis.gaussian.draw()
+    val fullExpressCoeffs = for (_ <- 0 until expressionComponents) yield rnd.rng.breezeRandBasis.gaussian.draw()
+    MoMoCoefficients(fullShapeCoeffs, fullColorCoeffs, fullExpressCoeffs)
   }
 }

--- a/src/main/scala/scalismo/faces/parameters/RenderObject.scala
+++ b/src/main/scala/scalismo/faces/parameters/RenderObject.scala
@@ -143,21 +143,8 @@ object MoMoInstance {
     fromCoefficients(MoMoCoefficients.zeros(shapeComponents, colorComponents, expressionComponents), modelURI)
   }
 
-  /** create a random coefficient vector with specified size with its elements N(0,1) distributed. */
-  def sample(shapeComponents: Int,
-             colorComponents: Int,
-             expressionComponents: Int,
-             modelURI: URI)(implicit rnd: Random): MoMoInstance = {
-    fromCoefficients( MoMoCoefficients.sample(shapeComponents, colorComponents, expressionComponents), modelURI )
-  }
-
   /** create a random coefficient vector with its elements N(0,1) distributed. */
-  def sample(model: MoMo, modelURI: URI)(implicit rnd: Random): MoMoInstance = {
-    val rankShape = model.neutralModel.shape.rank
-    val rankColor = model.neutralModel.color.rank
-    val expressionRank = if(!model.hasExpressions) 0 else model.expressionModel.get.expression.rank
-    sample(rankShape, rankColor, expressionRank, modelURI)
-  }
+  def sample(model: MoMo, modelURI: URI)(implicit rnd: Random): MoMoInstance = fromCoefficients(model.sampleCoefficients(), modelURI)
 }
 
 /** mesh file reference to render */

--- a/src/main/scala/scalismo/faces/parameters/RenderObject.scala
+++ b/src/main/scala/scalismo/faces/parameters/RenderObject.scala
@@ -20,7 +20,6 @@ import java.io.File
 import java.net.URI
 import java.util.Map.Entry
 
-import breeze.stats.distributions.Gaussian
 import scalismo.faces.io.MoMoIO
 import scalismo.faces.io.msh.MSHMeshIO
 import scalismo.faces.mesh.{ColorNormalMesh3D, VertexColorMesh3D}
@@ -146,16 +145,10 @@ object MoMoInstance {
 
   /** create a random coefficient vector with its elements N(0,1) distributed. */
   def sample(model: MoMo, modelURI: URI)(implicit rnd: Random): MoMoInstance = {
-    val fullShapeCoeffs = for (_ <- 0 until model.neutralModel.shape.rank) yield Gaussian(0, 1).draw()
-    val fullColorCoeffs = for (_ <- 0 until model.neutralModel.color.rank) yield Gaussian(0, 1).draw()
-    val expressionRank = model.expressionModel.get.expression.rank
-    val coeff = if(expressionRank > 0) {
-      val fullExpressCoeffs = for (_ <- 0 until expressionRank) yield Gaussian(0, 1).draw()
-      MoMoCoefficients(fullShapeCoeffs, fullColorCoeffs, fullExpressCoeffs)
-    } else {
-      MoMoCoefficients(fullShapeCoeffs, fullColorCoeffs)
-    }
-    fromCoefficients(coeff, modelURI)
+    val rankShape = model.neutralModel.shape.rank
+    val rankColor = model.neutralModel.color.rank
+    val expressionRank = if(!model.hasExpressions) 0 else model.expressionModel.get.expression.rank
+    fromCoefficients( MoMoCoefficients.sample(rankShape, rankColor, expressionRank), modelURI )
   }
 }
 

--- a/src/main/scala/scalismo/faces/parameters/RenderObject.scala
+++ b/src/main/scala/scalismo/faces/parameters/RenderObject.scala
@@ -143,12 +143,20 @@ object MoMoInstance {
     fromCoefficients(MoMoCoefficients.zeros(shapeComponents, colorComponents, expressionComponents), modelURI)
   }
 
+  /** create a random coefficient vector with specified size with its elements N(0,1) distributed. */
+  def sample(shapeComponents: Int,
+             colorComponents: Int,
+             expressionComponents: Int,
+             modelURI: URI)(implicit rnd: Random): MoMoInstance = {
+    fromCoefficients( MoMoCoefficients.sample(shapeComponents, colorComponents, expressionComponents), modelURI )
+  }
+
   /** create a random coefficient vector with its elements N(0,1) distributed. */
   def sample(model: MoMo, modelURI: URI)(implicit rnd: Random): MoMoInstance = {
     val rankShape = model.neutralModel.shape.rank
     val rankColor = model.neutralModel.color.rank
     val expressionRank = if(!model.hasExpressions) 0 else model.expressionModel.get.expression.rank
-    fromCoefficients( MoMoCoefficients.sample(rankShape, rankColor, expressionRank), modelURI )
+    sample(rankShape, rankColor, expressionRank, modelURI)
   }
 }
 


### PR DESCRIPTION
Currently, it is laborious to draw a random MoMoInstance random coefficient that can be used for example rendering a random model sample.

Functionality:
Draws shape, color and expression vector entries N(0,1) distributed.

This is a possible use case of the proposed functionality:
```scala
val model: MoMo = ???
val renderer = MoMoRenderer(model)
val parameter = RenderParameter.defaultSquare.withMoMo(MoMoInstance.sample(model))
val randomRendering = renderer.renderImage(parameter)
```