### PR TITLE
Fixes  #100 bug in MeshIO when writing OptionalColorNormalMesh without normals but with color

### DIFF
--- a/src/main/scala/scalismo/faces/io/MeshIO.scala
+++ b/src/main/scala/scalismo/faces/io/MeshIO.scala
@@ -60,7 +60,7 @@ object MeshIO {
         if (mesh.colorNormalMesh3D.isDefined)
           Try(PLYMesh.writePLY(mesh.colorNormalMesh3D.get, filename))
         else if (mesh.hasColor)
-          mesh.color match {
+          mesh.color.get match {
             case texture: TextureMappedProperty[RGBA] =>
               Try(PLYMesh.writePLY(mesh.copy(normals = Some(mesh.shape.vertexNormals)).colorNormalMesh3D.get, filename))
             case vertexColor: SurfacePointProperty[RGBA] =>


### PR DESCRIPTION
The change in the behavior is, that given there is color given as a `TextureMappedProperty[RGBA]` but no normals, we calculate the vertex normals based on the shape before writing the mesh to disk. This solves that given color but no normals only the shape was written to disk.