### PR TITLE
albedo, illumination and normal renderer added

### DIFF
--- a/src/main/scala/scalismo/faces/parameters/ParametricRenderer.scala
+++ b/src/main/scala/scalismo/faces/parameters/ParametricRenderer.scala
@@ -55,13 +55,14 @@ object ParametricRenderer {
     *
     * @param parameter scene description
     * @param mesh mesh to render, has positions, colors and normals
+    * @param pixelShader used to calculate the color for a pixel
     * @param clearColor background color of buffer
     * @return
     */
   def renderParameterMesh[A: ClassTag](parameter: RenderParameter,
-                          mesh: ColorNormalMesh3D,
-                          pixelShader: PixelShader[A],
-                          clearColor: A): PixelImage[A] = {
+                                       mesh: ColorNormalMesh3D,
+                                       pixelShader: PixelShader[A],
+                                       clearColor: A): PixelImage[A] = {
     val buffer = ZBuffer(parameter.imageSize.width, parameter.imageSize.height, clearColor)
 
     val worldMesh = mesh.transform(parameter.modelViewTransform)
@@ -95,13 +96,14 @@ object ParametricRenderer {
     *
     * @param parameter scene description
     * @param mesh mesh to render, vertex color, vertex normals
+    * @param pixelShader used to calculate the color for a pixel
     * @param clearColor background color of buffer
     * @return
     */
   def renderParameterVertexColorMesh[A:ClassTag](parameter: RenderParameter,
-                                     mesh: VertexColorMesh3D,
-                                     pixelShader: PixelShader[A],
-                                     clearColor: A ): PixelImage[A] = {
+                                                 mesh: VertexColorMesh3D,
+                                                 pixelShader: PixelShader[A],
+                                                 clearColor: A ): PixelImage[A] = {
     renderParameterMesh(parameter, ColorNormalMesh3D(mesh), pixelShader, clearColor)
   }
 
@@ -122,12 +124,13 @@ object ParametricRenderer {
     * render the object described by the render parameters
     *
     * @param parameter scene description, including the object
+    * @param pixelShader used to calculate the color for a pixel
     * @param clearColor background color of scene/buffer
     * @return
     */
   def renderParameter[A: ClassTag](parameter: RenderParameter,
-                         pixelShader: PixelShader[A],
-                      clearColor: A): PixelImage[A] = {
+                                   pixelShader: PixelShader[A],
+                                   clearColor: A): PixelImage[A] = {
     val mesh = RenderObject.instance(parameter.momo)
     renderParameterMesh(parameter, mesh, pixelShader, clearColor)
   }

--- a/src/main/scala/scalismo/faces/parameters/ParametricRenderer.scala
+++ b/src/main/scala/scalismo/faces/parameters/ParametricRenderer.scala
@@ -19,7 +19,7 @@ package scalismo.faces.parameters
 import scalismo.faces.color.RGBA
 import scalismo.faces.image.PixelImage
 import scalismo.faces.mesh.{ColorNormalMesh3D, VertexColorMesh3D}
-import scalismo.faces.render.{TriangleFilters, TriangleRenderer, ZBuffer}
+import scalismo.faces.render.{PixelShader, TriangleFilters, TriangleRenderer, ZBuffer}
 import scalismo.mesh.{MeshSurfaceProperty, TriangleMesh3D}
 
 import scala.reflect.ClassTag
@@ -51,6 +51,32 @@ object ParametricRenderer {
   }
 
   /**
+    * render a mesh with specified colors and normals according to scene description parameter
+    *
+    * @param parameter scene description
+    * @param mesh mesh to render, has positions, colors and normals
+    * @param clearColor background color of buffer
+    * @return
+    */
+  def renderParameterMesh[A: ClassTag](parameter: RenderParameter,
+                          mesh: ColorNormalMesh3D,
+                          pixelShader: PixelShader[A],
+                          clearColor: A): PixelImage[A] = {
+    val buffer = ZBuffer(parameter.imageSize.width, parameter.imageSize.height, clearColor)
+
+    val worldMesh = mesh.transform(parameter.modelViewTransform)
+    val backfaceCullingFilter = TriangleFilters.backfaceCullingFilter(worldMesh.shape, parameter.view.eyePosition)
+
+    TriangleRenderer.renderMesh[A](
+      mesh.shape,
+      backfaceCullingFilter,
+      parameter.pointShader,
+      parameter.imageSize.screenTransform,
+      pixelShader,
+      buffer).toImage
+  }
+
+  /**
     * render according to parameters, convenience for vertex color mesh with vertex normals
     *
     * @param parameter scene description
@@ -65,6 +91,21 @@ object ParametricRenderer {
   }
 
   /**
+    * render according to parameters, convenience for vertex color mesh with vertex normals
+    *
+    * @param parameter scene description
+    * @param mesh mesh to render, vertex color, vertex normals
+    * @param clearColor background color of buffer
+    * @return
+    */
+  def renderParameterVertexColorMesh[A:ClassTag](parameter: RenderParameter,
+                                     mesh: VertexColorMesh3D,
+                                     pixelShader: PixelShader[A],
+                                     clearColor: A ): PixelImage[A] = {
+    renderParameterMesh(parameter, ColorNormalMesh3D(mesh), pixelShader, clearColor)
+  }
+
+  /**
     * render the object described by the render parameters
     *
     * @param parameter scene description, including the object
@@ -75,6 +116,20 @@ object ParametricRenderer {
                       clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
     val mesh = RenderObject.instance(parameter.momo)
     renderParameterMesh(parameter, mesh, clearColor)
+  }
+
+  /**
+    * render the object described by the render parameters
+    *
+    * @param parameter scene description, including the object
+    * @param clearColor background color of scene/buffer
+    * @return
+    */
+  def renderParameter[A: ClassTag](parameter: RenderParameter,
+                         pixelShader: PixelShader[A],
+                      clearColor: A): PixelImage[A] = {
+    val mesh = RenderObject.instance(parameter.momo)
+    renderParameterMesh(parameter, mesh, pixelShader, clearColor)
   }
 
   /**

--- a/src/main/scala/scalismo/faces/sampling/face/CorrespondenceMoMoRenderer.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/CorrespondenceMoMoRenderer.scala
@@ -74,38 +74,6 @@ abstract class RenderFromCorrespondenceImage[A](correspondenceMoMoRenderer: Corr
   override def renderImage(parameters: RenderParameter): PixelImage[A]
 }
 
-case class DepthMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.Black) extends RenderFromCorrespondenceImage[RGBA](correspondenceMoMoRenderer: CorrespondenceMoMoRenderer) {
-  override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {
-    val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
-    val depthMap = correspondenceImage.map{ px=>
-      if(px.isDefined){
-        val frag = px.get
-        val tId = frag.triangleId
-        val bcc = frag.worldBCC
-        val mesh = frag.mesh
-
-        val posModel = mesh.position(tId, bcc)
-        val posEyeCoordinates = parameters.modelViewTransform(posModel)
-
-        Some((parameters.view.eyePosition-posEyeCoordinates).norm)
-      }else{
-        None
-      }
-    }
-    val values  = depthMap.values.toIndexedSeq.flatten
-    val ma = values.max
-    val mi = values.min
-    val mami = ma-mi
-    depthMap.map{d=>
-      if(d.isEmpty)
-        clearColor
-      else {
-        RGBA(1.0 - (d.get - mi)/mami)
-      }
-    }
-  }
-}
-
 case class CorrespondenceColorImageRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, backgroundColor: RGBA = RGBA.Black) extends RenderFromCorrespondenceImage[RGBA](correspondenceMoMoRenderer){
   val reference: VertexColorMesh3D = correspondenceMoMoRenderer.model.mean
   val normalizedReference: SurfacePointProperty[RGBA] = {

--- a/src/main/scala/scalismo/faces/sampling/face/MoMoRenderer.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/MoMoRenderer.scala
@@ -29,30 +29,11 @@ import scalismo.utils.Memoize
 
 /** parametric renderer for a Morphable Model, implements all useful Parameteric*Renderer interfaces */
 class MoMoRenderer(val model: MoMo, val clearColor: RGBA)
-  extends ParametricImageRenderer[RGBA]
+  extends ParametricModel(model)
     with ParametricLandmarksRenderer
     with ParametricMaskRenderer
     with ParametricMeshRenderer
-    with ParametricModel {
-
-  /** pad a coefficient vector if it is too short, basis with single vector */
-  private def padCoefficients(coefficients: DenseVector[Double], rank: Int): DenseVector[Double] = {
-    require(coefficients.length <= rank, "too many coefficients for model")
-    if (coefficients.length == rank)
-      coefficients
-    else
-      DenseVector(coefficients.toArray ++ Array.fill(rank - coefficients.length)(0.0))
-  }
-
-  /** create an instance of the model, in the original model's object coordinates */
-  override def instance(parameters: RenderParameter): VertexColorMesh3D = {
-    instanceFromCoefficients(parameters.momo)
-  }
-
-  /** draw a model instance directly from the coefficients */
-  def instanceFromCoefficients(instance: MoMoInstance): VertexColorMesh3D = {
-    model.instance(instance.coefficients)
-  }
+    with ParametricImageRenderer[RGBA] {
 
   /** render the image described by the parameters */
   override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -76,7 +76,8 @@ case class NormalMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRende
       if (n.isEmpty)
         clearColor
       else {
-        RGBA(n.get.x, n.get.y, n.get.z)
+        val v = n.get * 0.5
+        RGBA(v.x + 0.5, v.y + 0.5, v.z + 0.5)
       })
   }
 }

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -77,7 +77,7 @@ case class NormalMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRende
         clearColor
       else {
         val v = n.get * 0.5
-        RGBA(v.x + 0.5, v.y + 0.5, v.z + 0.5)
+        RGBA(v.x - 0.5, v.y - 0.5, v.z - 0.5)
       })
   }
 }

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -25,7 +25,7 @@ import scalismo.mesh.{BarycentricCoordinates, SurfacePointProperty, TriangleId}
 
 object ModalityRenderers {
 
-  object CorrespondenceRenderer {
+  object CorrespondenceMoMoModalityRenderer {
 
     def renderDepthMap(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer): PixelImage[Option[Double]] = {
       val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
@@ -69,7 +69,7 @@ object ModalityRenderers {
 
   }
 
-  object ParametricModel {
+  object ParametricModelModalityRenderer {
 
     def renderDepthMap(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: Option[Double] = None): PixelImage[Option[Double]] = {
       val instance = parametricModel.instance(parameters)

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -60,7 +60,8 @@ case class NormalMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRende
   /** render the normals described by the parameters */
   override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {
     val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
-    val normalMap = correspondenceImage.map { px =>
+
+    correspondenceImage.map { px =>
       if (px.isDefined) {
         val frag = px.get
         val tId = frag.triangleId
@@ -68,19 +69,12 @@ case class NormalMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRende
         val mesh = frag.mesh
         val normal = parameters.modelViewTransform(mesh.vertexNormals(tId, bcc))
 
-        Some(normal)
+        val v = normal * 0.5
+        RGBA(0.5 - v.x, 0.5 - v.y, 0.5 - v.z)
       } else {
-        None
+        clearColor
       }
     }
-
-    normalMap.map(n =>
-      if (n.isEmpty)
-        clearColor
-      else {
-        val v = n.get * 0.5
-        RGBA(0.5 - v.x, 0.5 - v.y, 0.5 - v.z)
-      })
   }
 }
 

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -77,7 +77,7 @@ case class NormalMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRende
         clearColor
       else {
         val v = n.get * 0.5
-        RGBA(v.x - 0.5, v.y - 0.5, v.z - 0.5)
+        RGBA(0.5 - v.x, 0.5 - v.y, 0.5 - v.z)
       })
   }
 }

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -45,7 +45,7 @@ object ModalityRenderers {
       }
     }
 
-    def renderNormalsImage(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
+    def renderNormalsVisualization(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
       val normals = renderNormals(parameters, correspondenceMoMoRenderer)
       colorNormalImage(normals, clearColor)
 
@@ -61,7 +61,7 @@ object ModalityRenderers {
       }
     }
 
-    def renderIlluminationImage(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
+    def renderIlluminationVisualization(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
       val instance = correspondenceMoMoRenderer.instance(parameters)
       val noColorInst = instance.copy(color = SurfacePointProperty(instance.shape.triangulation, instance.color.pointData.map(_ => RGBA(0.5, 0.5, 0.5))))
       val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
@@ -96,7 +96,7 @@ object ModalityRenderers {
         clearColor)
     }
 
-    def renderNormalsImage(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+    def renderNormalsVisualization(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
       val normals = renderNormals(parameters, parametricModel)
       colorNormalImage(normals, clearColor)
     }
@@ -108,7 +108,7 @@ object ModalityRenderers {
         instance.color).map(_.getOrElse(clearColor))
     }
 
-    def renderIlluminationImage(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+    def renderIlluminationVisualization(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
       val instance = parametricModel.instance(parameters)
       val noColorInst = instance.copy(color = SurfacePointProperty(instance.shape.triangulation, instance.color.pointData.map(_ => RGBA(0.5, 0.5, 0.5))))
       ParametricRenderer.renderParameterVertexColorMesh(

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -19,7 +19,6 @@ package scalismo.faces.sampling.face
 import scalismo.faces.color.RGBA
 import scalismo.faces.image.PixelImage
 import scalismo.faces.parameters.{ParametricRenderer, RenderParameter}
-import scalismo.faces.render.PixelShaders.MoMoShader
 import scalismo.geometry.{Point, Vector, _3D}
 import scalismo.mesh.{BarycentricCoordinates, SurfacePointProperty, TriangleId}
 

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -129,10 +129,9 @@ object ModalityRenderers {
     val instance = correspondenceMoMoRenderer.instance(parameters)
     val noColorInst = instance.copy(color = SurfacePointProperty(instance.shape.triangulation, instance.color.pointData.map(_ => RGBA(0.5, 0.5, 0.5))))
     val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
-    val shader = MoMoShader.pixelShader(noColorInst,parameters)
     correspondenceImage.map{ optFrag =>
       optFrag.map{ fragment =>
-        shader(fragment)
+        parameters.pixelShader(instance)(fragment.triangleId,fragment.worldBCC,Point(fragment.x,fragment.y,fragment.z))
       }.getOrElse(clearColor)
     }
   }

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -45,6 +45,12 @@ object ModalityRenderers {
       }
     }
 
+    def renderNormalsImage(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
+      val normals = renderNormals(parameters, correspondenceMoMoRenderer)
+      colorNormalImage(normals, clearColor)
+
+    }
+
     def renderAlbedo(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
       val instance = correspondenceMoMoRenderer.instance(parameters)
       val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
@@ -55,7 +61,7 @@ object ModalityRenderers {
       }
     }
 
-    def renderIllumination(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
+    def renderIlluminationImage(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
       val instance = correspondenceMoMoRenderer.instance(parameters)
       val noColorInst = instance.copy(color = SurfacePointProperty(instance.shape.triangulation, instance.color.pointData.map(_ => RGBA(0.5, 0.5, 0.5))))
       val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
@@ -90,6 +96,11 @@ object ModalityRenderers {
         clearColor)
     }
 
+    def renderNormalsImage(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+      val normals = renderNormals(parameters, parametricModel)
+      colorNormalImage(normals, clearColor)
+    }
+
     def renderAlbedo(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
       val instance = parametricModel.instance(parameters)
       ParametricRenderer.renderPropertyImage(parameters,
@@ -97,7 +108,7 @@ object ModalityRenderers {
         instance.color).map(_.getOrElse(clearColor))
     }
 
-    def renderIllumination(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+    def renderIlluminationImage(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
       val instance = parametricModel.instance(parameters)
       val noColorInst = instance.copy(color = SurfacePointProperty(instance.shape.triangulation, instance.color.pointData.map(_ => RGBA(0.5, 0.5, 0.5))))
       ParametricRenderer.renderParameterVertexColorMesh(
@@ -134,15 +145,15 @@ object ModalityRenderers {
     }
   }
 
-  def colorNormalImage(depthMap: PixelImage[Option[Vector[_3D]]]) : PixelImage[Option[RGBA]] = {
-    depthMap.map(opt => opt.map { normal =>
+  def colorNormalImage(normals: PixelImage[Option[Vector[_3D]]]) : PixelImage[Option[RGBA]] = {
+    normals.map(opt => opt.map { normal =>
       val v = normal * 0.5
       RGBA(0.5 - v.x, 0.5 - v.y, 0.5 - v.z, 1.0)
     })
   }
 
-  def colorNormalImage(depthMap: PixelImage[Option[Vector[_3D]]], clearColor: RGBA) : PixelImage[RGBA] = {
-    depthMap.map { opt =>
+  def colorNormalImage(normals: PixelImage[Option[Vector[_3D]]], clearColor: RGBA) : PixelImage[RGBA] = {
+    normals.map { opt =>
       opt.map { normal =>
         val v = normal * 0.5
         RGBA(0.5 - v.x, 0.5 - v.y, 0.5 - v.z, 1.0)

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -24,6 +24,7 @@ import scalismo.mesh.SurfacePointProperty
 
 
 case class DepthMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.Black) extends RenderFromCorrespondenceImage[RGBA](correspondenceMoMoRenderer: CorrespondenceMoMoRenderer) {
+  /** render the depthimage described by the parameters */
   override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {
     val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
     val depthMap = correspondenceImage.map{ px=>
@@ -56,6 +57,7 @@ case class DepthMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRender
 }
 
 case class NormalMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.Black) extends RenderFromCorrespondenceImage[RGBA](correspondenceMoMoRenderer: CorrespondenceMoMoRenderer) {
+  /** render the normals described by the parameters */
   override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {
     val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
     val normalMap = correspondenceImage.map { px =>

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -64,8 +64,9 @@ case class NormalMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRende
         val tId = frag.triangleId
         val bcc = frag.worldBCC
         val mesh = frag.mesh
+        val normal = parameters.modelViewTransform(mesh.vertexNormals(tId, bcc))
 
-        Some(mesh.vertexNormals(tId, bcc))
+        Some(normal)
       } else {
         None
       }

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -89,7 +89,7 @@ case class AlbedoRenderer(override val model: MoMo, override val clearColor: RGB
   /** render the albedo described by the parameters */
   override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {
     val inst = instance(parameters)
-    val ambientParameters = parameters.withEnvironmentMap(SphericalHarmonicsLight.ambientWhite)
+    val ambientParameters = parameters.noLightAndColor
     ParametricRenderer.renderParameterVertexColorMesh(
       ambientParameters,
       inst,
@@ -105,7 +105,7 @@ case class IlluminationRenderer(override val model: MoMo, override val clearColo
     val inst = instance(parameters)
     val noColorInst = inst.copy(color = SurfacePointProperty(inst.shape.triangulation, inst.color.pointData.map(_ => RGBA(0.5, 0.5, 0.5))))
     ParametricRenderer.renderParameterVertexColorMesh(
-      parameters,
+      parameters.noColorTransform,
       noColorInst,
       clearColor)
   }

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.faces.sampling.face
+
+import scalismo.faces.color.RGBA
+import scalismo.faces.image.PixelImage
+import scalismo.faces.momo.MoMo
+import scalismo.faces.parameters.{ParametricRenderer, RenderParameter, SphericalHarmonicsLight}
+import scalismo.mesh.SurfacePointProperty
+
+
+case class DepthMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.Black) extends RenderFromCorrespondenceImage[RGBA](correspondenceMoMoRenderer: CorrespondenceMoMoRenderer) {
+  override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {
+    val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
+    val depthMap = correspondenceImage.map{ px=>
+      if(px.isDefined){
+        val frag = px.get
+        val tId = frag.triangleId
+        val bcc = frag.worldBCC
+        val mesh = frag.mesh
+
+        val posModel = mesh.position(tId, bcc)
+        val posEyeCoordinates = parameters.modelViewTransform(posModel)
+
+        Some((parameters.view.eyePosition-posEyeCoordinates).norm)
+      }else{
+        None
+      }
+    }
+    val values  = depthMap.values.toIndexedSeq.flatten
+    val ma = values.max
+    val mi = values.min
+    val mami = ma-mi
+    depthMap.map{d=>
+      if(d.isEmpty)
+        clearColor
+      else {
+        RGBA(1.0 - (d.get - mi)/mami)
+      }
+    }
+  }
+}
+
+case class NormalMapRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.Black) extends RenderFromCorrespondenceImage[RGBA](correspondenceMoMoRenderer: CorrespondenceMoMoRenderer) {
+  override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {
+    val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
+    val normalMap = correspondenceImage.map { px =>
+      if (px.isDefined) {
+        val frag = px.get
+        val tId = frag.triangleId
+        val bcc = frag.worldBCC
+        val mesh = frag.mesh
+
+        Some(mesh.vertexNormals(tId, bcc))
+      } else {
+        None
+      }
+    }
+
+    normalMap.map(n =>
+      if (n.isEmpty)
+        clearColor
+      else {
+        RGBA(n.get.x, n.get.y, n.get.z)
+      })
+  }
+}
+
+case class AlbedoRenderer(override val model: MoMo, override val clearColor: RGBA = RGBA.Black) extends MoMoRenderer(model: MoMo, clearColor: RGBA){
+
+  /** render the albedo described by the parameters */
+  override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {
+    val inst = instance(parameters)
+    val ambientParameters = parameters.withEnvironmentMap(SphericalHarmonicsLight.ambientWhite)
+    ParametricRenderer.renderParameterVertexColorMesh(
+      ambientParameters,
+      inst,
+      clearColor)
+  }
+
+}
+
+case class IlluminationRenderer(override val model: MoMo, override val clearColor: RGBA = RGBA.Black) extends MoMoRenderer(model: MoMo, clearColor: RGBA){
+
+  /** render the illumination component described by the parameters */
+  override def renderImage(parameters: RenderParameter): PixelImage[RGBA] = {
+    val inst = instance(parameters)
+    val noColorInst = inst.copy(color = SurfacePointProperty(inst.shape.triangulation, inst.color.pointData.map(_ => RGBA(0.5, 0.5, 0.5))))
+    ParametricRenderer.renderParameterVertexColorMesh(
+      parameters,
+      noColorInst,
+      clearColor)
+  }
+
+}
+

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -77,10 +77,10 @@ object ModalityRenderers {
     }
   }
 
-  object IlluminationRenderer {
-    def apply(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) = new IlluminationRenderer(correspondenceMoMoRenderer, clearColor)
+  object IlluminationVisualizationRenderer {
+    def apply(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) = new IlluminationVisualizationRenderer(correspondenceMoMoRenderer, clearColor)
   }
-  class IlluminationRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA) extends ParametricImageRenderer[RGBA] {
+  class IlluminationVisualizationRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA) extends ParametricImageRenderer[RGBA] {
 
     override def renderImage(parameters: RenderParameter) : PixelImage[RGBA] = {
       val instance = correspondenceMoMoRenderer.instance(parameters)

--- a/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ModalityRenderers.scala
@@ -25,9 +25,12 @@ import scalismo.mesh.{BarycentricCoordinates, SurfacePointProperty, TriangleId}
 
 object ModalityRenderers {
 
-  object CorrespondenceMoMoModalityRenderer {
+  object CorrespondenceModalityRenderer {
+    def apply(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer) = new CorrespondenceModalityRenderer(correspondenceMoMoRenderer)
+  }
+  class CorrespondenceModalityRenderer(correspondenceMoMoRenderer: CorrespondenceMoMoRenderer) {
 
-    def renderDepthMap(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer): PixelImage[Option[Double]] = {
+    def renderDepthMap(parameters: RenderParameter): PixelImage[Option[Double]] = {
       val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
       correspondenceImage.map { optFrag =>
         optFrag.map { fragment =>
@@ -36,7 +39,7 @@ object ModalityRenderers {
       }
     }
 
-    def renderNormals(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer) : PixelImage[Option[Vector[_3D]]] = {
+    def renderNormals(parameters: RenderParameter) : PixelImage[Option[Vector[_3D]]] = {
       val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
       correspondenceImage.map{ optFrag =>
         optFrag.map{ fragment =>
@@ -45,13 +48,12 @@ object ModalityRenderers {
       }
     }
 
-    def renderNormalsVisualization(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
-      val normals = renderNormals(parameters, correspondenceMoMoRenderer)
+    def renderNormalsVisualization(parameters: RenderParameter, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
+      val normals = renderNormals(parameters)
       colorNormalImage(normals, clearColor)
-
     }
 
-    def renderAlbedo(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+    def renderAlbedo(parameters: RenderParameter, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
       val instance = correspondenceMoMoRenderer.instance(parameters)
       val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
       correspondenceImage.map { optFrag =>
@@ -61,7 +63,7 @@ object ModalityRenderers {
       }
     }
 
-    def renderIlluminationVisualization(parameters: RenderParameter, correspondenceMoMoRenderer: CorrespondenceMoMoRenderer, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
+    def renderIlluminationVisualization(parameters: RenderParameter, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
       val instance = correspondenceMoMoRenderer.instance(parameters)
       val noColorInst = instance.copy(color = SurfacePointProperty(instance.shape.triangulation, instance.color.pointData.map(_ => RGBA(0.5, 0.5, 0.5))))
       val correspondenceImage = correspondenceMoMoRenderer.renderCorrespondenceImage(parameters)
@@ -76,8 +78,11 @@ object ModalityRenderers {
   }
 
   object ParametricModelModalityRenderer {
+    def apply(parametricModel: ParametricModel) = new ParametricModelModalityRenderer(parametricModel)
+  }
+  class ParametricModelModalityRenderer( parametricModel: ParametricModel) {
 
-    def renderDepthMap(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: Option[Double] = None): PixelImage[Option[Double]] = {
+    def renderDepthMap(parameters: RenderParameter, clearColor: Option[Double] = None): PixelImage[Option[Double]] = {
       val instance = parametricModel.instance(parameters)
       ParametricRenderer.renderParameter(parameters, (triangleId: TriangleId,
                                                       worldBCC: BarycentricCoordinates,
@@ -86,7 +91,7 @@ object ModalityRenderers {
       }, clearColor)
     }
 
-    def renderNormals(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: Option[Vector[_3D]] = None): PixelImage[Option[Vector[_3D]]] = {
+    def renderNormals(parameters: RenderParameter, clearColor: Option[Vector[_3D]] = None): PixelImage[Option[Vector[_3D]]] = {
       val instance = parametricModel.instance(parameters)
       ParametricRenderer.renderParameter(parameters, (triangleId: TriangleId,
                                                       worldBCC: BarycentricCoordinates,
@@ -96,19 +101,19 @@ object ModalityRenderers {
         clearColor)
     }
 
-    def renderNormalsVisualization(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
-      val normals = renderNormals(parameters, parametricModel)
+    def renderNormalsVisualization(parameters: RenderParameter, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+      val normals = renderNormals(parameters)
       colorNormalImage(normals, clearColor)
     }
 
-    def renderAlbedo(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
+    def renderAlbedo(parameters: RenderParameter, clearColor: RGBA = RGBA.BlackTransparent) : PixelImage[RGBA] = {
       val instance = parametricModel.instance(parameters)
       ParametricRenderer.renderPropertyImage(parameters,
         instance.shape,
         instance.color).map(_.getOrElse(clearColor))
     }
 
-    def renderIlluminationVisualization(parameters: RenderParameter, parametricModel: ParametricModel, clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
+    def renderIlluminationVisualization(parameters: RenderParameter,clearColor: RGBA = RGBA.BlackTransparent): PixelImage[RGBA] = {
       val instance = parametricModel.instance(parameters)
       val noColorInst = instance.copy(color = SurfacePointProperty(instance.shape.triangulation, instance.color.pointData.map(_ => RGBA(0.5, 0.5, 0.5))))
       ParametricRenderer.renderParameterVertexColorMesh(

--- a/src/main/scala/scalismo/faces/sampling/face/ParametricModel.scala
+++ b/src/main/scala/scalismo/faces/sampling/face/ParametricModel.scala
@@ -16,10 +16,29 @@
 
 package scalismo.faces.sampling.face
 
+import breeze.linalg.DenseVector
 import scalismo.faces.mesh.VertexColorMesh3D
-import scalismo.faces.parameters.RenderParameter
+import scalismo.faces.momo.MoMo
+import scalismo.faces.parameters.{MoMoInstance, RenderParameter}
 
 /** generates a model instance in original model coordinates */
-trait ParametricModel {
-  def instance(parameters: RenderParameter): VertexColorMesh3D
+class ParametricModel(model: MoMo ) {
+  /** pad a coefficient vector if it is too short, basis with single vector */
+  private def padCoefficients(coefficients: DenseVector[Double], rank: Int): DenseVector[Double] = {
+    require(coefficients.length <= rank, "too many coefficients for model")
+    if (coefficients.length == rank)
+      coefficients
+    else
+      DenseVector(coefficients.toArray ++ Array.fill(rank - coefficients.length)(0.0))
+  }
+
+  /** create an instance of the model, in the original model's object coordinates */
+  def instance(parameters: RenderParameter): VertexColorMesh3D = {
+    instanceFromCoefficients(parameters.momo)
+  }
+
+  /** draw a model instance directly from the coefficients */
+  def instanceFromCoefficients(instance: MoMoInstance): VertexColorMesh3D = {
+    model.instance(instance.coefficients)
+  }
 }


### PR DESCRIPTION
Adding new renderer for:
- surface normals
- albedo
- illumination

I'm not sure if the albedo and illumination should be rendered more elegant. I tried over PixelShaders but there seems to be a hurdle from the two illumination models which are slighty hardcoded.