### PR TITLE
Upgrade to scalismo-0.17.0 from RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ organization  := "ch.unibas.cs.gravis"
 name := """scalismo-faces"""
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")) 
 
-scalaVersion  := "2.12.6"
+scalaVersion  := "2.12.8"
 
-crossScalaVersions := Seq("2.12.6", "2.11.8")
+crossScalaVersions := Seq("2.12.8", "2.11.8")
 
 scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2,  11)) =>  Seq("-deprecation", "-unchecked", "-feature")
@@ -14,7 +14,7 @@ scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
 resolvers += Resolver.jcenterRepo
 
 libraryDependencies  ++= Seq(
-    "ch.unibas.cs.gravis" %% "scalismo" % "0.17-RC1",
+    "ch.unibas.cs.gravis" %% "scalismo" % "0.17.0",
     "ch.unibas.cs.gravis" % "scalismo-native-all" % "4.0.0",
     "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.8


### PR DESCRIPTION
This PR updates the dependency from `scalismo-v0.17-RC1` to `scalismo-v0.17.0` and also updates the tooling (scala and sbt).