### PR TITLE
Fixed wrong marginal function.

### DIFF
--- a/src/main/scala/scalismo/faces/momo/MoMo.scala
+++ b/src/main/scala/scalismo/faces/momo/MoMo.scala
@@ -97,11 +97,11 @@ trait MoMo {
   def sampleCoefficients()(implicit rnd: Random): MoMoCoefficients
 
   /**
-    * Compute the marginal on a set of points (masking).
+    * Mask the model using a set of points (masking).
     *
-    * @return the marginal model.
+    * @return the masked model.
     */
-  def marginal(pointIds: Seq[PointId]): MoMo
+  def mask(pointIds: Seq[PointId]): MoMo
 
   /**
     * Returns the same model but with exchanged or added landmarks.
@@ -499,16 +499,17 @@ case class MoMoExpress(override val referenceMesh: TriangleMesh3D,
   }
 
   /**
-    * Compute the marginal on a set of points (masking).
+    * Mask the model with a set of points.
     *
-    * @return the marginal model.
+    * @return the masked model.
     */
-  override def marginal(pointIds: Seq[PointId]): MoMo = {
+  override def mask(pointIds: Seq[PointId]): MoMo = {
     val op = referenceMesh.operations.maskPoints(id => pointIds.contains(id))
     val maskedMesh = op.transformedMesh
-    val maskedModelShape = shape.marginal(pointIds)
-    val maskedModelColor = color.marginal(pointIds)
-    val maskedModelExpressions = expression.marginal(pointIds)
+    val remainingPtIds = maskedMesh.pointSet.pointIds.map(id => op.pointBackMap(id)).toIndexedSeq
+    val maskedModelShape = shape.marginal(remainingPtIds)
+    val maskedModelColor = color.marginal(remainingPtIds)
+    val maskedModelExpressions = expression.marginal(remainingPtIds)
     MoMo(maskedMesh, maskedModelShape, maskedModelColor, maskedModelExpressions, landmarks)
   }
 
@@ -668,15 +669,16 @@ case class MoMoBasic(override val referenceMesh: TriangleMesh3D,
 
 
   /**
-    * Compute the marginal on a set of points (masking).
+    * Mask the model with a set of points (masking).
     *
-    * @return the marginal model.
+    * @return the masked model.
     */
-  override def marginal(pointIds: Seq[PointId]): MoMo = {
+  override def mask(pointIds: Seq[PointId]): MoMo = {
     val op = referenceMesh.operations.maskPoints(id => pointIds.contains(id))
     val maskedMesh = op.transformedMesh
-    val maskedModelShape = shape.marginal(pointIds)
-    val maskedModelColor = color.marginal(pointIds)
+    val remainingPtIds = maskedMesh.pointSet.pointIds.map(id => op.pointBackMap(id)).toIndexedSeq
+    val maskedModelShape = shape.marginal(remainingPtIds)
+    val maskedModelColor = color.marginal(remainingPtIds)
     MoMo(maskedMesh, maskedModelShape, maskedModelColor, landmarks)
   }
 

--- a/src/main/scala/scalismo/faces/momo/MoMo.scala
+++ b/src/main/scala/scalismo/faces/momo/MoMo.scala
@@ -97,13 +97,6 @@ trait MoMo {
   def sampleCoefficients()(implicit rnd: Random): MoMoCoefficients
 
   /**
-    * Mask the model using a set of points (masking).
-    *
-    * @return the masked model.
-    */
-  def mask(pointIds: Seq[PointId]): MoMo
-
-  /**
     * Returns the same model but with exchanged or added landmarks.
     *
     * @param landmarksMap Map of named landmarks.
@@ -499,21 +492,6 @@ case class MoMoExpress(override val referenceMesh: TriangleMesh3D,
   }
 
   /**
-    * Mask the model with a set of points.
-    *
-    * @return the masked model.
-    */
-  override def mask(pointIds: Seq[PointId]): MoMo = {
-    val op = referenceMesh.operations.maskPoints(id => pointIds.contains(id))
-    val maskedMesh = op.transformedMesh
-    val remainingPtIds = maskedMesh.pointSet.pointIds.map(id => op.pointBackMap(id)).toIndexedSeq
-    val maskedModelShape = shape.marginal(remainingPtIds)
-    val maskedModelColor = color.marginal(remainingPtIds)
-    val maskedModelExpressions = expression.marginal(remainingPtIds)
-    MoMo(maskedMesh, maskedModelShape, maskedModelColor, maskedModelExpressions, landmarks)
-  }
-
-  /**
     * Returns the same model but with exchanged or added landmarks.
     *
     * @param landmarksMap Map of named landmarks.
@@ -665,21 +643,6 @@ case class MoMoBasic(override val referenceMesh: TriangleMesh3D,
       shape.coefficientsDistribution.sample(),
       color.coefficientsDistribution.sample()
     )
-  }
-
-
-  /**
-    * Mask the model with a set of points (masking).
-    *
-    * @return the masked model.
-    */
-  override def mask(pointIds: Seq[PointId]): MoMo = {
-    val op = referenceMesh.operations.maskPoints(id => pointIds.contains(id))
-    val maskedMesh = op.transformedMesh
-    val remainingPtIds = maskedMesh.pointSet.pointIds.map(id => op.pointBackMap(id)).toIndexedSeq
-    val maskedModelShape = shape.marginal(remainingPtIds)
-    val maskedModelColor = color.marginal(remainingPtIds)
-    MoMo(maskedMesh, maskedModelShape, maskedModelColor, landmarks)
   }
 
   /**

--- a/src/main/scala/scalismo/faces/momo/ModelHelpers.scala
+++ b/src/main/scala/scalismo/faces/momo/ModelHelpers.scala
@@ -141,7 +141,7 @@ object ModelHelpers {
     val op = referenceMesh.operations.maskPoints(id => pointIds.contains(id))
     val maskedMesh = op.transformedMesh
 
-    if (strict && (maskedMesh.pointSet.numberOfPoints+pointIds.distinct.size != referenceMesh.pointSet.numberOfPoints) ) {
+    if (strict && (maskedMesh.pointSet.numberOfPoints != pointIds.distinct.size) ) {
       return Failure(new Exception(
         "Masking the model would remove additonal points not specified in the provided list of point ids.\n"+
         "Either provide a different list of point ids or set the parameter stict to false to mask the model."))
@@ -170,8 +170,8 @@ object ModelHelpers {
 
   def maskMoMo(momo : MoMo, maskMesh: TriangleMesh[_3D]): Try[MoMo] = {
 
-    val remainingPtIds = momo.referenceMesh.pointSet.points.map(p => maskMesh.pointSet.findClosestPoint(p).id).toIndexedSeq
-    val maskedReference = momo.referenceMesh.operations.maskPoints(remainingPtIds.contains)
+    val remainingPtIds = maskMesh.pointSet.points.map(p => momo.referenceMesh.pointSet.findClosestPoint(p).id).toIndexedSeq
+    val maskedReference = momo.referenceMesh.operations.maskPoints(pid => remainingPtIds.contains(pid)).transformedMesh
     if (maskMesh == maskedReference) {
       val maskedModelShape = momo.neutralModel.shape.marginal(remainingPtIds)
       val maskedModelColor = momo.neutralModel.color.marginal(remainingPtIds)


### PR DESCRIPTION
The marginal function to mask a MoMo gave wrong results. The reason was that the masked mesh can result in a different amount of PointIds. Since the mask MoMo function depends on the mesh in contrast to the marginal function for the GP, I would propose to rename it to  **mask()**.