### PR TITLE
Replace spray with ujson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,7 @@ lazy val root = (project in file("."))
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
       "ch.unibas.cs.gravis" %% "scalismo" % "0.92-RC1",
-      "org.scalatest" %% "scalatest" % "3.2.15" % Test,
-      "io.spray" %% "spray-json" % "1.3.6"
+      "org.scalatest" %% "scalatest" % "3.2.15" % Test
     )
   )
   .enablePlugins(BuildInfoPlugin)

--- a/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatLegacy.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatLegacy.scala
@@ -17,308 +17,92 @@
 package scalismo.faces.io.renderparameters
 
 import java.net.URI
-
 import scalismo.color.{RGB, RGBA}
-import scalismo.faces.parameters._
-import scalismo.faces.mesh._
-import scalismo.geometry._
+import scalismo.faces.io.renderparameters.fromats.DirectLightLegacySerializationFormat
+import scalismo.faces.parameters.*
+import scalismo.faces.mesh.*
+import scalismo.geometry.*
 
-import spray.json._
+import scala.util.Try
+import scala.util.Success
+import scala.util.Failure
+import upickle.default.{read, writeJs as write}
 
-/** legacy JSON format for RenderParameter, compatible to C++, uses spray's AST but no typeclass conversions */
-trait RenderParameterJSONFormatLegacy extends DefaultJsonProtocol {
-  val version = "V1.0"
+object RenderParameterJSONFormatLegacy extends RenderParameterRootJsonFormat {
 
-  implicit val vector1DFormat: JsonFormat[EuclideanVector[_1D]] = new JsonFormat[EuclideanVector[_1D]] {
-    override def write(vec: EuclideanVector[_1D]): JsValue = JsArray(JsNumber(vec.x))
+  override val version = "1.0"
 
-    override def read(json: JsValue): EuclideanVector[_1D] = json match {
-      case JsArray(Seq(JsNumber(x))) => EuclideanVector(x.toDouble)
-      case _                         => deserializationError("Expected EuclideanVector[_1D], got:" + json)
-    }
-  }
+  import scalismo.faces.io.renderparameters.fromats.RenderParameterJSONFormats.directionalLightMapper
+  import scalismo.faces.io.renderparameters.fromats.RenderParameterJSONFormats.poseMapper
 
-  implicit val vector2DFormat: JsonFormat[EuclideanVector[_2D]] = new JsonFormat[EuclideanVector[_2D]] {
-    override def write(vec: EuclideanVector[_2D]): JsValue = JsArray(JsNumber(vec.x), JsNumber(vec.y))
+  import fromats.SphericalHarmonicsLegacyFormat
+  import fromats.MoMoInstanceLegacyFormat
+  import fromats.LegacyCameraFormat
+  import fromats.ColorTransformLegacyFormat
 
-    override def read(json: JsValue): EuclideanVector[_2D] = json match {
-      case JsArray(Seq(JsNumber(x), JsNumber(y))) => EuclideanVector(x.toDouble, y.toDouble)
-      case _                                      => deserializationError("Expected EuclideanVector[_2D], got:" + json)
-    }
-  }
-
-  implicit val vector3DFormat: JsonFormat[EuclideanVector[_3D]] = new JsonFormat[EuclideanVector[_3D]] {
-    override def write(vec: EuclideanVector[_3D]): JsValue = JsArray(JsNumber(vec.x), JsNumber(vec.y), JsNumber(vec.z))
-
-    override def read(json: JsValue): EuclideanVector[_3D] = json match {
-      case JsArray(Seq(JsNumber(x), JsNumber(y), JsNumber(z))) => EuclideanVector(x.toDouble, y.toDouble, z.toDouble)
-      case _ => deserializationError("Expected EuclideanVector[_3D], got:" + json)
-    }
-  }
-
-  implicit val rgbFormat: JsonFormat[RGB] = new JsonFormat[RGB] {
-    override def write(col: RGB): JsValue = JsArray(JsNumber(col.r), JsNumber(col.g), JsNumber(col.b))
-
-    override def read(json: JsValue): RGB = json match {
-      case JsArray(Seq(JsNumber(r), JsNumber(g), JsNumber(b))) => RGB(r.toDouble, g.toDouble, b.toDouble)
-      case _                                                   => deserializationError(s"Expected RGB, got: $json")
-    }
-  }
-
-  implicit val rgbaFormat: JsonFormat[RGBA] = new JsonFormat[RGBA] {
-    override def write(col: RGBA): JsValue = JsArray(JsNumber(col.r), JsNumber(col.g), JsNumber(col.b), JsNumber(col.a))
-
-    override def read(json: JsValue): RGBA = json match {
-      case JsArray(Seq(JsNumber(r), JsNumber(g), JsNumber(b), JsNumber(a))) =>
-        RGBA(r.toDouble, g.toDouble, b.toDouble, a.toDouble)
-      case _ => deserializationError(s"Expected RGBA, got: $json")
-    }
-  }
-
-  implicit val uriFormat: JsonFormat[URI] = new JsonFormat[URI] {
-    override def read(json: JsValue): URI = json match {
-      case JsString(uri) => new URI(uri)
-      case _             => throw DeserializationException(s"expected URI, got $json")
-    }
-
-    override def write(obj: URI): JsValue = JsString(obj.toString)
-  }
-
-  implicit val colorFormat: RootJsonFormat[ColorTransform] = new RootJsonFormat[ColorTransform] {
-    override def write(color: ColorTransform): JsValue =
-      JsObject("gain" -> color.gain.toJson, "gamma" -> color.colorContrast.toJson, "offset" -> color.offset.toJson)
-
-    override def read(json: JsValue): ColorTransform = {
-      val fields = json.asJsObject(s"expected Color object, got: $json").fields
-      ColorTransform(gain = fields("gain").convertTo[RGB],
-                     colorContrast = fields("gamma").convertTo[Double],
-                     offset = fields("offset").convertTo[RGB]
-      )
-    }
-  }
-
-  implicit val poseFormat: RootJsonFormat[Pose] = new RootJsonFormat[Pose] {
-    override def write(p: Pose): JsValue = JsObject(("scaling", p.scaling.toJson),
-                                                    ("translation", p.translation.toJson),
-                                                    ("roll", p.roll.toJson),
-                                                    ("yaw", p.yaw.toJson),
-                                                    ("pitch", p.pitch.toJson)
+  implicit val imageSizeLegacyMapper: upickle.default.ReadWriter[ImageSize] = upickle.default
+    .readwriter[List[Int]]
+    .bimap[ImageSize](
+      is => List(is.height, is.width),
+      l => ImageSize(l(1), l(0))
     )
 
-    override def read(json: JsValue): Pose = {
-      val fields = json.asJsObject(s"expected Pose object, got: $json").fields
-      Pose(
-        scaling = fields("scaling").convertTo[Double],
-        translation = fields("translation").convertTo[EuclideanVector[_3D]],
-        roll = fields("roll").convertTo[Double],
-        yaw = fields("yaw").convertTo[Double],
-        pitch = fields("pitch").convertTo[Double]
-      )
-    }
-  }
+  implicit val colorTransformLegacyMapper: upickle.default.ReadWriter[ColorTransform] = upickle.default
+    .readwriter[ColorTransformLegacyFormat]
+    .bimap[ColorTransform](
+      ct => ColorTransformLegacyFormat(ct),
+      ctl => ctl.toColorTransform()
+    )
 
-  private case class LegacyCamera(far: Double,
-                                  focalLength: Double,
-                                  near: Double,
-                                  orthographic: Boolean,
-                                  pitch: Double,
-                                  principlePoint: EuclideanVector[_2D],
-                                  roll: Double,
-                                  sensorSize: EuclideanVector[_2D],
-                                  skewFactor: Double,
-                                  translation: EuclideanVector[_3D],
-                                  yaw: Double
+  case class RenderParameterLegacy(
+    camera: LegacyCameraFormat,
+    color: ColorTransformLegacyFormat,
+    directionalLight: DirectLightLegacySerializationFormat,
+    image: ImageSize,
+    morphableModel: MoMoInstanceLegacyFormat,
+    pose: Pose,
+    sphericalHarmonicsLight: SphericalHarmonicsLegacyFormat
   ) {
-    def toCamera(imageSize: ImageSize): Camera = {
-      val pp = Point(2 * principlePoint.x / imageSize.width, 2 * principlePoint.y / imageSize.height)
-      Camera(
-        focalLength,
-        pp,
-        sensorSize / near,
-        near = near,
-        far = far,
-        orthographic = orthographic
-      )
-    }
-
-    def toView: ViewParameter = ViewParameter(
-      translation = translation,
-      pitch = pitch,
-      yaw = yaw,
-      roll = roll
-    )
-  }
-
-  private object LegacyCamera {
-    def apply(cam: Camera, imageSize: ImageSize, view: ViewParameter): LegacyCamera = {
-      val pp = Point(0.5 * imageSize.width * cam.principalPoint.x, 0.5 * imageSize.height * cam.principalPoint.y)
-      new LegacyCamera(
-        far = cam.far,
-        focalLength = cam.focalLength,
-        near = cam.near,
-        orthographic = cam.orthographic,
-        pitch = view.pitch,
-        principlePoint = pp.toVector,
-        roll = view.roll,
-        sensorSize = cam.sensorSize * cam.near,
-        skewFactor = 1.0,
-        translation = view.translation,
-        yaw = view.yaw
-      )
-    }
-  }
-
-  implicit private val legacyCameraFormat: RootJsonFormat[LegacyCamera] = jsonFormat11(LegacyCamera.apply)
-
-  implicit val imageFormat: JsonFormat[ImageSize] = new JsonFormat[ImageSize] {
-    override def write(img: ImageSize): JsValue = JsArray(JsNumber(img.height), JsNumber(img.width))
-
-    override def read(json: JsValue): ImageSize = json match {
-      // warning: order of width and height is not as expected!!
-      case JsArray(Seq(JsNumber(height), JsNumber(width))) => ImageSize(width.toInt, height.toInt)
-      case _                                               => deserializationError("Expected Image, got:" + json)
-    }
-  }
-
-  implicit val directionalLightFormat: RootJsonFormat[DirectionalLight] = new RootJsonFormat[DirectionalLight] {
-    override def write(light: DirectionalLight): JsValue = JsObject(("ambient", light.ambient.toJson),
-                                                                    ("diffuse", light.diffuse.toJson),
-                                                                    ("direction", light.direction.toJson),
-                                                                    ("specular", light.specular.toJson)
-    )
-
-    override def read(json: JsValue): DirectionalLight = {
-      val fields = json.asJsObject(s"expected DirectionalLight object, got: $json").fields
-      DirectionalLight(
-        ambient = fields("ambient").convertTo[RGB],
-        diffuse = fields("diffuse").convertTo[RGB],
-        direction = fields("direction").convertTo[EuclideanVector[_3D]],
-        specular = fields("specular").convertTo[RGB]
-      )
-    }
-  }
-
-  private case class MoMoInstanceLegacy(shapeCoefficients: IndexedSeq[Double],
-                                        colorCoefficients: IndexedSeq[Double],
-                                        modelURI: URI,
-                                        shininess: Double
-  ) {
-    def toMoMoInstance = MoMoInstance(shapeCoefficients, colorCoefficients, IndexedSeq.empty, modelURI)
-  }
-
-  private object MoMoInstanceLegacy {
-    def apply(momo: MoMoInstance, shininess: Double): MoMoInstanceLegacy =
-      MoMoInstanceLegacy(momo.shape, momo.color, momo.modelURI, shininess)
-  }
-
-  implicit private val momoLegacyFormat: RootJsonFormat[MoMoInstanceLegacy] = jsonFormat4(MoMoInstanceLegacy.apply)
-
-  implicit val sphericalHarmonicsLightFormat: RootJsonFormat[SphericalHarmonicsLight] =
-    new RootJsonFormat[SphericalHarmonicsLight] {
-
-      override def write(shl: SphericalHarmonicsLight): JsValue = {
-        def convertSHLToJz(shl: IndexedSeq[EuclideanVector[_3D]]): IndexedSeq[EuclideanVector[_3D]] = {
-          if (shl.isEmpty)
-            shl
-          else if (shl.size > 9)
-            throw new SerializationException(
-              "SHL json writer (V1): cannot write more than 9 coefficients in jz format (use modern version)"
-            )
-          else {
-            // 1 - 9 coefficients
-            val permutation = IndexedSeq(0, 3, 1, 2, 6, 5, 7, 4, 8).take(shl.size)
-            permutation map (i => shl(i))
-          }
-        }
-
-        convertSHLToJz(shl.coefficients).toJson
-      }
-
-      override def read(value: JsValue): SphericalHarmonicsLight = {
-        // need to convert from V1 order to our own order (jz order -> ss order)
-        def convertJzToSHL(shl: IndexedSeq[EuclideanVector[_3D]]): IndexedSeq[EuclideanVector[_3D]] = {
-          if (shl.isEmpty)
-            shl
-          else if (shl.size > 9)
-            throw DeserializationException(
-              "SHL json reader (V1): cannot read more than 2 bands (9 coeffs), there is no conversion from jz to our format"
-            )
-          else {
-            // 1 - 0 coeffs
-            val permutation = IndexedSeq(0, 2, 3, 1, 7, 5, 4, 6, 8).take(shl.size)
-            permutation map (i => shl(i))
-          }
-        }
-
-        val shl = value.convertTo[IndexedSeq[EuclideanVector[_3D]]]
-        SphericalHarmonicsLight(convertJzToSHL(shl))
-      }
-    }
-
-  implicit val renderParameterFormat: RootJsonFormat[RenderParameter] = new RootJsonFormat[RenderParameter] {
-
-    override def write(param: RenderParameter): JsValue = {
-
-      val shLight = param.environmentMap
-      val dirLight = if (shLight.nonEmpty) DirectionalLight.off else param.directionalLight
-
-      val momoInst: MoMoInstanceLegacy = MoMoInstanceLegacy(param.momo, dirLight.shininess)
-
-      val legacyCamera = LegacyCamera(param.camera, param.imageSize, param.view)
-
-      JsObject(
-        ("camera", legacyCamera.toJson),
-        ("color", param.colorTransform.toJson),
-        ("directionalLight", dirLight.toJson),
-        ("image", param.imageSize.toJson),
-        ("morphableModel", momoInst.toJson),
-        ("pose", param.pose.toJson),
-        ("sphericalHarmonicsLight", shLight.toJson)
-      )
-    }
-
-    override def read(json: JsValue): RenderParameter = {
-      val fields = json.asJsObject(s"expected RenderParameter object, got: $json").fields
-
-      // V1.0: missing version field
-      if (fields.contains("version")) {
-        val version = fields("version").convertTo[String]
-        if (version != "1.0")
-          throw DeserializationException(s"V1 json reader expects V1.0 json file, got: $version")
-      }
-
-      // parse illumination: SHL overrides directed light
-      val momoLegacy = fields("morphableModel").convertTo[MoMoInstanceLegacy]
-      val momo = momoLegacy.toMoMoInstance
-
-      val shLight = fields("sphericalHarmonicsLight").convertTo[SphericalHarmonicsLight]
-      val dirLight =
-        if (shLight.nonEmpty) DirectionalLight.off
-        else fields("directionalLight").convertTo[DirectionalLight].copy(shininess = momoLegacy.shininess)
-
-      val illumination = if (shLight.nonEmpty) shLight else dirLight
-
-      val pose = fields("pose").convertTo[Pose]
-      val imageSize = fields("image").convertTo[ImageSize]
-      val color = fields("color").convertTo[ColorTransform]
-
-      // legacy camera format
-      val legCam = fields("camera").convertTo[LegacyCamera]
-      val cam = legCam.toCamera(imageSize)
-      val view = legCam.toView
-
+    def toRenderParameter(): RenderParameter = {
       RenderParameter(
         pose = pose,
-        view = view,
-        camera = cam,
-        environmentMap = shLight,
-        directionalLight = dirLight,
-        momo = momo,
-        imageSize = imageSize,
-        colorTransform = color
+        view = camera.toView,
+        camera = camera.toCamera(image),
+        environmentMap = sphericalHarmonicsLight.toSphericalHarmonics(),
+        directionalLight =
+          if (sphericalHarmonicsLight.coefficients.nonEmpty)
+            DirectionalLight.off
+          else
+            directionalLight.toDirectionalLight(morphableModel.shininess),
+        momo = morphableModel.toMoMoInstance,
+        imageSize = image,
+        colorTransform = color.toColorTransform()
       )
     }
   }
-}
 
-object RenderParameterJSONFormatLegacy extends RenderParameterJSONFormatLegacy
+  object RenderParameterLegacy {
+    def apply(rps: RenderParameter) = new RenderParameterLegacy(
+      LegacyCameraFormat(rps.camera, rps.imageSize, rps.view),
+      ColorTransformLegacyFormat(rps.colorTransform),
+      if (rps.environmentMap.coefficients.nonEmpty)
+        DirectLightLegacySerializationFormat(DirectionalLight.off)
+      else
+        DirectLightLegacySerializationFormat(rps.directionalLight),
+      rps.imageSize,
+      MoMoInstanceLegacyFormat(rps.momo, rps.directionalLight.shininess),
+      rps.pose,
+      SphericalHarmonicsLegacyFormat(rps.environmentMap)
+    )
+
+    implicit val rpsLegacyMapper: upickle.default.ReadWriter[RenderParameterLegacy] = upickle.default.macroRW
+
+  }
+
+  implicit val rpsMapper: upickle.default.ReadWriter[RenderParameter] = upickle.default
+    .readwriter[RenderParameterLegacy]
+    .bimap[RenderParameter](
+      rps => RenderParameterLegacy(rps),
+      rpsLegacy => rpsLegacy.toRenderParameter()
+    )
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatV2.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterJSONFormatV2.scala
@@ -17,590 +17,164 @@
 package scalismo.faces.io.renderparameters
 
 import java.net.URI
-
 import scalismo.common.PointId
 import scalismo.color.{ColorSpaceOperations, RGB, RGBA}
-import scalismo.faces.image._
-import scalismo.faces.mesh._
-import scalismo.faces.parameters._
-import scalismo.geometry._
-import scalismo.mesh._
+import scalismo.faces.image.*
+import scalismo.faces.mesh.*
+import scalismo.faces.parameters.*
+import scalismo.geometry.*
+import scalismo.mesh.*
 import scalismo.numerics.ValueInterpolator
-import spray.json._
+
+import scalismo.faces.io.renderparameters.fromats.RenderParameterJSONFormats._
 
 import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
 
-/** JSON object format with variable renderables and illumination */
-trait RenderParameterJSONFormatV2 extends RenderParameterJSONFormatLegacy {
+import upickle.default.{read, writeJs as write}
+
+object RenderParameterJSONFormatV2 extends RenderParameterRootJsonFormat {
+
   override val version = "V2.0"
 
-  // momo express writer and reader
-  protected case class MoMoInstanceV2(shape: IndexedSeq[Double], color: IndexedSeq[Double], modelURI: URI) {
-    def toMoMoInstance = MoMoInstance(shape, color, IndexedSeq.empty, modelURI)
-  }
+  import fromats.ColorTransformLegacyFormat
+  import scalismo.faces.io.renderparameters.fromats.RenderParameterJSONFormats.imageSizeMapper
+  import scalismo.faces.io.renderparameters.fromats.CameraFormatV2
+  import scalismo.faces.io.renderparameters.fromats.MeshFileFormat
 
-  // momo writer and reader
-  implicit protected val momoInstanceV2Format: RootJsonFormat[MoMoInstanceV2] = new RootJsonFormat[MoMoInstanceV2] {
-    def write(momo: MoMoInstanceV2): JsValue = JsObject(("shape", momo.shape.toJson),
-                                                        ("color", momo.color.toJson),
-                                                        ("modelURI", momo.modelURI.toJson),
-                                                        ("@type", "MoMoInstance".toJson)
-    )
-
-    def read(json: JsValue): MoMoInstanceV2 = {
-      val fields = json.asJsObject(s"expected MoMoInstance object, got: $json").fields
-      MoMoInstanceV2(shape = fields("shape").convertTo[IndexedSeq[Double]],
-                     color = fields("color").convertTo[IndexedSeq[Double]],
-                     modelURI = fields("modelURI").convertTo[URI]
-      )
-    }
-  }
-
-  // momo instance writer and reader: maps to a MoMoExpressInstance in this format
-  implicit val momoInstanceFormat: RootJsonFormat[MoMoInstance] = new RootJsonFormat[MoMoInstance] {
-    def write(momo: MoMoInstance): JsValue = momoExpressInstanceV2Format.write(MoMoExpressInstanceV2(momo))
-    def read(json: JsValue): MoMoInstance = json.convertTo[MoMoExpressInstanceV2].toMoMoInstance
-  }
-
-  // momo express writer and reader
-  protected case class MoMoExpressInstanceV2(shape: IndexedSeq[Double],
-                                             color: IndexedSeq[Double],
-                                             expression: IndexedSeq[Double],
-                                             modelURI: URI
-  ) {
-    def toMoMoInstance = MoMoInstance(shape, color, expression, modelURI)
-  }
-
-  protected object MoMoExpressInstanceV2 {
-    def apply(momo: MoMoInstance): MoMoExpressInstanceV2 =
-      MoMoExpressInstanceV2(momo.shape, momo.color, momo.expression, momo.modelURI)
-  }
-
-  implicit protected val momoExpressInstanceV2Format: RootJsonFormat[MoMoExpressInstanceV2] =
-    new RootJsonFormat[MoMoExpressInstanceV2] {
-      def write(momo: MoMoExpressInstanceV2): JsValue = JsObject(
-        ("shape", momo.shape.toJson),
-        ("color", momo.color.toJson),
-        ("expression", momo.expression.toJson),
-        ("modelURI", momo.modelURI.toJson),
-        ("@type", "MoMoExpressInstance".toJson)
-      )
-
-      override def read(json: JsValue): MoMoExpressInstanceV2 = {
-        val fields = json.asJsObject(s"expected MoMoInstance object, got: $json").fields
-        MoMoExpressInstanceV2(
-          shape = fields("shape").convertTo[IndexedSeq[Double]],
-          color = fields("color").convertTo[IndexedSeq[Double]],
-          expression = fields("expression").convertTo[IndexedSeq[Double]],
-          modelURI = fields("modelURI").convertTo[URI]
-        )
-      }
-    }
-
-  // mesh file
-  implicit val meshFileFormat: RootJsonFormat[MeshFile] = new RootJsonFormat[MeshFile] {
-    override def write(meshFile: MeshFile): JsValue = JsObject(
-      ("meshURI", meshFile.meshURI.toJson),
-      ("@type", "MeshFile".toJson)
-    )
-
-    override def read(json: JsValue): MeshFile = {
-      val fields = json.asJsObject(s"expected MeshFile object, got: $json").fields
-      MeshFile(
-        meshURI = fields("meshURI").convertTo[URI]
-      )
-    }
-  }
-
-  implicit val triangleCellFormat: JsonFormat[TriangleCell] = new JsonFormat[TriangleCell] {
-    override def read(json: JsValue): TriangleCell = json match {
-      case JsArray(Seq(JsNumber(p1), JsNumber(p2), JsNumber(p3))) =>
-        TriangleCell(PointId(p1.toInt), PointId(p2.toInt), PointId(p3.toInt))
-      case _ => throw new DeserializationException(s"expected TriangleCell, got $json")
-    }
-
-    override def write(obj: TriangleCell): JsValue =
-      JsArray(obj.ptId1.id.toJson, obj.ptId2.id.toJson, obj.ptId3.id.toJson)
-  }
-
-  implicit def surfacePointPropertyFormat[A](implicit
-    formatA: JsonFormat[A],
-    interpolator: ValueInterpolator[A]
-  ): RootJsonFormat[SurfacePointProperty[A]] = new RootJsonFormat[SurfacePointProperty[A]] {
-    override def read(json: JsValue): SurfacePointProperty[A] = {
-      val fields = json.asJsObject(s"expected SurfacePointProperty, got $json").fields
-
-      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
-      val triangulation = TriangleList(triangles)
-
-      val pointData = fields("pointData").convertTo[IndexedSeq[A]]
-
-      SurfacePointProperty(
-        triangulation = triangulation,
-        pointData = pointData
-      )
-    }
-
-    override def write(obj: SurfacePointProperty[A]): JsValue = {
-      JsObject(
-        "triangles" -> obj.triangulation.triangles.toJson,
-        "pointData" -> obj.pointData.toJson,
-        "@type" -> "SurfacePointProperty".toJson
-      )
-    }
-  }
-
-  implicit def trianglePropertyFormat[A](implicit formatA: JsonFormat[A]): RootJsonFormat[TriangleProperty[A]] =
-    new RootJsonFormat[TriangleProperty[A]] {
-      override def read(json: JsValue): TriangleProperty[A] = {
-        val fields = json.asJsObject(s"expected TriangleProperty, got $json").fields
-
-        val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
-        val triangulation = TriangleList(triangles)
-
-        val triangleData = fields("triangleData").convertTo[IndexedSeq[A]]
-
-        TriangleProperty(
-          triangulation = triangulation,
-          triangleData = triangleData
-        )
-      }
-
-      override def write(obj: TriangleProperty[A]): JsValue = {
-        JsObject(
-          "triangles" -> obj.triangulation.triangles.toJson,
-          "triangleData" -> obj.triangleData.toJson,
-          "@type" -> "TriangleProperty".toJson
-        )
-      }
-    }
-
-  implicit def vertexPropertyPerTriangleFormat[A](implicit
-    formatA: JsonFormat[A],
-    interpolator: ValueInterpolator[A]
-  ): RootJsonFormat[VertexPropertyPerTriangle[A]] = new RootJsonFormat[VertexPropertyPerTriangle[A]] {
-    override def read(json: JsValue): VertexPropertyPerTriangle[A] = {
-      val fields = json.asJsObject(s"expected VertexPropertyPerTriangle, got $json").fields
-
-      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
-      val triangulation = TriangleList(triangles)
-
-      val pointData = fields("pointData").convertTo[IndexedSeq[A]]
-      val triangleIndex =
-        fields("triangleIndex").convertTo[IndexedSeq[(Int, Int, Int)]].map { case (i, j, k) => IntVector3D(i, j, k) }
-
-      VertexPropertyPerTriangle(triangulation, triangleIndex, pointData)
-    }
-
-    override def write(obj: VertexPropertyPerTriangle[A]): JsValue = JsObject(
-      "triangles" -> obj.triangulation.triangles.toJson,
-      "pointData" -> obj.vertexData.toJson,
-      "triangleIndex" -> obj.triangleVertexIndex.map { v => (v.i, v.j, v.k) }.toJson,
-      "@type" -> "VertexPropertyPerTriangle".toJson
-    )
-  }
-
-  implicit def pixelImageFormat[A: ClassTag](implicit formatA: JsonFormat[A]): RootJsonFormat[PixelImage[A]] =
-    new RootJsonFormat[PixelImage[A]] {
-      override def read(json: JsValue): PixelImage[A] = {
-        val fields = json.asJsObject(s"expected PixelImage, got $json").fields
-
-        val width = fields("width").convertTo[Int]
-        val height = fields("height").convertTo[Int]
-        val data = fields("data").convertTo[IndexedSeq[A]]
-        val domain = fields("domainMode").convertTo[String] match {
-          case "ColumnMajor" => ColumnMajorImageDomain(width, height)
-          case "RowMajor"    => RowMajorImageDomain(width, height)
-          case s: String     => throw new DeserializationException(s"unknown image domain mode: $s")
+  implicit val illuminationMapper: upickle.default.ReadWriter[Illumination] = upickle.default
+    .readwriter[ujson.Value]
+    .bimap[Illumination](
+      {
+        case dl: DirectionalLight => {
+          val js = write(dl)
+          js("@type") = "DirectionalLight"
+          js
         }
-
-        PixelImage(domain, data).withAccessMode(AccessMode.Repeat())
+        case shl: SphericalHarmonicsLight => {
+          val js = write(shl)
+          js("@type") = "SphericalHarmonicsLight"
+          js
+        }
+      },
+      j => {
+        val typeValue = j("@type").str
+        typeValue match {
+          case "DirectionalLight"        => read[DirectionalLight](j)
+          case "SphericalHarmonicsLight" => read[SphericalHarmonicsLight](j)
+        }
       }
-
-      override def write(obj: PixelImage[A]): JsValue = JsObject(
-        "width" -> obj.width.toJson,
-        "height" -> obj.height.toJson,
-        "domainMode" -> (obj.domain match {
-          case d: ColumnMajorImageDomain => "ColumnMajor"
-          case d: RowMajorImageDomain    => "RowMajor"
-        }).toJson,
-        "data" -> obj.values.toIndexedSeq.toJson
-      )
-    }
-
-  implicit val point2DFormat: JsonFormat[Point[_2D]] = new JsonFormat[Point[_2D]] {
-    override def write(vec: Point[_2D]): JsValue = JsArray(JsNumber(vec.x), JsNumber(vec.y))
-
-    override def read(json: JsValue): Point[_2D] = json match {
-      case JsArray(Seq(JsNumber(x), JsNumber(y))) => Point(x.toDouble, y.toDouble)
-      case _                                      => deserializationError("Expected Point[_2D], got:" + json)
-    }
-  }
-
-  implicit val colSpaceOps2D: ColorSpaceOperations[Point[_2D]] = new ColorSpaceOperations[Point[_2D]] {
-    override def add(pix1: Point[_2D], pix2: Point[_2D]): Point[_2D] = (pix1.toVector + pix2.toVector).toPoint
-    override def multiply(pix1: Point[_2D], pix2: Point[_2D]): Point[_2D] = Point(pix1.x * pix2.x, pix1.y * pix2.y)
-    override def dot(pix1: Point[_2D], pix2: Point[_2D]): Double = pix1.toVector.dot(pix2.toVector)
-    override def dimensionality: Int = 2
-    override def scale(pix: Point[_2D], l: Double): Point[_2D] = (pix.toVector * l).toPoint
-    override def zero: Point[_2D] = Point2D.origin
-  }
-
-  implicit def textureMappedPropertyFormat[A: ClassTag](implicit
-    formatA: JsonFormat[A],
-    interpolator: ValueInterpolator[A],
-    colorSpaceOperations: ColorSpaceOperations[A]
-  ): RootJsonFormat[TextureMappedProperty[A]] = new RootJsonFormat[TextureMappedProperty[A]] {
-    override def read(json: JsValue): TextureMappedProperty[A] = {
-      val fields = json.asJsObject(s"expected TextureMappedProperty, got $json").fields
-
-      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
-      val triangulation = TriangleList(triangles)
-
-      val textureMapping = fields("textureMapping").convertTo[MeshSurfaceProperty[Point[_2D]]]
-      val texture = fields("texture").convertTo[PixelImage[A]]
-
-      TextureMappedProperty(triangulation, textureMapping, texture)
-    }
-
-    override def write(obj: TextureMappedProperty[A]): JsValue = JsObject(
-      "triangles" -> obj.triangulation.triangles.toJson,
-      "textureMapping" -> obj.textureMapping.toJson,
-      "texture" -> obj.texture.toJson,
-      "@type" -> "TextureMappedProperty".toJson
-    )
-  }
-
-  implicit def indirectPropertyFormat[A: ClassTag](implicit
-    formatA: JsonFormat[A],
-    interpolator: ValueInterpolator[A],
-    colorSpaceOperations: ColorSpaceOperations[A]
-  ): RootJsonFormat[IndirectProperty[A]] = new RootJsonFormat[IndirectProperty[A]] {
-    override def read(json: JsValue): IndirectProperty[A] = {
-      val fields = json.asJsObject(s"expected IndirectProperty, got $json").fields
-
-      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
-      val triangulation = TriangleList(triangles)
-
-      val properties = fields("properties").convertTo[IndexedSeq[MeshSurfaceProperty[A]]]
-      val triangleIndirectionIndex = fields("triangleIndirectionIndex").convertTo[IndexedSeq[Int]]
-
-      IndirectProperty(triangulation, triangleIndirectionIndex, properties)
-    }
-
-    override def write(obj: IndirectProperty[A]): JsValue = JsObject(
-      "triangles" -> obj.triangulation.triangles.toJson,
-      "properties" -> obj.properties.toJson,
-      "triangleIndirectionIndex" -> obj.triangleIndirectionIndex.toJson,
-      "@type" -> "IndirectProperty".toJson
-    )
-  }
-
-  implicit def meshSurfaceProperty[A: ClassTag](implicit
-    formatA: JsonFormat[A],
-    interpolator: ValueInterpolator[A],
-    colorSpaceOperations: ColorSpaceOperations[A]
-  ): RootJsonFormat[MeshSurfaceProperty[A]] = new RootJsonFormat[MeshSurfaceProperty[A]] {
-    override def read(json: JsValue): MeshSurfaceProperty[A] = {
-      val fields = json.asJsObject(s"expected MeshSurfaceProperty, got: $json").fields
-      fields("@type") match {
-        case JsString("SurfacePointProperty")      => json.convertTo[SurfacePointProperty[A]]
-        case JsString("TriangleProperty")          => json.convertTo[TriangleProperty[A]]
-        case JsString("IndirectProperty")          => json.convertTo[IndirectProperty[A]]
-        case JsString("VertexPropertyPerTriangle") => json.convertTo[VertexPropertyPerTriangle[A]]
-        case JsString("TextureMappedProperty")     => json.convertTo[TextureMappedProperty[A]]
-        case _ => throw new DeserializationException(s"Unknown type of MeshSurfaceProperty")
-      }
-    }
-
-    override def write(obj: MeshSurfaceProperty[A]): JsValue = obj match {
-      case prop: SurfacePointProperty[A]      => prop.toJson
-      case prop: TriangleProperty[A]          => prop.toJson
-      case prop: IndirectProperty[A]          => prop.toJson
-      case prop: VertexPropertyPerTriangle[A] => prop.toJson
-      case prop: TextureMappedProperty[A]     => prop.toJson
-      case _ => throw new SerializationException("cannot serialize MeshSurfaceProperty, unknown type")
-    }
-  }
-
-  implicit val colorNormalMesh: RootJsonFormat[ColorNormalMesh3D] = new RootJsonFormat[ColorNormalMesh3D] {
-
-    override def write(mesh: ColorNormalMesh3D): JsValue = JsObject(
-      "points" -> mesh.shape.pointSet.points.map(_.toVector).toIndexedSeq.toJson,
-      "color" -> mesh.color.toJson,
-      "normals" -> mesh.normals.toJson,
-      "triangles" -> mesh.shape.triangles.toJson,
-      "@type" -> "ColorNormalMesh".toJson
     )
 
-    override def read(json: JsValue): ColorNormalMesh3D = {
-      val fields = json.asJsObject(s"expected Mesh object, got: $json").fields
-
-      val points = fields("points").convertTo[IndexedSeq[EuclideanVector[_3D]]].map(_.toPoint)
-      val color = fields("color").convertTo[MeshSurfaceProperty[RGBA]]
-      val normals = fields("normals").convertTo[MeshSurfaceProperty[EuclideanVector[_3D]]]
-      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
-
-      val triangulation = TriangleList(triangles)
-      val shape = TriangleMesh3D(points, triangulation)
-
-      ColorNormalMesh3D(shape, color, normals)
-    }
-  }
-
-  implicit val vertexColorMesh: RootJsonFormat[VertexColorMesh3D] = new RootJsonFormat[VertexColorMesh3D] {
-
-    override def write(mesh: VertexColorMesh3D): JsValue = JsObject(
-      "points" -> mesh.shape.pointSet.points.map(_.toVector).toIndexedSeq.toJson,
-      "color" -> mesh.color.pointData.toJson,
-      "triangles" -> mesh.shape.triangles.toJson,
-      "@type" -> "VertexColorMesh".toJson
+  implicit val renderObjectMapper: upickle.default.ReadWriter[RenderObject] = upickle.default
+    .readwriter[ujson.Value]
+    .bimap[RenderObject](
+      ro =>
+        ro match {
+          case momo: MoMoInstance =>
+            val mj = write(momo)
+            if (momo.expression.nonEmpty) mj("@type") = "MoMoExpressInstance"
+            else
+              mj.obj -= "expression"
+              mj("@type") = "MoMoInstance"
+            mj
+          case mF: MeshFile                 => write(mF)
+          case meshDirect: MeshColorNormals => write(meshDirect.colorNormalMesh)
+          case _ => throw new IllegalArgumentException(s"no JSON writer for RenderObject: $ro")
+        },
+      vj =>
+        Try {
+          vj("@type").str
+        } match {
+          case Success("MoMoInstance") =>
+            val sanitized = vj
+            sanitized("expression") = write(IndexedSeq[Double]())
+            read[MoMoInstance](sanitized)
+          case Success("MoMoExpressInstance") => read[MoMoInstance](vj)
+          case Success("MeshFile")            => read[MeshFile](vj)
+          case Success("ColorNormalMesh")     => MeshColorNormals(read[ColorNormalMesh3D](vj))
+          case _ => throw new IllegalArgumentException("Unknown type of RenderObject: " + vj.toString)
+        }
     )
 
-    override def read(json: JsValue): VertexColorMesh3D = {
-      val fields = json.asJsObject(s"expected VertexColorMesh3D object, got: $json").fields
-
-      val points = fields("points").convertTo[IndexedSeq[EuclideanVector[_3D]]].map(_.toPoint)
-      val color = fields("color").convertTo[IndexedSeq[RGBA]]
-      val triangles = fields("triangles").convertTo[IndexedSeq[TriangleCell]]
-
-      val triangulation = TriangleList(triangles)
-      val shape = TriangleMesh3D(points, triangulation)
-
-      require(color.length == points.length)
-
-      VertexColorMesh3D(shape, SurfacePointProperty(triangulation, color))
-    }
-  }
-
-  implicit val meshColorNormalsFormat: RootJsonFormat[MeshColorNormals] = new RootJsonFormat[MeshColorNormals] {
-
-    override def write(mesh: MeshColorNormals): JsValue = mesh.colorNormalMesh.toJson
-
-    override def read(json: JsValue): MeshColorNormals = MeshColorNormals(json.convertTo[ColorNormalMesh3D])
-  }
-
-  implicit val meshVertexColorFormat: RootJsonFormat[MeshVertexColor] = new RootJsonFormat[MeshVertexColor] {
-
-    override def write(mesh: MeshVertexColor): JsValue = mesh.vertexColorMesh3D.toJson
-
-    override def read(json: JsValue): MeshVertexColor = MeshVertexColor(json.convertTo[VertexColorMesh3D])
-  }
-
-  // general object reader/writer
-  implicit val renderObjectFormat: RootJsonFormat[RenderObject] = new RootJsonFormat[RenderObject] {
-
-    override def write(renderObject: RenderObject): JsValue = renderObject match {
-      case momo: MoMoInstance           => MoMoExpressInstanceV2(momo).toJson
-      case mF: MeshFile                 => mF.toJson
-      case meshDirect: MeshColorNormals => meshDirect.colorNormalMesh.toJson
-      case _ => throw new SerializationException(s"no JSON writer for RenderObject: $renderObject")
-    }
-
-    override def read(json: JsValue): RenderObject = {
-      val fields = json.asJsObject(s"expected RenderObject, got: $json").fields
-      fields("@type") match {
-        case JsString("MoMoInstance")        => json.convertTo[MoMoInstanceV2].toMoMoInstance
-        case JsString("MoMoExpressInstance") => json.convertTo[MoMoExpressInstanceV2].toMoMoInstance
-        case JsString("MeshFile")            => json.convertTo[MeshFile]
-        case JsString("ColorNormalMesh")     => MeshColorNormals(json.convertTo[ColorNormalMesh3D])
-        case _                               => throw new DeserializationException("Unknown type of RenderObject")
-      }
-    }
-  }
-
-  // illumination
-
-  implicit override val directionalLightFormat: RootJsonFormat[DirectionalLight] =
-    new RootJsonFormat[DirectionalLight] {
-      override def write(light: DirectionalLight): JsValue = JsObject(
-        ("ambient", light.ambient.toJson),
-        ("diffuse", light.diffuse.toJson),
-        ("direction", light.direction.toJson),
-        ("specular", light.specular.toJson),
-        ("shininess", light.shininess.toJson),
-        ("@type", JsString("DirectionalLight"))
-      )
-
-      override def read(json: JsValue): DirectionalLight = {
-        val fields = json.asJsObject(s"expected DirectionalLight object, got: $json").fields
-        DirectionalLight(
-          ambient = fields("ambient").convertTo[RGB],
-          diffuse = fields("diffuse").convertTo[RGB],
-          direction = fields("direction").convertTo[EuclideanVector[_3D]],
-          specular = fields("specular").convertTo[RGB],
-          shininess = fields("shininess").convertTo[Double]
-        )
-      }
-    }
-
-  implicit override val sphericalHarmonicsLightFormat: RootJsonFormat[SphericalHarmonicsLight] =
-    new RootJsonFormat[SphericalHarmonicsLight] {
-      override def write(obj: SphericalHarmonicsLight): JsValue = JsObject(
-        "coefficients" -> obj.coefficients.toJson,
-        "@type" -> "SphericalHarmonicsLight".toJson
-      )
-
-      override def read(json: JsValue): SphericalHarmonicsLight = {
-        val fields = json.asJsObject(s"expected Spherical Harmonics object, got: $json").fields
-        SphericalHarmonicsLight(
-          coefficients = fields("coefficients").convertTo[IndexedSeq[EuclideanVector[_3D]]]
-        )
-      }
-    }
-
-  implicit val illuminationFormat: RootJsonFormat[Illumination] = new RootJsonFormat[Illumination] {
-    override def write(obj: Illumination): JsValue = obj match {
-      case dl: DirectionalLight         => dl.toJson
-      case shl: SphericalHarmonicsLight => shl.toJson
-    }
-
-    override def read(json: JsValue): Illumination = {
-      val fields = json.asJsObject(s"expected Illumination, got: $json").fields
-      fields("@type") match {
-        case JsString("DirectionalLight")        => json.convertTo[DirectionalLight]
-        case JsString("SphericalHarmonicsLight") => json.convertTo[SphericalHarmonicsLight]
-        case _                                   => throw new DeserializationException("Unknown type of Illumination")
-      }
-    }
-  }
-
-  private case class CameraV2(far: Double,
-                              focalLength: Double,
-                              near: Double,
-                              orthographic: Boolean,
-                              pitch: Double,
-                              principalPoint: EuclideanVector[_2D],
-                              roll: Double,
-                              sensorSize: EuclideanVector[_2D],
-                              skewFactor: Double,
-                              translation: EuclideanVector[_3D],
-                              yaw: Double
+  case class RenderParameterV2(pose: Pose,
+                               camera: CameraFormatV2,
+                               illumination: Illumination,
+                               renderObject: RenderObject,
+                               image: ImageSize,
+                               color: ColorTransform,
+                               version: String = version
   ) {
-    def toCamera(imageSize: ImageSize): Camera = {
-      val pp = Point(2 * principalPoint.x / imageSize.width, 2 * principalPoint.y / imageSize.height)
-      Camera(
-        focalLength,
-        pp,
-        sensorSize,
-        near = near,
-        far = far,
-        orthographic = orthographic
-      )
-    }
-
-    def toView: ViewParameter = ViewParameter(
-      translation = translation,
-      pitch = pitch,
-      yaw = yaw,
-      roll = roll
-    )
-  }
-
-  private object CameraV2 {
-    def apply(cam: Camera, imageSize: ImageSize, view: ViewParameter): CameraV2 = {
-      val pp = Point(0.5 * imageSize.width * cam.principalPoint.x, 0.5 * imageSize.height * cam.principalPoint.y)
-      new CameraV2(
-        far = cam.far,
-        focalLength = cam.focalLength,
-        near = cam.near,
-        orthographic = cam.orthographic,
-        pitch = view.pitch,
-        principalPoint = pp.toVector,
-        roll = view.roll,
-        sensorSize = cam.sensorSize,
-        skewFactor = 1.0,
-        translation = view.translation,
-        yaw = view.yaw
-      )
-    }
-  }
-
-  implicit private val camFormatV2: RootJsonFormat[CameraV2] = jsonFormat11(CameraV2.apply)
-
-  implicit override val imageFormat: JsonFormat[ImageSize] = new JsonFormat[ImageSize] {
-    override def write(img: ImageSize): JsValue =
-      JsObject("height" -> JsNumber(img.height), "width" -> JsNumber(img.width))
-
-    override def read(json: JsValue): ImageSize = json.asJsObject.getFields("width", "height") match {
-      case Seq(JsNumber(width), JsNumber(height)) => ImageSize(width.toInt, height.toInt)
-      case _                                      => deserializationError("Expected Image, got:" + json)
-    }
-  }
-
-  implicit override val colorFormat: RootJsonFormat[ColorTransform] = new RootJsonFormat[ColorTransform] {
-    override def write(color: ColorTransform): JsValue = JsObject(("gain", color.gain.toJson),
-                                                                  ("colorContrast", color.colorContrast.toJson),
-                                                                  ("offset", color.offset.toJson)
-    )
-
-    override def read(json: JsValue): ColorTransform = {
-      val fields = json.asJsObject(s"expected Color object, got: $json").fields
-      ColorTransform(gain = fields("gain").convertTo[RGB],
-                     colorContrast = fields("colorContrast").convertTo[Double],
-                     offset = fields("offset").convertTo[RGB]
-      )
-    }
-  }
-  // render parameter reader / writer
-  implicit override val renderParameterFormat: RootJsonFormat[RenderParameter] = new RootJsonFormat[RenderParameter] {
-
-    override def write(param: RenderParameter): JsValue = {
-
-      val camV2 = CameraV2(param.camera, param.imageSize, param.view)
-      val momoV2 = MoMoExpressInstanceV2(param.momo)
-
-      val illumination: Illumination =
-        if (param.environmentMap.nonEmpty) param.environmentMap else param.directionalLight
-
-      JsObject(
-        "pose" -> param.pose.toJson,
-        "camera" -> camV2.toJson,
-        "illumination" -> illumination.toJson,
-        "renderObject" -> momoV2.toJson,
-        "image" -> param.imageSize.toJson,
-        "color" -> param.colorTransform.toJson,
-        "version" -> version.toJson
-      )
-    }
-
-    override def read(json: JsValue): RenderParameter = {
-      val fields = json.asJsObject(s"expected BetterRenderParameter object, got: $json").fields
-      fields("version") match {
-        case JsString(`version`) =>
-          val imageSize = fields("image").convertTo[ImageSize]
-          val camV2 = fields("camera").convertTo[CameraV2]
-          val momoV2 = fields("renderObject").convertTo[RenderObject] match {
-            case momo: MoMoInstance => momo
-            case _ =>
-              throw new RuntimeException("does not support reading other objects than MoMoInstance/MoMoExpressInstance")
-          }
-
-          val shLight = fields("illumination").convertTo[Illumination] match {
-            case sh: SphericalHarmonicsLight => sh
-            case dirLight: DirectionalLight  => SphericalHarmonicsLight.empty
-          }
-
-          val dirLight = fields("illumination").convertTo[Illumination] match {
-            case sh: SphericalHarmonicsLight => DirectionalLight.off
-            case dirLight: DirectionalLight  => dirLight
-          }
-
-          RenderParameter(
-            pose = fields("pose").convertTo[Pose],
-            view = camV2.toView,
-            camera = camV2.toCamera(imageSize),
-            environmentMap = shLight,
-            directionalLight = dirLight,
-            momo = momoV2,
-            imageSize = imageSize,
-            colorTransform = fields("color").convertTo[ColorTransform]
-          )
-        case v => throw new DeserializationException(s"wrong version number, expected $version, got $v")
+    def toRenderParameter(): RenderParameter = {
+      val shLight = illumination match {
+        case sh: SphericalHarmonicsLight => sh
+        case _: DirectionalLight         => SphericalHarmonicsLight.empty
       }
+
+      val dirLight = illumination match {
+        case _: SphericalHarmonicsLight => DirectionalLight.off
+        case dirLight: DirectionalLight => dirLight
+      }
+
+      val momo = renderObject match {
+        case momo: MoMoInstance => momo
+        case ro =>
+          throw new RuntimeException(
+            "does not support reading other objects than MoMoInstance/MoMoExpressInstance like " + ro.getClass.getSimpleName
+          )
+      }
+
+      RenderParameter(
+        pose = pose,
+        view = camera.toView,
+        camera = camera.toCamera(image),
+        environmentMap = shLight,
+        directionalLight = dirLight,
+        momo = momo,
+        imageSize = image,
+        colorTransform = color
+      )
     }
   }
 
-}
+  object RenderParameterV2 {
+    def apply(rps: RenderParameter) = new RenderParameterV2(
+      pose = rps.pose,
+      camera = CameraFormatV2(rps.camera, rps.imageSize, rps.view),
+      illumination =
+        if (rps.environmentMap.nonEmpty)
+          rps.environmentMap
+        else
+          rps.directionalLight,
+      renderObject = rps.momo,
+      image = rps.imageSize,
+      color = rps.colorTransform
+    )
 
-object RenderParameterJSONFormatV2 extends RenderParameterJSONFormatV2
+    val renderParameterV2Mapper: upickle.default.ReadWriter[RenderParameterV2] = upickle.default.macroRW
+    implicit val renderParameterV2GuardedMapper: upickle.default.ReadWriter[RenderParameterV2] = upickle.default
+      .readwriter[ujson.Value]
+      .bimap[RenderParameterV2](
+        rpsV2 => write(rpsV2)(renderParameterV2Mapper),
+        json => {
+          Try {
+            json("version").str
+          } match {
+            case Success(version) =>
+              if (version != "V2.0")
+                throw IllegalArgumentException(s"V2 json reader expects V2.0 json file, got: $version")
+            case Failure(e) =>
+              throw IllegalArgumentException(s"V2 json reader expects V2.0 json file, got: $e")
+          }
+          read[RenderParameterV2](json)(renderParameterV2Mapper)
+        }
+      )
+  }
+
+  implicit val rpsMapper: upickle.default.ReadWriter[RenderParameter] = upickle.default
+    .readwriter[RenderParameterV2]
+    .bimap[RenderParameter](
+      rps => RenderParameterV2(rps),
+      rpsV2 => rpsV2.toRenderParameter()
+    )
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterRootJsonFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/RenderParameterRootJsonFormat.scala
@@ -1,0 +1,11 @@
+package scalismo.faces.io.renderparameters
+
+import scalismo.faces.parameters.RenderParameter
+
+import upickle.default.ReadWriter
+
+trait RenderParameterRootJsonFormat {
+  val version: String = ""
+
+  val rpsMapper: ReadWriter[RenderParameter]
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/CameraFormatV2.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/CameraFormatV2.scala
@@ -1,0 +1,60 @@
+package scalismo.faces.io.renderparameters.fromats
+
+import scalismo.geometry.{_2D, _3D, EuclideanVector, Point}
+import scalismo.faces.parameters.{Camera, ImageSize, ViewParameter}
+
+case class CameraFormatV2(far: Double,
+                          focalLength: Double,
+                          near: Double,
+                          orthographic: Boolean,
+                          pitch: Double,
+                          principalPoint: EuclideanVector[_2D],
+                          roll: Double,
+                          sensorSize: EuclideanVector[_2D],
+                          skewFactor: Double,
+                          translation: EuclideanVector[_3D],
+                          yaw: Double
+) {
+  def toCamera(imageSize: ImageSize): Camera = {
+    val pp = Point(2 * principalPoint.x / imageSize.width, 2 * principalPoint.y / imageSize.height)
+    Camera(
+      focalLength,
+      pp,
+      sensorSize,
+      near = near,
+      far = far,
+      orthographic = orthographic
+    )
+  }
+
+  def toView: ViewParameter = ViewParameter(
+    translation = translation,
+    pitch = pitch,
+    yaw = yaw,
+    roll = roll
+  )
+}
+
+object CameraFormatV2 {
+  def apply(cam: Camera, imageSize: ImageSize, view: ViewParameter): CameraFormatV2 = {
+    val pp = Point(0.5 * imageSize.width * cam.principalPoint.x, 0.5 * imageSize.height * cam.principalPoint.y)
+    new CameraFormatV2(
+      far = cam.far,
+      focalLength = cam.focalLength,
+      near = cam.near,
+      orthographic = cam.orthographic,
+      pitch = view.pitch,
+      principalPoint = pp.toVector,
+      roll = view.roll,
+      sensorSize = cam.sensorSize,
+      skewFactor = 1.0,
+      translation = view.translation,
+      yaw = view.yaw
+    )
+  }
+
+  import RenderParameterJSONFormats.ev2DMapper
+  import RenderParameterJSONFormats.ev3DMapper
+
+  implicit val cameraV2Mapper: upickle.default.ReadWriter[CameraFormatV2] = upickle.default.macroRW
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/CameraLegacyFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/CameraLegacyFormat.scala
@@ -1,0 +1,62 @@
+package scalismo.faces.io.renderparameters.fromats
+
+import scalismo.geometry.{_2D, _3D, EuclideanVector, Point}
+import scalismo.faces.parameters.Camera
+import scalismo.faces.parameters.ImageSize
+import scalismo.faces.parameters.ViewParameter
+
+case class LegacyCameraFormat(far: Double,
+                              focalLength: Double,
+                              near: Double,
+                              orthographic: Boolean,
+                              pitch: Double,
+                              principlePoint: EuclideanVector[_2D],
+                              roll: Double,
+                              sensorSize: EuclideanVector[_2D],
+                              skewFactor: Double,
+                              translation: EuclideanVector[_3D],
+                              yaw: Double
+) {
+  def toCamera(imageSize: ImageSize): Camera = {
+    val pp = Point(2 * principlePoint.x / imageSize.width, 2 * principlePoint.y / imageSize.height)
+    Camera(
+      focalLength,
+      pp,
+      sensorSize / near,
+      near = near,
+      far = far,
+      orthographic = orthographic
+    )
+  }
+
+  def toView: ViewParameter = ViewParameter(
+    translation = translation,
+    pitch = pitch,
+    yaw = yaw,
+    roll = roll
+  )
+}
+
+object LegacyCameraFormat {
+  def apply(cam: Camera, imageSize: ImageSize, view: ViewParameter): LegacyCameraFormat = {
+    val pp = Point(0.5 * imageSize.width * cam.principalPoint.x, 0.5 * imageSize.height * cam.principalPoint.y)
+    new LegacyCameraFormat(
+      far = cam.far,
+      focalLength = cam.focalLength,
+      near = cam.near,
+      orthographic = cam.orthographic,
+      pitch = view.pitch,
+      principlePoint = pp.toVector,
+      roll = view.roll,
+      sensorSize = cam.sensorSize * cam.near,
+      skewFactor = 1.0,
+      translation = view.translation,
+      yaw = view.yaw
+    )
+  }
+
+  import RenderParameterJSONFormats.ev2DMapper
+  import RenderParameterJSONFormats.ev3DMapper
+
+  implicit val legacyCameraMapper: upickle.default.ReadWriter[LegacyCameraFormat] = upickle.default.macroRW
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/ColorTransformLegacyFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/ColorTransformLegacyFormat.scala
@@ -1,0 +1,19 @@
+package scalismo.faces.io.renderparameters.fromats
+
+import scalismo.color.RGB
+import scalismo.faces.parameters.ColorTransform
+
+case class ColorTransformLegacyFormat(gain: RGB, gamma: Double, offset: RGB) {
+  def toColorTransform() = {
+    ColorTransform(gain, gamma, offset)
+  }
+}
+
+object ColorTransformLegacyFormat {
+  def apply(ct: ColorTransform) = new ColorTransformLegacyFormat(ct.gain, ct.colorContrast, ct.offset)
+
+  import RenderParameterJSONFormats.rgbMapper
+
+  implicit val colorTransformLegacyMapper: upickle.default.ReadWriter[ColorTransformLegacyFormat] =
+    upickle.default.macroRW
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/DirectLightLegacySerializationFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/DirectLightLegacySerializationFormat.scala
@@ -1,0 +1,25 @@
+package scalismo.faces.io.renderparameters.fromats
+
+import scalismo.color.RGB
+import scalismo.faces.parameters.DirectionalLight
+import scalismo.geometry.{_3D, EuclideanVector}
+
+case class DirectLightLegacySerializationFormat(
+  ambient: RGB,
+  diffuse: RGB,
+  direction: EuclideanVector[_3D],
+  specular: RGB
+) {
+  def toDirectionalLight(shininess: Double): DirectionalLight =
+    DirectionalLight(ambient, diffuse, direction, specular, shininess)
+}
+
+object DirectLightLegacySerializationFormat {
+  def apply(dl: DirectionalLight) =
+    new DirectLightLegacySerializationFormat(dl.ambient, dl.diffuse, dl.direction, dl.specular)
+
+  import RenderParameterJSONFormats.{ev3DMapper, rgbMapper}
+
+  implicit val directionalLightSerializationMapper: upickle.default.ReadWriter[DirectLightLegacySerializationFormat] =
+    upickle.default.macroRW
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/DirectLightSerializationFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/DirectLightSerializationFormat.scala
@@ -1,0 +1,26 @@
+package scalismo.faces.io.renderparameters.fromats
+
+import scalismo.color.RGB
+import scalismo.faces.parameters.DirectionalLight
+import scalismo.geometry.{_3D, EuclideanVector}
+
+case class DirectLightSerializationFormat(
+  ambient: RGB,
+  diffuse: RGB,
+  direction: EuclideanVector[_3D],
+  specular: RGB,
+  shininess: Double
+) {
+  def toDirectionalLight(): DirectionalLight = DirectionalLight(ambient, diffuse, direction, specular, shininess)
+}
+
+object DirectLightSerializationFormat {
+  def apply(dl: DirectionalLight) =
+    new DirectLightSerializationFormat(dl.ambient, dl.diffuse, dl.direction, dl.specular, dl.shininess)
+
+  import RenderParameterJSONFormats.rgbMapper
+  import RenderParameterJSONFormats.ev3DMapper
+
+  implicit val directionalLightSerializationMapper: upickle.default.ReadWriter[DirectLightSerializationFormat] =
+    upickle.default.macroRW
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/MeshFileFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/MeshFileFormat.scala
@@ -1,0 +1,35 @@
+package scalismo.faces.io.renderparameters.fromats
+
+import scalismo.faces.parameters.MeshFile
+
+import scala.util.{Failure, Success, Try}
+
+import java.net.URI
+
+object MeshFileFormat {
+
+  import RenderParameterJSONFormats.uriMapper
+
+  implicit val meshFileMapper: upickle.default.ReadWriter[MeshFile] = upickle.default
+    .readwriter[ujson.Value]
+    .bimap(
+      muri =>
+        ujson.Obj(
+          "meshURI" -> muri.toString,
+          "@type" -> "MeshFile"
+        ),
+      v =>
+        Try {
+          v("@type").str
+        } match {
+          case Success(typeName) =>
+            if (typeName != "MeshFile")
+              throw new IllegalArgumentException("Expected MeshFile entry")
+            MeshFile(
+              meshURI = new URI(v("meshURI").str)
+            )
+          case Failure(e) =>
+            throw new IllegalArgumentException("Expected field with the stored type.")
+        }
+    )
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/MoMoInstanceLegacyFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/MoMoInstanceLegacyFormat.scala
@@ -1,0 +1,23 @@
+package scalismo.faces.io.renderparameters.fromats
+
+import scalismo.faces.parameters.MoMoInstance
+
+import java.net.URI
+
+case class MoMoInstanceLegacyFormat(
+  colorCoefficients: IndexedSeq[Double],
+  modelURI: URI,
+  shapeCoefficients: IndexedSeq[Double],
+  shininess: Double
+) {
+  def toMoMoInstance = MoMoInstance(shapeCoefficients, colorCoefficients, IndexedSeq.empty, modelURI)
+}
+
+object MoMoInstanceLegacyFormat {
+  def apply(momo: MoMoInstance, shininess: Double): MoMoInstanceLegacyFormat =
+    MoMoInstanceLegacyFormat(momo.color, momo.modelURI, momo.shape, shininess)
+
+  import RenderParameterJSONFormats.uriMapper
+
+  implicit val moMoInstanceLegacyMapper: upickle.default.ReadWriter[MoMoInstanceLegacyFormat] = upickle.default.macroRW
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/MoMoInstanceSerializationFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/MoMoInstanceSerializationFormat.scala
@@ -1,0 +1,27 @@
+package scalismo.faces.io.renderparameters.fromats
+
+import java.net.URI
+
+import scalismo.faces.parameters.MoMoInstance
+
+case class MoMoInstanceSerializationFormat(shape: IndexedSeq[Double],
+                                           color: IndexedSeq[Double],
+                                           expression: IndexedSeq[Double],
+                                           modelURI: URI
+) {
+  def toMoMo(): MoMoInstance = MoMoInstance(shape, color, expression, modelURI)
+}
+
+object MoMoInstanceSerializationFormat {
+  def apply(momoInstance: MoMoInstance): MoMoInstanceSerializationFormat = new MoMoInstanceSerializationFormat(
+    momoInstance.shape,
+    momoInstance.color,
+    momoInstance.expression,
+    momoInstance.modelURI
+  )
+
+  import RenderParameterJSONFormats.uriMapper
+
+  implicit val momoInstanceSerializationMapper: upickle.default.ReadWriter[MoMoInstanceSerializationFormat] =
+    upickle.default.macroRW
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/RenderParameterJSONFormats.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/RenderParameterJSONFormats.scala
@@ -1,0 +1,363 @@
+package scalismo.faces.io.renderparameters.fromats
+
+import scalismo.color.{ColorSpaceOperations, RGB, RGBA}
+import scalismo.common.PointId
+import scalismo.faces.image.{AccessMode, ColumnMajorImageDomain, PixelImage, RowMajorImageDomain}
+import scalismo.faces.mesh.{ColorNormalMesh3D, IndirectProperty, TextureMappedProperty, VertexPropertyPerTriangle}
+import scalismo.faces.parameters.*
+import scalismo.geometry.*
+import scalismo.numerics.ValueInterpolator
+import scalismo.mesh.{
+  MeshSurfaceProperty,
+  SurfacePointProperty,
+  TriangleCell,
+  TriangleList,
+  TriangleMesh3D,
+  TriangleProperty,
+  VertexColorMesh3D
+}
+import upickle.default
+import upickle.default.{read, readwriter, writeJs as write, ReadWriter}
+
+import java.net.URI
+import scala.reflect.ClassTag
+import scala.util.Try
+
+object RenderParameterJSONFormats {
+
+  implicit val uriMapper: upickle.default.ReadWriter[URI] = upickle.default
+    .readwriter[String]
+    .bimap[URI](
+      uri => uri.toString,
+      s => URI(s)
+    )
+
+  implicit val ev1DMapper: default.ReadWriter[EuclideanVector[_1D]] =
+    readwriter[List[Double]].bimap[EuclideanVector[_1D]](
+      ev => ev.toArray.toList,
+      l => EuclideanVector(l.toArray)
+    )
+
+  implicit val ev2DMapper: default.ReadWriter[EuclideanVector[_2D]] =
+    readwriter[List[Double]].bimap[EuclideanVector[_2D]](
+      ev => ev.toArray.toList,
+      l => EuclideanVector(l.toArray)
+    )
+
+  implicit val ev3DMapper: default.ReadWriter[EuclideanVector[_3D]] =
+    readwriter[List[Double]].bimap[EuclideanVector[_3D]](
+      ev => ev.toArray.toList,
+      l => EuclideanVector(l.toArray)
+    )
+
+  implicit val pt1DMapper: default.ReadWriter[Point[_1D]] = readwriter[List[Double]].bimap[Point[_1D]](
+    ev => ev.toArray.toList,
+    l => Point(l.toArray)
+  )
+
+  implicit val pt2DMapper: default.ReadWriter[Point[_2D]] = readwriter[List[Double]].bimap[Point[_2D]](
+    ev => ev.toArray.toList,
+    l => Point(l.toArray)
+  )
+
+  implicit val pt3DMapper: default.ReadWriter[Point[_3D]] = readwriter[List[Double]].bimap[Point[_3D]](
+    ev => ev.toArray.toList,
+    l => Point(l.toArray)
+  )
+
+  implicit val rgbaMapper: default.ReadWriter[RGBA] = readwriter[List[Double]].bimap[RGBA](
+    col => List(col.r, col.g, col.b, col.a),
+    l => RGBA(l(0), l(1), l(2), l(3))
+  )
+
+  implicit val rgbMapper: default.ReadWriter[RGB] = readwriter[List[Double]].bimap[RGB](
+    col => List(col.r, col.g, col.b),
+    l => RGB(l(0), l(1), l(2))
+  )
+
+  implicit val shlMapper: default.ReadWriter[SphericalHarmonicsLight] =
+    readwriter[SphericalHarmonicsLightSerializationFormat].bimap[SphericalHarmonicsLight](
+      light => SphericalHarmonicsLightSerializationFormat(light.coefficients.map(_.toArray.toList).toList),
+      ll => SphericalHarmonicsLight(ll.coefficients.map(l => EuclideanVector[_3D](l.toArray)).toIndexedSeq)
+    )
+
+  implicit val directionalLightMapper: default.ReadWriter[DirectionalLight] =
+    readwriter[DirectLightSerializationFormat].bimap[DirectionalLight](
+      dl => DirectLightSerializationFormat(dl),
+      dlm => dlm.toDirectionalLight()
+    )
+
+  implicit val poseMapper: upickle.default.ReadWriter[Pose] = upickle.default.macroRW
+
+  implicit val viewMapper: upickle.default.ReadWriter[ViewParameter] = upickle.default.macroRW
+
+  implicit val cameraMapper: upickle.default.ReadWriter[Camera] = upickle.default.macroRW
+
+  implicit val imageSizeMapper: upickle.default.ReadWriter[ImageSize] = upickle.default.macroRW
+
+  implicit val colorTransformMapper: upickle.default.ReadWriter[ColorTransform] = upickle.default.macroRW
+
+  implicit val triangleCellMapper: default.ReadWriter[TriangleCell] = readwriter[List[Double]].bimap[TriangleCell](
+    cell => cell.pointIds.map(_.id.toDouble).toList,
+    l =>
+      TriangleCell(
+        PointId(l(0).toInt),
+        PointId(l(1).toInt),
+        PointId(l(2).toInt)
+      )
+  )
+
+  implicit val meshFileFormat: ReadWriter[MeshFile] = readwriter[ujson.Value].bimap[MeshFile](
+    meshFile =>
+      ujson.Obj(
+        ("meshURI", write(meshFile.meshURI)),
+        ("@type", "MeshFile")
+      ),
+    json => {
+      MeshFile(
+        meshURI = read[URI](json("meshURI"))
+      )
+    }
+  )
+
+  implicit val momoInstanceMapper: default.ReadWriter[MoMoInstance] =
+    readwriter[MoMoInstanceSerializationFormat].bimap[MoMoInstance](
+      mi => MoMoInstanceSerializationFormat(mi),
+      mis => mis.toMoMo()
+    )
+
+  implicit val colSpaceOps2D: ColorSpaceOperations[Point[_2D]] = new ColorSpaceOperations[Point[_2D]] {
+    override def add(pix1: Point[_2D], pix2: Point[_2D]): Point[_2D] = (pix1.toVector + pix2.toVector).toPoint
+    override def multiply(pix1: Point[_2D], pix2: Point[_2D]): Point[_2D] = Point(pix1.x * pix2.x, pix1.y * pix2.y)
+    override def dot(pix1: Point[_2D], pix2: Point[_2D]): Double = pix1.toVector.dot(pix2.toVector)
+    override def dimensionality: Int = 2
+    override def scale(pix: Point[_2D], l: Double): Point[_2D] = (pix.toVector * l).toPoint
+    override def zero: Point[_2D] = Point2D.origin
+  }
+
+  implicit def pixelImageFormat[A: ClassTag](implicit formatA: ReadWriter[A]): ReadWriter[PixelImage[A]] =
+    readwriter[ujson.Value].bimap[PixelImage[A]](
+      pi =>
+        ujson.Obj(
+          "width" -> pi.width,
+          "height" -> pi.height,
+          "domainMode" -> (pi.domain match {
+            case _: ColumnMajorImageDomain => "ColumnMajor"
+            case _: RowMajorImageDomain    => "RowMajor"
+          }),
+          "data" -> write(pi.values.toIndexedSeq)
+        ),
+      json => {
+        val width = read[Int](json("width"))
+        val height = read[Int](json("height"))
+        val data = read[IndexedSeq[A]](json("data"))
+        val domain = read[String](json("domainMode")) match {
+          case "ColumnMajor" => ColumnMajorImageDomain(width, height)
+          case "RowMajor"    => RowMajorImageDomain(width, height)
+          case s: String     => throw new IllegalArgumentException(s"unknown image domain mode: $s")
+        }
+
+        PixelImage(domain, data).withAccessMode(AccessMode.Repeat())
+      }
+    )
+
+  implicit def meshSurfaceProperty[A: ClassTag](implicit
+    formatA: ReadWriter[A],
+    interpolator: ValueInterpolator[A],
+    colorSpaceOperations: ColorSpaceOperations[A]
+  ): ReadWriter[MeshSurfaceProperty[A]] = readwriter[ujson.Value].bimap[MeshSurfaceProperty[A]](
+    obj =>
+      obj match {
+        case prop: SurfacePointProperty[A]      => write(prop)
+        case prop: TriangleProperty[A]          => write(prop)
+        case prop: IndirectProperty[A]          => write(prop)
+        case prop: VertexPropertyPerTriangle[A] => write(prop)
+        case prop: TextureMappedProperty[A]     => write(prop)
+        case _ => throw new IllegalArgumentException("cannot serialize MeshSurfaceProperty, unknown type")
+      },
+    json =>
+      json("@type").str match {
+        case "SurfacePointProperty"      => read[SurfacePointProperty[A]](json)
+        case "TriangleProperty"          => read[TriangleProperty[A]](json)
+        case "IndirectProperty"          => read[IndirectProperty[A]](json)
+        case "VertexPropertyPerTriangle" => read[VertexPropertyPerTriangle[A]](json)
+        case "TextureMappedProperty"     => read[TextureMappedProperty[A]](json)
+        case _                           => throw new IllegalArgumentException(s"Unknown type of MeshSurfaceProperty")
+      }
+  )
+
+  implicit def surfacePointPropertyFormat[A: ClassTag](implicit
+    formatA: ReadWriter[A],
+    interpolator: ValueInterpolator[A]
+  ): default.ReadWriter[SurfacePointProperty[A]] = readwriter[ujson.Value].bimap[SurfacePointProperty[A]](
+    spp => {
+      ujson.Obj(
+        "triangles" -> write(spp.triangulation.triangles),
+        "pointData" -> write(spp.pointData),
+        "@type" -> "SurfacePointProperty"
+      )
+    },
+    json => {
+      assert(json("@type").str == "SurfacePointProperty")
+
+      val triangles = read[IndexedSeq[TriangleCell]](json("triangles"))
+      val triangulation = TriangleList(triangles)
+
+      val pointData = read[IndexedSeq[A]](json("pointData"))
+
+      SurfacePointProperty(
+        triangulation = triangulation,
+        pointData = pointData
+      )
+    }
+  )
+  implicit def trianglePropertyFormat[A: ClassTag](implicit formatA: ReadWriter[A]): ReadWriter[TriangleProperty[A]] =
+    readwriter[ujson.Value].bimap[TriangleProperty[A]](
+      obj => {
+        ujson.Obj(
+          "triangles" -> write(obj.triangulation.triangles),
+          "triangleData" -> write(obj.triangleData),
+          "@type" -> "TriangleProperty"
+        )
+      },
+      json => {
+        val triangles = read[IndexedSeq[TriangleCell]](json("triangles"))
+        val triangulation = TriangleList(triangles)
+
+        val triangleData = read[IndexedSeq[A]](json("triangleData"))
+
+        TriangleProperty(
+          triangulation = triangulation,
+          triangleData = triangleData
+        )
+      }
+    )
+
+  implicit def vertexPropertyPerTriangleFormat[A: ClassTag](implicit
+    formatA: ReadWriter[A],
+    interpolator: ValueInterpolator[A]
+  ): ReadWriter[VertexPropertyPerTriangle[A]] = readwriter[ujson.Value].bimap[VertexPropertyPerTriangle[A]](
+    obj =>
+      ujson.Obj(
+        "triangles" -> write(obj.triangulation.triangles),
+        "pointData" -> write(obj.vertexData),
+        "triangleIndex" -> write(obj.triangleVertexIndex.map { v => (v.i, v.j, v.k) }),
+        "@type" -> "VertexPropertyPerTriangle"
+      ),
+    json => {
+      val triangles = read[IndexedSeq[TriangleCell]](json("triangles"))
+      val triangulation = TriangleList(triangles)
+
+      val pointData = read[IndexedSeq[A]](json("pointData"))
+      val triangleIndex = read[IndexedSeq[(Int, Int, Int)]](json("triangleIndex")).map { case (i, j, k) =>
+        IntVector3D(i, j, k)
+      }
+
+      VertexPropertyPerTriangle(triangulation, triangleIndex, pointData)
+    }
+  )
+
+  implicit def textureMappedPropertyFormat[A: ClassTag](implicit
+    formatA: ReadWriter[A],
+    interpolator: ValueInterpolator[A],
+    colorSpaceOperations: ColorSpaceOperations[A]
+  ): ReadWriter[TextureMappedProperty[A]] = upickle.default
+    .readwriter[ujson.Value]
+    .bimap[TextureMappedProperty[A]](
+      tmp =>
+        ujson.Obj(
+          "triangles" -> write(tmp.triangulation.triangles),
+          "textureMapping" -> write(tmp.textureMapping),
+          "texture" -> write(tmp.texture),
+          "@type" -> "TextureMappedProperty"
+        ),
+      json => {
+        assert(json("@type").str == "TextureMappedProperty")
+
+        val triangles = read[IndexedSeq[TriangleCell]](json("triangles"))
+        val triangulation = TriangleList(triangles)
+
+        val textureMapping = read[MeshSurfaceProperty[Point[_2D]]](json("textureMapping"))
+        val texture = read[PixelImage[A]](json("texture"))
+
+        TextureMappedProperty(triangulation, textureMapping, texture)
+      }
+    )
+
+  implicit def indirectPropertyFormat[A: ClassTag](implicit
+    formatA: ReadWriter[A],
+    interpolator: ValueInterpolator[A],
+    colorSpaceOperations: ColorSpaceOperations[A]
+  ): ReadWriter[IndirectProperty[A]] = readwriter[ujson.Value].bimap[IndirectProperty[A]](
+    obj =>
+      ujson.Obj(
+        "triangles" -> write(obj.triangulation.triangles),
+        "properties" -> write(obj.properties),
+        "triangleIndirectionIndex" -> write(obj.triangleIndirectionIndex),
+        "@type" -> "IndirectProperty"
+      ),
+    json => {
+      val triangles = read[IndexedSeq[TriangleCell]](json("triangles"))
+      val triangulation = TriangleList(triangles)
+
+      val properties = read[IndexedSeq[MeshSurfaceProperty[A]]](json("properties"))
+      val triangleIndirectionIndex = read[IndexedSeq[Int]](json("triangleIndirectionIndex"))
+
+      IndirectProperty(triangulation, triangleIndirectionIndex, properties)
+    }
+  )
+
+  implicit val colorNormalMeshMapper: ReadWriter[ColorNormalMesh3D] = readwriter[ujson.Value].bimap[ColorNormalMesh3D](
+    mesh =>
+      ujson.Obj(
+        "points" -> write(mesh.shape.pointSet.points.map(_.toVector).toIndexedSeq),
+        "color" -> write(mesh.color),
+        "normals" -> write(mesh.normals),
+        "triangles" -> write(mesh.shape.triangles),
+        "@type" -> "ColorNormalMesh"
+      ),
+    json => {
+      val points = read[IndexedSeq[EuclideanVector[_3D]]](json("points")).map(_.toPoint)
+      val color = read[MeshSurfaceProperty[RGBA]](json("color"))
+      val normals = read[MeshSurfaceProperty[EuclideanVector[_3D]]](json("normals"))
+      val triangles = read[IndexedSeq[TriangleCell]](json("triangles"))
+
+      val triangulation = TriangleList(triangles)
+      val shape = TriangleMesh3D(points, triangulation)
+
+      ColorNormalMesh3D(shape, color, normals)
+    }
+  )
+
+  implicit val vertexColorMeshMapper: ReadWriter[VertexColorMesh3D] = readwriter[ujson.Value].bimap[VertexColorMesh3D](
+    mesh =>
+      ujson.Obj(
+        "points" -> write(mesh.shape.pointSet.points.map(_.toVector).toIndexedSeq),
+        "color" -> write(mesh.color.pointData),
+        "triangles" -> write(mesh.shape.triangles),
+        "@type" -> "VertexColorMesh"
+      ),
+    json => {
+      val points = read[IndexedSeq[EuclideanVector[_3D]]](json("points")).map(_.toPoint)
+      val color = read[IndexedSeq[RGBA]](json("color"))
+      val triangles = read[IndexedSeq[TriangleCell]](json("triangles"))
+
+      val triangulation = TriangleList(triangles)
+      val shape = TriangleMesh3D(points, triangulation)
+
+      require(color.length == points.length)
+
+      VertexColorMesh3D(shape, SurfacePointProperty(triangulation, color))
+    }
+  )
+
+  implicit val meshColorNormalsFormat: ReadWriter[MeshColorNormals] = readwriter[ujson.Value].bimap[MeshColorNormals](
+    mesh => write(mesh.colorNormalMesh),
+    json => MeshColorNormals(read[ColorNormalMesh3D](json))
+  )
+
+  implicit val meshVertexColorFormat: ReadWriter[MeshVertexColor] = readwriter[ujson.Value].bimap[MeshVertexColor](
+    mesh => write(mesh.vertexColorMesh3D),
+    json => MeshVertexColor(read[VertexColorMesh3D](json))
+  )
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/SphericalHarmonicsLegacyFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/SphericalHarmonicsLegacyFormat.scala
@@ -1,0 +1,52 @@
+package scalismo.faces.io.renderparameters.fromats
+
+import scalismo.geometry.{_3D, EuclideanVector}
+import scalismo.faces.parameters.SphericalHarmonicsLight
+
+case class SphericalHarmonicsLegacyFormat(coefficients: IndexedSeq[EuclideanVector[_3D]]) {
+  def toSphericalHarmonics() = {
+    SphericalHarmonicsLight(SphericalHarmonicsLegacyFormat.convertJzToSHL(coefficients))
+  }
+}
+
+object SphericalHarmonicsLegacyFormat {
+  def apply(sphericalHarmonicsLight: SphericalHarmonicsLight) = new SphericalHarmonicsLegacyFormat(
+    convertSHLToJz(sphericalHarmonicsLight.coefficients)
+  )
+
+  def convertSHLToJz(shl: IndexedSeq[EuclideanVector[_3D]]): IndexedSeq[EuclideanVector[_3D]] = {
+    if (shl.isEmpty)
+      shl
+    else if (shl.size > 9)
+      throw new IllegalArgumentException(
+        "SHL json writer (V1): cannot write more than 9 coefficients in jz format (use modern version)"
+      )
+    else {
+      // 1 - 9 coefficients
+      val permutation = IndexedSeq(0, 3, 1, 2, 6, 5, 7, 4, 8).take(shl.size)
+      permutation map (i => shl(i))
+    }
+  }
+
+  def convertJzToSHL(shl: IndexedSeq[EuclideanVector[_3D]]): IndexedSeq[EuclideanVector[_3D]] = {
+    if (shl.isEmpty)
+      shl
+    else if (shl.size > 9)
+      throw IllegalArgumentException(
+        "SHL json reader (V1): cannot read more than 2 bands (9 coeffs), there is no conversion from jz to our format"
+      )
+    else {
+      // 1 - 0 coeffs
+      val permutation = IndexedSeq(0, 2, 3, 1, 7, 5, 4, 6, 8).take(shl.size)
+      permutation map (i => shl(i))
+    }
+  }
+
+  implicit val sphericalHarmonicsLegacyMapper: upickle.default.ReadWriter[SphericalHarmonicsLegacyFormat] =
+    upickle.default
+      .readwriter[List[List[Double]]]
+      .bimap[SphericalHarmonicsLegacyFormat](
+        leg => leg.coefficients.map(_.toArray.toList).toList,
+        ll => SphericalHarmonicsLegacyFormat(ll.map(l => EuclideanVector[_3D](l.toArray)).toIndexedSeq)
+      )
+}

--- a/src/main/scala/scalismo/faces/io/renderparameters/fromats/SphericalHarmonicsLightSerializationFormat.scala
+++ b/src/main/scala/scalismo/faces/io/renderparameters/fromats/SphericalHarmonicsLightSerializationFormat.scala
@@ -1,0 +1,6 @@
+package scalismo.faces.io.renderparameters.fromats
+
+case class SphericalHarmonicsLightSerializationFormat(coefficients: List[List[Double]])
+
+implicit val sphericalHarmonicsLightSerializationFormatMapper
+  : upickle.default.ReadWriter[SphericalHarmonicsLightSerializationFormat] = upickle.default.macroRW


### PR DESCRIPTION
This PR replaces spray json with ujson as dependency.

While the tests are reordered a bit, they are covering the same functionality as before and they pass.