### PR TITLE
fixed bug regarding colorestimation in LoopyBPSegmentation

### DIFF
--- a/src/main/scala/scalismo/faces/segmentation/LoopyBPSegmentation.scala
+++ b/src/main/scala/scalismo/faces/segmentation/LoopyBPSegmentation.scala
@@ -126,13 +126,11 @@ object LoopyBPSegmentation {
       loopyBeliefPropagationPass(messageField, localMessages, binaryDistribution, numLabels)
       val belief = calculateBelief(unsafeMsgFieldView, localMessages)
 
+      colorDistributions = estimateColorDistributions(image, belief)
+
       if(gui) {
         // gui update
-        if (i%1 == 0) {
-          colorDistributions = estimateColorDistributions(image, belief)
-          println(colorDistributions)
-        }
-
+        println(colorDistributions)
         counterLabel.setText("iteration: " + i)
         stack(
           counterLabel,


### PR DESCRIPTION
The code for estimating colorDistribution is only called when the flag to show the gui is set to true. This leads to incorrect segmentations when the gui is not shown. The fix was is to simply call the corresponding function before the if-block is entered.