### PR TITLE
Fixes #112 - Calculate vertex normals if not available in the file

### DIFF
--- a/src/main/scala/scalismo/faces/io/ply/PLYMesh.scala
+++ b/src/main/scala/scalismo/faces/io/ply/PLYMesh.scala
@@ -141,14 +141,12 @@ object PLYMesh {
 
     val colors = getSurfaceColor(vertexProperties, faceProperties, texture, triangles)
 
-    Try { // use stored vertex normals if available
-      val normals = getSurfaceNormal(vertexProperties, faceProperties, texture, triangles)
-      ColorNormalMesh3D(triangleMesh3D, colors, normals)
-
+    val normals = Try { // use stored vertex normals from file if available
+      getSurfaceNormal(vertexProperties, faceProperties, texture, triangles)
     }.getOrElse { // compute the vertex normals using the built mesh - note: this will fail if vertices without adjacent triangles exist
-      val normals = triangleMesh3D.vertexNormals
-      ColorNormalMesh3D(triangleMesh3D, colors, normals)
+      triangleMesh3D.vertexNormals
     }
+    ColorNormalMesh3D(triangleMesh3D, colors, normals)
 
   }
 

--- a/src/main/scala/scalismo/faces/io/ply/PLYMesh.scala
+++ b/src/main/scala/scalismo/faces/io/ply/PLYMesh.scala
@@ -140,10 +140,16 @@ object PLYMesh {
     val triangleMesh3D = TriangleMesh3D(points, triangles)
 
     val colors = getSurfaceColor(vertexProperties, faceProperties, texture, triangles)
-    val normals = getSurfaceNormal(vertexProperties, faceProperties, texture, triangles)
 
-    // building the mesh class
-    ColorNormalMesh3D(triangleMesh3D, colors, normals)
+    Try { // use stored vertex normals if available
+      val normals = getSurfaceNormal(vertexProperties, faceProperties, texture, triangles)
+      ColorNormalMesh3D(triangleMesh3D, colors, normals)
+
+    }.getOrElse { // compute the vertex normals using the built mesh - note: this will fail if vertices without adjacent triangles exist
+      val normals = triangleMesh3D.vertexNormals
+      ColorNormalMesh3D(triangleMesh3D, colors, normals)
+    }
+
   }
 
 

--- a/src/test/scala/scalismo/faces/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/faces/io/MeshIOTests.scala
@@ -145,8 +145,13 @@ class MeshIOTests extends FacesTestSuite {
     f.deleteOnExit()
     MeshIO.write(mesh, f).get
     val readMesh = MeshIO.read(f).get
+
+    val correctedMesh = if ( readMesh.normals.isDefined && !mesh.normals.isDefined){ // maybe normals are generated while reading
+      OptionalColorNormalMesh3D(readMesh.shape,readMesh.color,None)
+    } else readMesh
+
     testDiffOptionalColorNormalMesh3D(
-      readMesh,
+      correctedMesh,
       mesh
     )
   }


### PR DESCRIPTION
This pull request tries to read the vertex normals from the file. If they are not present, they are calculated from the already available triangle mesh.

Note: This method will fail if the mesh is not compact, i.e. if there are vertices which are not part of a triangle. However, this would need to be addressed in the vertex normal calculation and not the reader.