### PR TITLE
Fixes #125 corrected backfaceCullingFilter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: scala
 env:
  - SCALISMO_PLATFORM=linux64
 
+jdk:
+  - openjdk8
+
 scala:
-  - 2.12.1
+  - 2.12.8
 
 script:
-  - jdk_switcher use oraclejdk8
   - travis_wait sbt ++$TRAVIS_SCALA_VERSION update
   - sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test

--- a/src/main/scala/scalismo/faces/parameters/ParametricRenderer.scala
+++ b/src/main/scala/scalismo/faces/parameters/ParametricRenderer.scala
@@ -20,6 +20,7 @@ import scalismo.color.RGBA
 import scalismo.faces.image.PixelImage
 import scalismo.faces.mesh.ColorNormalMesh3D
 import scalismo.faces.render.{PixelShader, TriangleFilters, TriangleRenderer, ZBuffer}
+import scalismo.geometry.Point3D
 import scalismo.mesh.{MeshSurfaceProperty, TriangleMesh3D, VertexColorMesh3D}
 
 import scala.reflect.ClassTag
@@ -39,7 +40,7 @@ object ParametricRenderer {
     val buffer = ZBuffer(parameter.imageSize.width, parameter.imageSize.height, clearColor)
 
     val worldMesh = mesh.transform(parameter.modelViewTransform)
-    val backfaceCullingFilter = TriangleFilters.backfaceCullingFilter(worldMesh.shape, parameter.view.eyePosition)
+    val backfaceCullingFilter = TriangleFilters.backfaceCullingFilter(worldMesh.shape, Point3D.origin)
 
     TriangleRenderer.renderMesh(
       mesh.shape,
@@ -66,7 +67,7 @@ object ParametricRenderer {
     val buffer = ZBuffer(parameter.imageSize.width, parameter.imageSize.height, clearColor)
 
     val worldMesh = mesh.transform(parameter.modelViewTransform)
-    val backfaceCullingFilter = TriangleFilters.backfaceCullingFilter(worldMesh.shape, parameter.view.eyePosition)
+    val backfaceCullingFilter = TriangleFilters.backfaceCullingFilter(worldMesh.shape, Point3D.origin)
 
     TriangleRenderer.renderMesh[A](
       mesh.shape,


### PR DESCRIPTION
The ParametricRenderer did a the backface culling wrong for settings where the camera is not in the origin. The worldMesh is the transformed mesh by applying the model-view transform. This transformation includes object pose and camera pose. Hence after this transformation the eye position is in the coordinate origin and no longer at the position specified in the RenderParameter.

This PR corrects the backfaceCullingFilter to use the origin instead of the RenderParameter.view.eyePosition.

EDIT: In addition this PR also updated the .travis.yml file so that the intergration check is now up and running again.