### PR TITLE
bugFix: sanitizing hue values when converting HSV to RGB

### DIFF
--- a/src/main/scala/scalismo/faces/color/HSV.scala
+++ b/src/main/scala/scalismo/faces/color/HSV.scala
@@ -67,8 +67,15 @@ object HSV {
       val m = 1.0 - l
       val h1 = obj1.hue
       val h2 = obj2.hue
+
+      val hue_nonSanitized = math.atan2(l * math.sin(h1) + m * math.cos(h1), l * math.sin(h2) + m * math.cos(h2))
+      val hue =   if(hue_nonSanitized < 0){
+        hue_nonSanitized % (2 * Math.PI) + (2 * Math.PI)
+      } else {
+        hue_nonSanitized % (2 * Math.PI)
+      }
       HSV(
-        math.atan2(l * math.sin(h1) + m * math.cos(h1), l * math.sin(h2) + m * math.cos(h2)),
+        hue,
         obj1.saturation * l + obj2.saturation * m,
         obj1.value * l + obj2.value * m
       )

--- a/src/main/scala/scalismo/faces/warp/WarpFieldVisualizer.scala
+++ b/src/main/scala/scalismo/faces/warp/WarpFieldVisualizer.scala
@@ -34,7 +34,13 @@ object WarpFieldVisualizer {
       // map len to value
       val value = len / maxLen
       val saturation = 1.0
-      val hue = dir
+
+      // since HSV to RGB conversion expects a number between 0 and 2 Pi, we need to sanitize dir (atan2 can return negative numbers)
+      val hue = if(dir < 0){
+        dir % (2 * Math.PI) + (2 * Math.PI)
+      } else {
+        dir % (2 * Math.PI)
+      }
       HSV(hue, saturation, value).toRGB
     }
     field.map(makeRGB)


### PR DESCRIPTION
conversion from HSV to RGB expects hue values between 0 and 2 Pi. At a couple of places the output of atan2 is passed as hue. This can triggers an exception since atan2 can return negative values. 

If accepted, I suggest this should be released as a hot-fix v0.10.2