### PR TITLE
Improve speed of PlyMeshReader.scala

### DIFF
--- a/src/main/scala/scalismo/faces/io/ply/PlyMeshReader.scala
+++ b/src/main/scala/scalismo/faces/io/ply/PlyMeshReader.scala
@@ -342,12 +342,12 @@ class PlyPropertyReader[A](private val reader: SequenceReader[A]) {
 
   def getList: List[A] = _buffer.toList
 
-  def read(scanner: Scanner): Seq[A] = {
-    (_buffer ++= reader.read(scanner)).toSeq
+  def read(scanner: Scanner): Unit = {
+    _buffer ++= reader.read(scanner)
   }
 
-  def read(is: InputStream, bo: ByteOrder): Seq[A] = {
-    (_buffer ++= reader.read(is, bo)).toSeq
+  def read(is: InputStream, bo: ByteOrder): Unit = {
+    _buffer ++= reader.read(is, bo)
   }
 
 }


### PR DESCRIPTION
The ply-reader is very slow when reading large meshes. This PR fixes it by not creating useless sequences that are not used anyway.

Some quick tests showed for very large meshes a potential speed up of a factor 100.