### PR TITLE
Functionality to write jpeg files with specified quality level

### DIFF
--- a/src/main/scala/scalismo/faces/io/PixelImageIO.scala
+++ b/src/main/scala/scalismo/faces/io/PixelImageIO.scala
@@ -16,6 +16,7 @@
 
 package scalismo.faces.io
 
+import java.awt.image.BufferedImage
 import java.io._
 
 import javax.imageio.stream.MemoryCacheImageOutputStream
@@ -50,23 +51,26 @@ object PixelImageIO {
     val bufImage = converter.toBufferedImage(image)
     file match {
       case f if f.getAbsolutePath.toLowerCase.endsWith(".png") => javax.imageio.ImageIO.write(bufImage, "png", file)
-      case f if f.getAbsolutePath.toLowerCase.endsWith(".jpg") => {
-        writeJPEGToStream(image, new FileOutputStream(file), 1.0)
-      }
+      case f if f.getAbsolutePath.toLowerCase.endsWith(".jpg") => writeJPEGToStream(bufImage, new FileOutputStream(file), 1.0f)
       case _ => throw new IOException("Unknown image format: " + file.getName)
     }
   }
 
   /** Write a JPEG image with a specified quality level where 1.0 is the maximally possible and 0 the minimal quality. */
-  def writeJPEGToStream[Pixel](image: PixelImage[Pixel], outputStream: OutputStream, quality: Double)(implicit converter: BufferedImageConverter[Pixel]): Try[Unit] = Try {
-    val bufImage = converter.toBufferedImage(image)
+  def writeJPEGToStream[Pixel](image: PixelImage[Pixel], outputStream: OutputStream, quality: Float)(implicit converter: BufferedImageConverter[Pixel]): Try[Unit] = Try {
+    val img = converter.toBufferedImage(image)
+    writeJPEGToStream(img, outputStream, quality)
+  }
+
+  /** Write a JPEG image with a specified quality level where 1.0 is the maximally possible and 0 the minimal quality. */
+  def writeJPEGToStream[Pixel](image: BufferedImage, outputStream: OutputStream, quality: Float): Try[Unit] = Try {
     val jpgWriter = javax.imageio.ImageIO.getImageWritersByFormatName("jpg").next()
     val jpgParams: ImageWriteParam = jpgWriter.getDefaultWriteParam
     jpgParams.setCompressionMode(ImageWriteParam.MODE_EXPLICIT)
     jpgParams.setCompressionQuality(quality.toFloat)
     val imageStream = new MemoryCacheImageOutputStream(outputStream)
     jpgWriter.setOutput(imageStream)
-    jpgWriter.write(null, new IIOImage(bufImage, null, null), jpgParams)
+    jpgWriter.write(null, new IIOImage(image, null, null), jpgParams)
     jpgWriter.dispose()
   }
 }

--- a/src/main/scala/scalismo/faces/io/PixelImageIO.scala
+++ b/src/main/scala/scalismo/faces/io/PixelImageIO.scala
@@ -16,8 +16,10 @@
 
 package scalismo.faces.io
 
-import java.io.{File, IOException, InputStream, OutputStream}
+import java.io._
 
+import javax.imageio.stream.MemoryCacheImageOutputStream
+import javax.imageio.{IIOImage, ImageWriteParam}
 import scalismo.faces.image.{BufferedImageConverter, PixelImage}
 
 import scala.util.Try
@@ -48,8 +50,23 @@ object PixelImageIO {
     val bufImage = converter.toBufferedImage(image)
     file match {
       case f if f.getAbsolutePath.toLowerCase.endsWith(".png") => javax.imageio.ImageIO.write(bufImage, "png", file)
-      case f if f.getAbsolutePath.toLowerCase.endsWith(".jpg") => javax.imageio.ImageIO.write(bufImage, "jpg", file)
+      case f if f.getAbsolutePath.toLowerCase.endsWith(".jpg") => {
+        writeJPEGToStream(image, new FileOutputStream(file), 1.0)
+      }
       case _ => throw new IOException("Unknown image format: " + file.getName)
     }
+  }
+
+  /** Write a JPEG image with a specified quality level where 1.0 is the maximally possible and 0 the minimal quality. */
+  def writeJPEGToStream[Pixel](image: PixelImage[Pixel], outputStream: OutputStream, quality: Double)(implicit converter: BufferedImageConverter[Pixel]): Try[Unit] = Try {
+    val bufImage = converter.toBufferedImage(image)
+    val jpgWriter = javax.imageio.ImageIO.getImageWritersByFormatName("jpg").next()
+    val jpgParams: ImageWriteParam = jpgWriter.getDefaultWriteParam
+    jpgParams.setCompressionMode(ImageWriteParam.MODE_EXPLICIT)
+    jpgParams.setCompressionQuality(quality.toFloat)
+    val imageStream = new MemoryCacheImageOutputStream(outputStream)
+    jpgWriter.setOutput(imageStream)
+    jpgWriter.write(null, new IIOImage(bufImage, null, null), jpgParams)
+    jpgWriter.dispose()
   }
 }


### PR DESCRIPTION
Currently, when writing JPEG images a quality level of 0.75 is chosen.

* Write jpg images with full quality (1.0) as default.
* Add functionality to choose quality level.

Code Schnippet that writes png and jpegs of varying quality:
```scala
object TestJpeg extends App {
  scalismo.initialize()
  val modelFn = new URI("file://...")
  val model = MoMoIO.read(modelFn).get
  val renderer = MoMoRenderer(model)

  val param = RenderParameter.defaultSquare
    .withMoMo(MoMoInstance.zero(model, modelFn)).withImageSize(ImageSize(100,100))

  val fnPng = new File("rendering.png")
  PixelImageIO.write(renderer.renderImage(param).map(_.toRGB), fnPng).get
  println(s"png file size: ${fnPng.length()}")

  for(quality <- 0.0 to 1.0 by 0.05) {
    val f = new File(f"rendering_${quality}%02f.jpg")
    val stream = new FileOutputStream(f)
    PixelImageIO.writeJPEGToStream(renderer.renderImage(param).map(_.toRGB), stream, quality).get
    println(f"jpg quality: ${quality}%02f, file size: ${f.length()}")
  }
}
```

> png file size: 10545
jpg quality: 0.000000, file size: 900
jpg quality: 0.250000, file size: 1367
jpg quality: 0.500000, file size: 1734
jpg quality: 0.750000, file size: 2168
jpg quality: 0.900000, file size: 3042
jpg quality: 0.950000, file size: 3938
jpg quality: 1.000000, file size: 6780
